### PR TITLE
Improvement: MapView.zoomToBoundingBox() can be used in onCreate() or…

### DIFF
--- a/osmdroid-android/src/main/java/microsoft/mappoint/TileSystem.java
+++ b/osmdroid-android/src/main/java/microsoft/mappoint/TileSystem.java
@@ -8,6 +8,8 @@ package microsoft.mappoint;
  *
  */
 
+import org.osmdroid.api.IGeoPoint;
+import org.osmdroid.api.IGeoPointE6;
 import org.osmdroid.util.GeoPoint;
 
 import android.graphics.Point;

--- a/osmdroid-android/src/main/java/org/osmdroid/api/IGeoPoint.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/api/IGeoPoint.java
@@ -3,9 +3,7 @@ package org.osmdroid.api;
 /**
  * An interface that resembles the Google Maps API GeoPoint class.
  */
-public interface IGeoPoint {
-	int getLatitudeE6();
-	int getLongitudeE6();
+public interface IGeoPoint extends IGeoPointE6 {
 	double getLatitude();
 	double getLongitude();
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/api/IGeoPointE6.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/api/IGeoPointE6.java
@@ -1,0 +1,12 @@
+package org.osmdroid.api;
+
+/**
+ * A minimalistic abstraction of a geopoint .
+ *
+ * Created by k3b on 18.07.2015.
+ */
+public interface IGeoPointE6 {
+    int getLongitudeE6();
+
+    int getLatitudeE6();
+}

--- a/osmdroid-android/src/main/java/org/osmdroid/api/IProjection.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/api/IProjection.java
@@ -1,5 +1,6 @@
 package org.osmdroid.api;
 
+import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.Projection;
 
@@ -15,7 +16,7 @@ import android.graphics.Point;
 public interface IProjection {
 
 	/**
-	 * Converts the given {@link IGeoPoint} to onscreen pixel coordinates, relative to the top-left
+	 * Converts the given {@link IGeoPointE6} to onscreen pixel coordinates, relative to the top-left
 	 * of the {@link MapView} that provided this Projection.
 	 * 
 	 * @param in
@@ -24,13 +25,13 @@ public interface IProjection {
 	 *            A pre-existing object to use for the output; if null, a new Point will be
 	 *            allocated and returned.
 	 */
-	Point toPixels(IGeoPoint in, Point out);
+	Point toPixels(IGeoPointE6 in, Point out);
 
 	/**
 	 * Create a new GeoPoint from pixel coordinates relative to the top-left of the MapView that
 	 * provided this PixelConverter.
 	 */
-	IGeoPoint fromPixels(int x, int y);
+	GeoPoint fromPixels(int x, int y);
 
 	/**
 	 * Converts a distance in meters (along the equator) to one in (horizontal) pixels at the
@@ -47,11 +48,11 @@ public interface IProjection {
 	/**
 	 * Get the coordinates of the most north-easterly visible point of the map.
 	 */
-	IGeoPoint getNorthEast();
+	GeoPoint getNorthEast();
 
 	/**
 	 * Get the coordinates of the most south-westerly visible point of the map.
 	 */
-	IGeoPoint getSouthWest();
+	GeoPoint getSouthWest();
 
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/util/BoundingBoxE6.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/BoundingBoxE6.java
@@ -8,6 +8,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 
 import org.osmdroid.api.IGeoPoint;
+import org.osmdroid.api.IGeoPointE6;
 import org.osmdroid.views.util.constants.MapViewConstants;
 
 import android.graphics.PointF;
@@ -171,7 +172,7 @@ public class BoundingBoxE6 implements Parcelable, Serializable, MapViewConstants
 	}
 
 	public BoundingBoxE6 increaseByScale(final float pBoundingboxPaddingRelativeScale) {
-		final GeoPoint pCenter = this.getCenter();
+		final IGeoPointE6 pCenter = this.getCenter();
 		final int mLatSpanE6Padded_2 = (int) ((this.getLatitudeSpanE6() * pBoundingboxPaddingRelativeScale) / 2);
 		final int mLonSpanE6Padded_2 = (int) ((this.getLongitudeSpanE6() * pBoundingboxPaddingRelativeScale) / 2);
 
@@ -200,12 +201,12 @@ public class BoundingBoxE6 implements Parcelable, Serializable, MapViewConstants
 				Math.max(this.mLonWestE6, Math.min(this.mLonEastE6, aLongitudeE6)));
 	}
 
-	public static BoundingBoxE6 fromGeoPoints(final ArrayList<? extends GeoPoint> partialPolyLine) {
+	public static BoundingBoxE6 fromGeoPoints(final ArrayList<? extends IGeoPointE6> partialPolyLine) {
 		int minLat = Integer.MAX_VALUE;
 		int minLon = Integer.MAX_VALUE;
 		int maxLat = Integer.MIN_VALUE;
 		int maxLon = Integer.MIN_VALUE;
-		for (final GeoPoint gp : partialPolyLine) {
+		for (final IGeoPointE6 gp : partialPolyLine) {
 			final int latitudeE6 = gp.getLatitudeE6();
 			final int longitudeE6 = gp.getLongitudeE6();
 

--- a/osmdroid-android/src/main/java/org/osmdroid/util/GeoPoint.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/GeoPoint.java
@@ -4,6 +4,7 @@ package org.osmdroid.util;
 import java.io.Serializable;
 
 import org.osmdroid.api.IGeoPoint;
+import org.osmdroid.api.IGeoPointE6;
 import org.osmdroid.util.constants.GeoConstants;
 import org.osmdroid.views.util.constants.MathConstants;
 
@@ -42,6 +43,10 @@ public class GeoPoint implements IGeoPoint, MathConstants, GeoConstants, Parcela
 		this.mLongitudeE6 = aLongitudeE6;
 	}
 
+	public GeoPoint(final IGeoPointE6 aGeoPoin) {
+		this(aGeoPoin.getLatitudeE6(), aGeoPoin.getLongitudeE6());
+
+	}
 	public GeoPoint(final int aLatitudeE6, final int aLongitudeE6, final int aAltitude) {
 		this.mLatitudeE6 = aLatitudeE6;
 		this.mLongitudeE6 = aLongitudeE6;
@@ -309,7 +314,7 @@ public class GeoPoint implements IGeoPoint, MathConstants, GeoConstants, Parcela
 		return new GeoPoint(lat2deg, lon2deg);
 	}
 
-	public static GeoPoint fromCenterBetween(final GeoPoint geoPointA, final GeoPoint geoPointB) {
+	public static GeoPoint fromCenterBetween(final IGeoPointE6 geoPointA, final IGeoPointE6 geoPointB) {
 		return new GeoPoint((geoPointA.getLatitudeE6() + geoPointB.getLatitudeE6()) / 2,
 				(geoPointA.getLongitudeE6() + geoPointB.getLongitudeE6()) / 2);
 	}

--- a/osmdroid-android/src/main/java/org/osmdroid/util/TileSystem.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/TileSystem.java
@@ -2,6 +2,9 @@ package org.osmdroid.util;
 
 import android.graphics.Point;
 
+import org.osmdroid.api.IGeoPoint;
+import org.osmdroid.api.IGeoPointE6;
+
 /**
  * Proxy class for TileSystem. For coordinate conversions (tile to lat/lon and reverse) TileSystem
  * only accepts input parameters within certain ranges and crops any values outside of it. For

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapControllerOld.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapControllerOld.java
@@ -4,6 +4,7 @@ package org.osmdroid.views;
 import microsoft.mappoint.TileSystem;
 
 import org.osmdroid.api.IGeoPoint;
+import org.osmdroid.api.IGeoPointE6;
 import org.osmdroid.api.IMapController;
 import org.osmdroid.util.BoundingBoxE6;
 import org.osmdroid.util.GeoPoint;
@@ -110,7 +111,7 @@ public class MapControllerOld implements IMapController, MapViewConstants {
 	 *
 	 * @param gp
 	 */
-	public void animateTo(final GeoPoint gp, final AnimationType aAnimationType) {
+	public void animateTo(final IGeoPointE6 gp, final AnimationType aAnimationType) {
 		animateTo(gp.getLatitudeE6(), gp.getLongitudeE6(), aAnimationType,
 				ANIMATION_DURATION_DEFAULT, ANIMATION_SMOOTHNESS_DEFAULT);
 	}
@@ -131,7 +132,7 @@ public class MapControllerOld implements IMapController, MapViewConstants {
 	 *            {@link MapViewConstants#ANIMATION_DURATION_DEFAULT},
 	 *            {@link MapViewConstants#ANIMATION_DURATION_LONG}
 	 */
-	public void animateTo(final GeoPoint gp, final AnimationType aAnimationType,
+	public void animateTo(final IGeoPointE6 gp, final AnimationType aAnimationType,
 			final int aSmoothness, final int aDuration) {
 		animateTo(gp.getLatitudeE6(), gp.getLongitudeE6(), aAnimationType, aSmoothness, aDuration);
 	}

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
@@ -17,6 +17,7 @@ import org.metalev.multitouch.controller.MultiTouchController.PositionAndScale;
 import org.osmdroid.DefaultResourceProxyImpl;
 import org.osmdroid.ResourceProxy;
 import org.osmdroid.api.IGeoPoint;
+import org.osmdroid.api.IGeoPointE6;
 import org.osmdroid.api.IMapController;
 import org.osmdroid.api.IMapView;
 import org.osmdroid.events.MapListener;
@@ -400,7 +401,7 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
 			if (DEBUGMODE) {
 				logger.debug("zoomToBoundingBox(" + boundingBox + ") executed");
 			}
-			
+
 			final BoundingBoxE6 currentBox = getBoundingBox();
 
 			// Calculated required zoom based on latitude span

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
@@ -368,43 +368,70 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
 		return this.mZoomLevel;
 	}
 
+	private BoundingBoxE6 mDelayedZoomToBoundingBox = null;
+	@Override
+	public void onWindowFocusChanged(boolean hasFocus) {
+		super.onWindowFocusChanged(hasFocus);
+		if (this.mDelayedZoomToBoundingBox != null) {
+			// zoomToBoundingBox does not work in onCreate() because getHeight() and getWidth() return 0;
+			// initial center must be set later when getHeight() and getWith() are set (i.e. in onWindowFocusChanged()).
+			// see http://stackoverflow.com/questions/10411975/how-to-get-the-width-and-height-of-an-image-view-in-android/10412209#10412209
+			final BoundingBoxE6 boundingBox = this.mDelayedZoomToBoundingBox;
+			this.mDelayedZoomToBoundingBox = null; // donot call it again
+			this.zoomToBoundingBox(boundingBox);
+
+		}
+	}
+
 	/**
-	 * Zoom the map to enclose the specified bounding box, as closely as possible. Must be called
-	 * after display layout is complete, or screen dimensions are not known, and will always zoom to
-	 * center of zoom level 0.<br>
-	 * Suggestion: Check getScreenRect(null).getHeight() &gt; 0
+	 * Zoom the map to enclose the specified bounding box, as closely as possible.
+	 * Since org.osmdroid:osmdroid-android:4.4 this can be done in onCreate
 	 */
 	public void zoomToBoundingBox(final BoundingBoxE6 boundingBox) {
-		final BoundingBoxE6 currentBox = getBoundingBox();
+		if (this.getWidth() == 0) {
+			// MapView not fully initialized. do it later in onWindowFocusChanged
+			if (DEBUGMODE) {
+				logger.debug("zoomToBoundingBox(" + boundingBox + ") delayed");
+			}
 
-		// Calculated required zoom based on latitude span
-		final double maxZoomLatitudeSpan = mZoomLevel == getMaxZoomLevel() ?
-				currentBox.getLatitudeSpanE6() :
-				currentBox.getLatitudeSpanE6() / Math.pow(2, getMaxZoomLevel() - mZoomLevel);
+			this.mDelayedZoomToBoundingBox = boundingBox;
+		} else {
+			// can execute immediately
+			if (DEBUGMODE) {
+				logger.debug("zoomToBoundingBox(" + boundingBox + ") executed");
+			}
+			
+			final BoundingBoxE6 currentBox = getBoundingBox();
 
-		final double requiredLatitudeZoom =
-			getMaxZoomLevel() -
-			Math.ceil(Math.log(boundingBox.getLatitudeSpanE6() / maxZoomLatitudeSpan) / Math.log(2));
+			// Calculated required zoom based on latitude span
+			final double maxZoomLatitudeSpan = mZoomLevel == getMaxZoomLevel() ?
+					currentBox.getLatitudeSpanE6() :
+					currentBox.getLatitudeSpanE6() / Math.pow(2, getMaxZoomLevel() - mZoomLevel);
+
+			final double requiredLatitudeZoom =
+					getMaxZoomLevel() -
+							Math.ceil(Math.log(boundingBox.getLatitudeSpanE6() / maxZoomLatitudeSpan) / Math.log(2));
 
 
-		// Calculated required zoom based on longitude span
-		final double maxZoomLongitudeSpan = mZoomLevel == getMaxZoomLevel() ?
-				currentBox.getLongitudeSpanE6() :
-				currentBox.getLongitudeSpanE6() / Math.pow(2, getMaxZoomLevel() - mZoomLevel);
+			// Calculated required zoom based on longitude span
+			final double maxZoomLongitudeSpan = mZoomLevel == getMaxZoomLevel() ?
+					currentBox.getLongitudeSpanE6() :
+					currentBox.getLongitudeSpanE6() / Math.pow(2, getMaxZoomLevel() - mZoomLevel);
 
-		final double requiredLongitudeZoom =
-			getMaxZoomLevel() -
-			Math.ceil(Math.log(boundingBox.getLongitudeSpanE6() / maxZoomLongitudeSpan) / Math.log(2));
+			final double requiredLongitudeZoom =
+					getMaxZoomLevel() -
+							Math.ceil(Math.log(boundingBox.getLongitudeSpanE6() / maxZoomLongitudeSpan) / Math.log(2));
 
 
-		// Zoom to boundingBox center, at calculated maximum allowed zoom level
-		getController().setZoom((int)(
-				requiredLatitudeZoom < requiredLongitudeZoom ?
-				requiredLatitudeZoom : requiredLongitudeZoom));
+			// Zoom to boundingBox center, at calculated maximum allowed zoom level
+			getController().setZoom((int) (
+					requiredLatitudeZoom < requiredLongitudeZoom ?
+							requiredLatitudeZoom : requiredLongitudeZoom));
 
-		getController().setCenter(
-				new GeoPoint(boundingBox.getCenter().getLatitudeE6(), boundingBox.getCenter()
-						.getLongitudeE6()));
+			getController().setCenter(
+					new GeoPoint(boundingBox.getCenter().getLatitudeE6(), boundingBox.getCenter()
+							.getLongitudeE6()));
+		}
 	}
 
 	/**

--- a/osmdroid-android/src/main/java/org/osmdroid/views/Projection.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/Projection.java
@@ -2,6 +2,7 @@ package org.osmdroid.views;
 
 
 import org.osmdroid.api.IGeoPoint;
+import org.osmdroid.api.IGeoPointE6;
 import org.osmdroid.api.IProjection;
 import org.osmdroid.util.BoundingBoxE6;
 import org.osmdroid.util.GeoPoint;
@@ -134,7 +135,7 @@ public class Projection implements IProjection, MapViewConstants {
 	/**
 	 * A wrapper for {@link #toProjectedPixels(int, int, Point)}
 	 */
-	public Point toProjectedPixels(final GeoPoint geoPoint, final Point reuse) {
+	public Point toProjectedPixels(final IGeoPointE6 geoPoint, final Point reuse) {
 		return toProjectedPixels(geoPoint.getLatitudeE6(), geoPoint.getLongitudeE6(), reuse);
 	}
 
@@ -208,7 +209,7 @@ public class Projection implements IProjection, MapViewConstants {
 	 */
 	public float metersToPixels(final float meters) {
 		return meters
-				/ (float) TileSystem.GroundResolution(getBoundingBox().getCenter().getLatitude(),
+				/ (float) TileSystem.GroundResolution(getBoundingBox().getCenter().getLatitudeE6()  * 1E-6,
 						mZoomLevelProjection);
 	}
 

--- a/osmdroid-android/src/main/java/org/osmdroid/views/Projection.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/Projection.java
@@ -1,7 +1,5 @@
 package org.osmdroid.views;
 
-
-import org.osmdroid.api.IGeoPoint;
 import org.osmdroid.api.IGeoPointE6;
 import org.osmdroid.api.IProjection;
 import org.osmdroid.util.BoundingBoxE6;
@@ -62,8 +60,8 @@ public class Projection implements IProjection, MapViewConstants {
 		mRotateAndScaleMatrix.invert(mUnrotateAndScaleMatrix);
 		mMultiTouchScale = mapView.mMultiTouchScale;
 
-		final IGeoPoint neGeoPoint = fromPixels(mMapViewWidth, 0, null);
-		final IGeoPoint swGeoPoint = fromPixels(0, mMapViewHeight, null);
+		final IGeoPointE6 neGeoPoint = fromPixels(mMapViewWidth, 0, null);
+		final IGeoPointE6 swGeoPoint = fromPixels(0, mMapViewHeight, null);
 
 		mBoundingBoxProjection = new BoundingBoxE6(neGeoPoint.getLatitudeE6(),
 				neGeoPoint.getLongitudeE6(), swGeoPoint.getLatitudeE6(),
@@ -91,17 +89,17 @@ public class Projection implements IProjection, MapViewConstants {
 	}
 
 	@Override
-	public IGeoPoint fromPixels(int x, int y) {
+	public GeoPoint fromPixels(int x, int y) {
 		return fromPixels(x, y, null);
 	}
 
-	public IGeoPoint fromPixels(int x, int y, GeoPoint reuse) {
+	public GeoPoint fromPixels(int x, int y, GeoPoint reuse) {
 		return TileSystem.PixelXYToLatLong(x - mOffsetX, y - mOffsetY, mZoomLevelProjection, reuse);
 	}
 
 	@Override
-	public Point toPixels(final IGeoPoint in, final Point reuse) {
-		Point out = TileSystem.LatLongToPixelXY(in.getLatitude(), in.getLongitude(),
+	public Point toPixels(final IGeoPointE6 in, final Point reuse) {
+		Point out = TileSystem.LatLongToPixelXY(in.getLatitudeE6() * 1E-6, in.getLongitudeE6() * 1E-6,
 				getZoomLevel(), reuse);
 
 		out = toPixelsFromMercator(out.x, out.y, out);
@@ -214,12 +212,12 @@ public class Projection implements IProjection, MapViewConstants {
 	}
 
 	@Override
-	public IGeoPoint getNorthEast() {
+	public GeoPoint getNorthEast() {
 		return fromPixels(mMapViewWidth, 0, null);
 	}
 
 	@Override
-	public IGeoPoint getSouthWest() {
+	public GeoPoint getSouthWest() {
 		return fromPixels(0, mMapViewHeight, null);
 	}
 

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/DirectedLocationOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/DirectedLocationOverlay.java
@@ -3,6 +3,7 @@ package org.osmdroid.views.overlay;
 
 import org.osmdroid.DefaultResourceProxyImpl;
 import org.osmdroid.ResourceProxy;
+import org.osmdroid.api.IGeoPointE6;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.Projection;

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/MyLocationOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/MyLocationOverlay.java
@@ -7,6 +7,7 @@ import org.osmdroid.DefaultResourceProxyImpl;
 import org.osmdroid.LocationListenerProxy;
 import org.osmdroid.ResourceProxy;
 import org.osmdroid.SensorEventListenerProxy;
+import org.osmdroid.api.IGeoPointE6;
 import org.osmdroid.api.IMapController;
 import org.osmdroid.api.IMapView;
 import org.osmdroid.api.IMyLocationOverlay;

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/PathOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/PathOverlay.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.osmdroid.DefaultResourceProxyImpl;
 import org.osmdroid.ResourceProxy;
 import org.osmdroid.api.IGeoPoint;
+import org.osmdroid.api.IGeoPointE6;
 import org.osmdroid.util.BoundingBoxE6;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.MapView;
@@ -115,15 +116,15 @@ public class PathOverlay extends Overlay {
 	 * @param endPoint end point of the great circle
 	 * @param numberOfPoints number of points to calculate along the path
 	 */
-	public void addGreatCircle(final GeoPoint startPoint, final GeoPoint endPoint, final int numberOfPoints) {
+	public void addGreatCircle(final IGeoPointE6 startPoint, final IGeoPointE6 endPoint, final int numberOfPoints) {
 		//	adapted from page http://compastic.blogspot.co.uk/2011/07/how-to-draw-great-circle-on-map-in.html
 		//	which was adapted from page http://maps.forum.nu/gm_flight_path.html
 
 		// convert to radians
-		final double lat1 = startPoint.getLatitude() * Math.PI / 180;
-		final double lon1 = startPoint.getLongitude() * Math.PI / 180;
-		final double lat2 = endPoint.getLatitude() * Math.PI / 180;
-		final double lon2 = endPoint.getLongitude() * Math.PI / 180;
+		final double lat1 = startPoint.getLatitudeE6() * 1E-6 * Math.PI / 180;
+		final double lon1 = startPoint.getLongitudeE6() * 1E-6 * Math.PI / 180;
+		final double lat2 = endPoint.getLatitudeE6() * 1E-6 * Math.PI / 180;
+		final double lon2 = endPoint.getLongitudeE6() * 1E-6 * Math.PI / 180;
 
 		final double d = 2 * Math.asin(Math.sqrt(Math.pow(Math.sin((lat1 - lat2) / 2), 2) + Math.cos(lat1) * Math.cos(lat2)
 				* Math.pow(Math.sin((lon1 - lon2) / 2), 2)));

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/SimpleLocationOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/SimpleLocationOverlay.java
@@ -3,6 +3,7 @@ package org.osmdroid.views.overlay;
 
 import org.osmdroid.DefaultResourceProxyImpl;
 import org.osmdroid.ResourceProxy;
+import org.osmdroid.api.IGeoPointE6;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.Projection;

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/mylocation/MyLocationNewOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/mylocation/MyLocationNewOverlay.java
@@ -4,6 +4,7 @@ import java.util.LinkedList;
 
 import org.osmdroid.DefaultResourceProxyImpl;
 import org.osmdroid.ResourceProxy;
+import org.osmdroid.api.IGeoPointE6;
 import org.osmdroid.api.IMapController;
 import org.osmdroid.api.IMapView;
 import org.osmdroid.util.GeoPoint;

--- a/osmdroid-android/src/main/java/org/osmdroid/views/util/Mercator.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/util/Mercator.java
@@ -2,6 +2,7 @@
 package org.osmdroid.views.util;
 
 import org.osmdroid.api.IGeoPoint;
+import org.osmdroid.api.IGeoPointE6;
 import org.osmdroid.util.BoundingBoxE6;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.util.constants.MapViewConstants;

--- a/osmdroid-android/src/main/java/org/osmdroid/views/util/PathProjection.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/util/PathProjection.java
@@ -2,8 +2,8 @@ package org.osmdroid.views.util;
 
 import java.util.List;
 
+import org.osmdroid.api.IGeoPointE6;
 import org.osmdroid.util.BoundingBoxE6;
-import org.osmdroid.util.GeoPoint;
 import org.osmdroid.util.TileSystem;
 import org.osmdroid.views.Projection;
 
@@ -14,12 +14,12 @@ import android.graphics.Rect;
 
 public class PathProjection {
 
-	public static Path toPixels(Projection projection, final List<? extends GeoPoint> in,
+	public static Path toPixels(Projection projection, final List<? extends IGeoPointE6> in,
 			final Path reuse) {
 		return toPixels(projection, in, reuse, true);
 	}
 
-	public static Path toPixels(Projection projection, final List<? extends GeoPoint> in,
+	public static Path toPixels(Projection projection, final List<? extends IGeoPointE6> in,
 			final Path reuse, final boolean doGudermann) throws IllegalArgumentException {
 		if (in.size() < 2) {
 			throw new IllegalArgumentException("List of GeoPoints needs to be at least 2.");
@@ -29,7 +29,7 @@ public class PathProjection {
 		out.incReserve(in.size());
 
 		boolean first = true;
-		for (final GeoPoint gp : in) {
+		for (final IGeoPointE6 gp : in) {
 			final Point underGeopointTileCoords = TileSystem.LatLongToPixelXY(
 					gp.getLatitudeE6() / 1E6, gp.getLongitudeE6() / 1E6, projection.getZoomLevel(),
 					null);
@@ -44,9 +44,9 @@ public class PathProjection {
 			final Point lowerLeft = TileSystem.TileXYToPixelXY(underGeopointTileCoords.x
 					+ TileSystem.getTileSize(),
 					underGeopointTileCoords.y + TileSystem.getTileSize(), null);
-			final GeoPoint neGeoPoint = TileSystem.PixelXYToLatLong(upperRight.x, upperRight.y,
+			final IGeoPointE6 neGeoPoint = TileSystem.PixelXYToLatLong(upperRight.x, upperRight.y,
 					projection.getZoomLevel(), null);
-			final GeoPoint swGeoPoint = TileSystem.PixelXYToLatLong(lowerLeft.x, lowerLeft.y,
+			final IGeoPointE6 swGeoPoint = TileSystem.PixelXYToLatLong(lowerLeft.x, lowerLeft.y,
 					projection.getZoomLevel(), null);
 			final BoundingBoxE6 bb = new BoundingBoxE6(neGeoPoint.getLatitudeE6(),
 					neGeoPoint.getLongitudeE6(), swGeoPoint.getLatitudeE6(),

--- a/osmdroid-android/src/test/java/org/osmdroid/util/GeoPointTest.java
+++ b/osmdroid-android/src/test/java/org/osmdroid/util/GeoPointTest.java
@@ -3,6 +3,7 @@ package org.osmdroid.util;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
+import org.osmdroid.api.IGeoPointE6;
 
 public class GeoPointTest {
 
@@ -74,49 +75,49 @@ public class GeoPointTest {
 		// this test is based on the actual result, not calculated expectations,
 		// but it is at least a basic sanity check for rounding errors and regression
 		final GeoPoint start = new GeoPoint(52387524, 4891604);
-		final GeoPoint end = new GeoPoint(52390698, 4886399);
+		final IGeoPointE6 end = new GeoPoint(52390698, 4886399);
 		assertEquals("destinationPoint north west", end, start.destinationPoint(500, -45));
 	}
 
 	@Test
 	public void test_toFromString_withoutAltitude() {
-		final GeoPoint in = new GeoPoint(52387524, 4891604);
-		final GeoPoint out = GeoPoint.fromIntString("52387524,4891604");
+		final IGeoPointE6 in = new GeoPoint(52387524, 4891604);
+		final IGeoPointE6 out = GeoPoint.fromIntString("52387524,4891604");
 		assertEquals("toFromString without altitude", in, out);
 	}
 
 	@Test
 	public void test_toFromString_withAltitude() {
-		final GeoPoint in = new GeoPoint(52387524, 4891604, 12345);
-		final GeoPoint out = GeoPoint.fromIntString(in.toString());
+		final IGeoPointE6 in = new GeoPoint(52387524, 4891604, 12345);
+		final IGeoPointE6 out = GeoPoint.fromIntString(in.toString());
 		assertEquals("toFromString with altitude", in, out);
 	}
 
 	@Test
 	public void test_toFromDoubleString_withoutAltitude() {
-		final GeoPoint in = new GeoPoint(-117.123, 33.123);
-		final GeoPoint out = GeoPoint.fromDoubleString("-117.123,33.123", ',');
+		final IGeoPointE6 in = new GeoPoint(-117.123, 33.123);
+		final IGeoPointE6 out = GeoPoint.fromDoubleString("-117.123,33.123", ',');
 		assertEquals("toFromString without altitude", in, out);
 	}
 
 	@Test
 	public void test_toFromDoubleString_withAltitude() {
 		final GeoPoint in = new GeoPoint(-117.123, 33.123, 12345);
-		final GeoPoint out = GeoPoint.fromDoubleString(in.toDoubleString(), ',');
+		final IGeoPointE6 out = GeoPoint.fromDoubleString(in.toDoubleString(), ',');
 		assertEquals("toFromString with altitude", in, out);
 	}
 
 	@Test
 	public void test_toFromInvertedDoubleString_withoutAltitude() {
-		final GeoPoint in = new GeoPoint(-117.123, 33.123);
-		final GeoPoint out = GeoPoint.fromInvertedDoubleString("33.123,-117.123", ',');
+		final IGeoPointE6 in = new GeoPoint(-117.123, 33.123);
+		final IGeoPointE6 out = GeoPoint.fromInvertedDoubleString("33.123,-117.123", ',');
 		assertEquals("toFromString without altitude", in, out);
 	}
 
 	@Test
 	public void test_toFromInvertedDoubleString_withAltitude() {
 		final GeoPoint in = new GeoPoint(-117.123, 33.123, 12345);
-		final GeoPoint out = GeoPoint.fromInvertedDoubleString(in.toInvertedDoubleString(), ',');
+		final IGeoPointE6 out = GeoPoint.fromInvertedDoubleString(in.toInvertedDoubleString(), ',');
 		assertEquals("toFromString with altitude", in, out);
 	}
 


### PR DESCRIPTION
… onCreateView.

Implemented workaround from http://stackoverflow.com/questions/10411975/how-to-get-the-width-and-height-of-an-image-view-in-android/10412209#10412209

so that the MapView user does not have to do this.
