### PR TITLE
Throw LowMemoryException on getDrawable(final String aFilePath)

### DIFF
--- a/osmdroid-android-it/src/main/java/org/osmdroid/views/util/OpenStreetMapTileProviderDirectTest.java
+++ b/osmdroid-android-it/src/main/java/org/osmdroid/views/util/OpenStreetMapTileProviderDirectTest.java
@@ -8,6 +8,7 @@ import org.osmdroid.tileprovider.MapTile;
 import org.osmdroid.tileprovider.MapTileProviderBasic;
 import org.osmdroid.tileprovider.MapTileRequestState;
 import org.osmdroid.tileprovider.modules.MapTileModuleProviderBase;
+import org.osmdroid.tileprovider.tilesource.BitmapTileSourceBase;
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
 
 import android.graphics.Bitmap;
@@ -45,7 +46,7 @@ public class OpenStreetMapTileProviderDirectTest extends AndroidTestCase {
 		assertNull("Expect tile to be null", drawable);
 	}
 
-	public void test_getMapTile_found() throws RemoteException, FileNotFoundException {
+	public void test_getMapTile_found() throws RemoteException, FileNotFoundException, BitmapTileSourceBase.LowMemoryException {
 		final MapTile tile = new MapTile(2, 3, 4);
 
 		// create a bitmap, draw something on it, write it to a file and put it in the cache

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/BitmapTileSourceBase.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/BitmapTileSourceBase.java
@@ -96,7 +96,7 @@ public abstract class BitmapTileSourceBase implements ITileSource,
 	}
 
 	@Override
-	public Drawable getDrawable(final String aFilePath) {
+	public Drawable getDrawable(final String aFilePath) throws LowMemoryException {
 		try {
 			// default implementation will load the file as a bitmap and create
 			// a BitmapDrawable from it
@@ -116,6 +116,7 @@ public abstract class BitmapTileSourceBase implements ITileSource,
 		} catch (final OutOfMemoryError e) {
 			logger.error("OutOfMemoryError loading bitmap: " + aFilePath);
 			System.gc();
+			throw new LowMemoryException(e);
 		}
 		return null;
 	}


### PR DESCRIPTION
It is more a question rather than a pull request.
Why the `getDrawable(String aFilePath)` does not throw an `LowMemoryException`?  It is to maintain compatibility somwhere?
It looks very strange. The [TileSource#getDrawable(String aFilePath)](https://github.com/illarionov/osmdroid/blob/master/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/ITileSource.java#L54) allows to throw this exception.