### PR TITLE
Allow OverlayItem to be used by non-GeoPoint class

### DIFF
--- a/OpenStreetMapViewer/src/org/osmdroid/samplefragments/SampleWithMinimapItemizedOverlayWithFocus.java
+++ b/OpenStreetMapViewer/src/org/osmdroid/samplefragments/SampleWithMinimapItemizedOverlayWithFocus.java
@@ -4,6 +4,7 @@ package org.osmdroid.samplefragments;
 import java.util.ArrayList;
 
 import org.osmdroid.RotationGestureOverlay;
+import org.osmdroid.api.IGeoPoint;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.overlay.ItemizedIconOverlay;
 import org.osmdroid.views.overlay.ItemizedOverlayWithFocus;
@@ -116,7 +117,7 @@ public class SampleWithMinimapItemizedOverlayWithFocus extends BaseSampleFragmen
 
 		// Zoom and center on the focused item.
 		mMapView.getController().setZoom(5);
-		GeoPoint geoPoint = mMyLocationOverlay.getFocusedItem().getPoint();
+        IGeoPoint geoPoint = mMyLocationOverlay.getFocusedItem().getPoint();
 		mMapView.getController().animateTo(geoPoint);
 
 		setHasOptionsMenu(true);

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/OverlayItem.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/OverlayItem.java
@@ -1,7 +1,7 @@
 // Created by plusminus on 00:02:58 - 03.10.2008
 package org.osmdroid.views.overlay;
 
-import org.osmdroid.util.GeoPoint;
+import org.osmdroid.api.IGeoPoint;
 
 import android.graphics.Point;
 import android.graphics.drawable.Drawable;
@@ -41,7 +41,7 @@ public class OverlayItem {
 	protected final String mUid;
 	protected final String mTitle;
 	protected final String mSnippet;
-	protected final GeoPoint mGeoPoint;
+	protected final IGeoPoint mGeoPoint;
 	protected Drawable mMarker;
 	protected HotspotPlace mHotspotPlace;
 
@@ -56,12 +56,12 @@ public class OverlayItem {
 	 *            a <b>multiLine</b> description ( <code>'\n'</code> possible)
 	 * @param aGeoPoint
 	 */
-	public OverlayItem(final String aTitle, final String aSnippet, final GeoPoint aGeoPoint) {
+	public OverlayItem(final String aTitle, final String aSnippet, final IGeoPoint aGeoPoint) {
 		this(null, aTitle, aSnippet, aGeoPoint);
 	}
 
 	public OverlayItem(final String aUid, final String aTitle, final String aDescription,
-			final GeoPoint aGeoPoint) {
+			final IGeoPoint aGeoPoint) {
 		this.mTitle = aTitle;
 		this.mSnippet = aDescription;
 		this.mGeoPoint = aGeoPoint;
@@ -83,7 +83,7 @@ public class OverlayItem {
 		return mSnippet;
 	}
 
-	public GeoPoint getPoint() {
+	public IGeoPoint getPoint() {
 		return mGeoPoint;
 	}
 


### PR DESCRIPTION
In my current osmdroid project i want to display gpx-trackpoint-items that are not inherited from class GeoPoint. This tiny change would make this possible by replacing reference to class GeoPoint with interface IGeoPoint.