### PR TITLE
Bugfix: contains fails when boundingbox spans 180th meridian

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/util/BoundingBoxE6.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/BoundingBoxE6.java
@@ -223,8 +223,19 @@ public class BoundingBoxE6 implements Parcelable, Serializable, MapViewConstants
 	}
 
 	public boolean contains(final int aLatitudeE6, final int aLongitudeE6) {
-		return ((aLatitudeE6 < this.mLatNorthE6) && (aLatitudeE6 > this.mLatSouthE6))
-				&& ((aLongitudeE6 < this.mLonEastE6) && (aLongitudeE6 > this.mLonWestE6));
+		if (aLatitudeE6 < this.mLatNorthE6 && aLatitudeE6 > this.mLatSouthE6) {
+			if (this.mLonWestE6 < this.mLonEastE6) {
+				if (aLongitudeE6 < this.mLonEastE6 && aLongitudeE6 > this.mLonWestE6) {
+					return true;
+				}
+			} else { 
+				// boundingbox spans 180th meridian 
+				if (aLongitudeE6 < this.mLonEastE6 || aLongitudeE6 > this.mLonWestE6) {
+					return true;
+				}
+			}
+		}
+		return false;
 	}
 
 	// ===========================================================


### PR DESCRIPTION
When a boundingbox spans the 180th meridian (anti-meridian), the contains method will fail.

Example: BoundingBoxE6(72.d, -128.d, 48.d, 170.d)