### PR TITLE
APK provider to bundle tiles with app itself

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ proguard/
 build/
 .gradle
 
+# vim swap files
+*.swp
+*.swo

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderBasic.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderBasic.java
@@ -1,6 +1,9 @@
 package org.osmdroid.tileprovider;
 
+import android.content.Context;
+
 import org.osmdroid.tileprovider.modules.INetworkAvailablityCheck;
+import org.osmdroid.tileprovider.modules.MapTileAssetsProvider;
 import org.osmdroid.tileprovider.modules.MapTileDownloader;
 import org.osmdroid.tileprovider.modules.MapTileFileArchiveProvider;
 import org.osmdroid.tileprovider.modules.MapTileFilesystemProvider;
@@ -9,8 +12,6 @@ import org.osmdroid.tileprovider.modules.TileWriter;
 import org.osmdroid.tileprovider.tilesource.ITileSource;
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
 import org.osmdroid.tileprovider.util.SimpleRegisterReceiver;
-
-import android.content.Context;
 
 /**
  * This top-level tile provider implements a basic tile request chain which includes a
@@ -36,17 +37,22 @@ public class MapTileProviderBasic extends MapTileProviderArray implements IMapTi
 	 */
 	public MapTileProviderBasic(final Context pContext, final ITileSource pTileSource) {
 		this(new SimpleRegisterReceiver(pContext), new NetworkAvailabliltyCheck(pContext),
-				pTileSource);
+				pTileSource, pContext);
 	}
 
 	/**
 	 * Creates a {@link MapTileProviderBasic}.
 	 */
 	public MapTileProviderBasic(final IRegisterReceiver pRegisterReceiver,
-			final INetworkAvailablityCheck aNetworkAvailablityCheck, final ITileSource pTileSource) {
+			final INetworkAvailablityCheck aNetworkAvailablityCheck, final ITileSource pTileSource,
+			final Context pContext) {
 		super(pTileSource, pRegisterReceiver);
 
 		final TileWriter tileWriter = new TileWriter();
+
+		final MapTileAssetsProvider assetsProvider = new MapTileAssetsProvider(
+				pRegisterReceiver, pContext.getAssets(), pTileSource);
+		mTileProviderList.add(assetsProvider);
 
 		final MapTileFilesystemProvider fileSystemProvider = new MapTileFilesystemProvider(
 				pRegisterReceiver, pTileSource);

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileAssetsProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileAssetsProvider.java
@@ -1,0 +1,166 @@
+package org.osmdroid.tileprovider.modules;
+
+import android.content.res.AssetManager;
+import android.graphics.drawable.Drawable;
+
+import org.osmdroid.tileprovider.IRegisterReceiver;
+import org.osmdroid.tileprovider.MapTile;
+import org.osmdroid.tileprovider.MapTileRequestState;
+import org.osmdroid.tileprovider.tilesource.BitmapTileSourceBase.LowMemoryException;
+import org.osmdroid.tileprovider.tilesource.ITileSource;
+import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Implements a file system cache and provides cached tiles from Assets. This
+ * functions as a tile provider by serving cached tiles for the supplied tile
+ * source.
+ *
+ * tiles should be put into apk's assets directory just like following example:
+ *
+ *     assets/Mapnik/11/1316/806.png
+ *
+ * @author Marc Kurtz
+ * @author Nicolas Gramlich
+ * @author Behrooz Shabani (everplays)
+ *
+ */
+public class MapTileAssetsProvider extends MapTileFileStorageProviderBase {
+
+	// ===========================================================
+	// Constants
+	// ===========================================================
+
+	private static final Logger logger = LoggerFactory.getLogger(MapTileAssetsProvider.class);
+
+	// ===========================================================
+	// Fields
+	// ===========================================================
+
+	private final long mMaximumCachedFileAge;
+
+	private AssetManager mAssets;
+
+	private final AtomicReference<ITileSource> mTileSource = new AtomicReference<ITileSource>();
+
+	// ===========================================================
+	// Constructors
+	// ===========================================================
+
+	public MapTileAssetsProvider(final IRegisterReceiver pRegisterReceiver, final AssetManager pAssets) {
+		this(pRegisterReceiver, pAssets, TileSourceFactory.DEFAULT_TILE_SOURCE);
+	}
+
+	public MapTileAssetsProvider(final IRegisterReceiver pRegisterReceiver,
+			final AssetManager pAssets,
+			final ITileSource aTileSource) {
+		this(pRegisterReceiver, pAssets, aTileSource, DEFAULT_MAXIMUM_CACHED_FILE_AGE);
+	}
+
+	public MapTileAssetsProvider(final IRegisterReceiver pRegisterReceiver,
+			final AssetManager pAssets,
+			final ITileSource pTileSource, final long pMaximumCachedFileAge) {
+		this(pRegisterReceiver, pAssets, pTileSource, pMaximumCachedFileAge,
+				NUMBER_OF_TILE_FILESYSTEM_THREADS,
+				TILE_FILESYSTEM_MAXIMUM_QUEUE_SIZE);
+	}
+
+	/**
+	 * Provides a file system based cache tile provider. Other providers can register and store data
+	 * in the cache.
+	 *
+	 * @param pRegisterReceiver
+	 */
+	public MapTileAssetsProvider(final IRegisterReceiver pRegisterReceiver,
+			final AssetManager pAssets,
+			final ITileSource pTileSource, final long pMaximumCachedFileAge, int pThreadPoolSize,
+			int pPendingQueueSize) {
+		super(pRegisterReceiver, pThreadPoolSize, pPendingQueueSize);
+		setTileSource(pTileSource);
+
+		mAssets = pAssets;
+		mMaximumCachedFileAge = pMaximumCachedFileAge;
+	}
+	// ===========================================================
+	// Getter & Setter
+	// ===========================================================
+
+	// ===========================================================
+	// Methods from SuperClass/Interfaces
+	// ===========================================================
+
+	@Override
+	public boolean getUsesDataConnection() {
+		return false;
+	}
+
+	@Override
+	protected String getName() {
+		return "Assets Cache Provider";
+	}
+
+	@Override
+	protected String getThreadGroupName() {
+		return "assets";
+	}
+
+	@Override
+	protected Runnable getTileLoader() {
+		return new TileLoader(mAssets);
+	}
+
+	@Override
+	public int getMinimumZoomLevel() {
+		ITileSource tileSource = mTileSource.get();
+		return tileSource != null ? tileSource.getMinimumZoomLevel() : MINIMUM_ZOOMLEVEL;
+	}
+
+	@Override
+	public int getMaximumZoomLevel() {
+		ITileSource tileSource = mTileSource.get();
+		return tileSource != null ? tileSource.getMaximumZoomLevel() : MAXIMUM_ZOOMLEVEL;
+	}
+
+	@Override
+	public void setTileSource(final ITileSource pTileSource) {
+		mTileSource.set(pTileSource);
+	}
+
+	// ===========================================================
+	// Inner and Anonymous Classes
+	// ===========================================================
+
+	protected class TileLoader extends MapTileModuleProviderBase.TileLoader {
+		private AssetManager mAssets = null;
+
+		public TileLoader(AssetManager pAssets) {
+			mAssets = pAssets;
+		}
+
+		@Override
+		public Drawable loadTile(final MapTileRequestState pState) throws CantContinueException {
+			ITileSource tileSource = mTileSource.get();
+			if (tileSource == null) {
+				return null;
+			}
+
+			final MapTile tile = pState.getMapTile();
+
+			try {
+				InputStream is = mAssets.open(tileSource.getTileRelativeFilenameString(tile));
+				return tileSource.getDrawable(is);
+			} catch (IOException e) {
+			} catch (final LowMemoryException e) {
+				throw new CantContinueException(e);
+			}
+
+			// If we get here then there is no file in the file cache
+			return null;
+		}
+	}
+}


### PR DESCRIPTION
With this change tiles can be bundled into assets of apk itself. With
this, people can easily make apps that load first couple of zoom levels
from apk and for the rest normal network/cache behavior be used.

P.S. It's not magic or something that can't be done by developers themselves. It just makes it easy to have offline map with tiles already bundled into apk.
