### PR TITLE
Implemented Animated Zoom To ZoomLevel

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleAnimatedZoomToLocation.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleAnimatedZoomToLocation.java
@@ -2,11 +2,6 @@ package org.osmdroid.samplefragments;
 
 import android.content.Context;
 import android.location.Location;
-import android.os.Bundle;
-import android.view.Menu;
-import android.view.MenuInflater;
-import android.view.MenuItem;
-import android.widget.Toast;
 
 import org.osmdroid.api.IGeoPoint;
 import org.osmdroid.api.IMapController;
@@ -19,7 +14,6 @@ import org.osmdroid.views.overlay.gestures.RotationGestureOverlay;
 import org.osmdroid.views.overlay.mylocation.GpsMyLocationProvider;
 import org.osmdroid.views.overlay.mylocation.IMyLocationConsumer;
 import org.osmdroid.views.overlay.mylocation.IMyLocationProvider;
-import org.osmdroid.views.overlay.mylocation.MyLocationNewOverlay;
 
 import java.util.ArrayList;
 
@@ -32,6 +26,15 @@ public class SampleAnimatedZoomToLocation extends BaseSampleFragment {
 
   private ItemizedOverlayWithFocus<OverlayItem> mMyLocationOverlay;
   private RotationGestureOverlay mRotationGestureOverlay;
+  private GpsMyLocationProvider mGpsMyLocationProvider;
+
+  @Override
+  public void onPause() {
+    super.onPause();
+    if(mGpsMyLocationProvider != null) {
+      mGpsMyLocationProvider.stopLocationProvider();
+    }
+  }
 
   @Override
   public String getSampleTitle() {
@@ -43,10 +46,11 @@ public class SampleAnimatedZoomToLocation extends BaseSampleFragment {
     super.addOverlays();
 
     final Context context = getActivity();
-
-    new GpsMyLocationProvider(context).startLocationProvider(new IMyLocationConsumer() {
+    mGpsMyLocationProvider = new GpsMyLocationProvider(context);
+    mGpsMyLocationProvider.startLocationProvider(new IMyLocationConsumer() {
       @Override
       public void onLocationChanged(Location location, IMyLocationProvider source) {
+        mGpsMyLocationProvider.stopLocationProvider();
         if(mMyLocationOverlay == null) {
           final ArrayList<OverlayItem> items = new ArrayList<OverlayItem>();
           items.add(new OverlayItem("Me", "My Location",

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleAnimatedZoomToLocation.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleAnimatedZoomToLocation.java
@@ -1,0 +1,92 @@
+package org.osmdroid.samplefragments;
+
+import android.content.Context;
+import android.location.Location;
+import android.os.Bundle;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.widget.Toast;
+
+import org.osmdroid.api.IGeoPoint;
+import org.osmdroid.api.IMapController;
+import org.osmdroid.util.GeoPoint;
+import org.osmdroid.views.overlay.ItemizedIconOverlay;
+import org.osmdroid.views.overlay.ItemizedOverlayWithFocus;
+import org.osmdroid.views.overlay.MinimapOverlay;
+import org.osmdroid.views.overlay.OverlayItem;
+import org.osmdroid.views.overlay.gestures.RotationGestureOverlay;
+import org.osmdroid.views.overlay.mylocation.GpsMyLocationProvider;
+import org.osmdroid.views.overlay.mylocation.IMyLocationConsumer;
+import org.osmdroid.views.overlay.mylocation.IMyLocationProvider;
+import org.osmdroid.views.overlay.mylocation.MyLocationNewOverlay;
+
+import java.util.ArrayList;
+
+/**
+ * @author Tyrone Tudehope
+ */
+public class SampleAnimatedZoomToLocation extends BaseSampleFragment {
+
+  public static final String TITLE = "Animated Zoom to Location";
+
+  private ItemizedOverlayWithFocus<OverlayItem> mMyLocationOverlay;
+  private RotationGestureOverlay mRotationGestureOverlay;
+
+  @Override
+  public String getSampleTitle() {
+    return TITLE;
+  }
+
+  @Override
+  protected void addOverlays() {
+    super.addOverlays();
+
+    final Context context = getActivity();
+
+    new GpsMyLocationProvider(context).startLocationProvider(new IMyLocationConsumer() {
+      @Override
+      public void onLocationChanged(Location location, IMyLocationProvider source) {
+        if(mMyLocationOverlay == null) {
+          final ArrayList<OverlayItem> items = new ArrayList<OverlayItem>();
+          items.add(new OverlayItem("Me", "My Location",
+            new GeoPoint(location)));
+
+          mMyLocationOverlay = new ItemizedOverlayWithFocus<OverlayItem>(items,
+            new ItemizedIconOverlay.OnItemGestureListener<OverlayItem>() {
+              @Override
+              public boolean onItemSingleTapUp(final int index, final OverlayItem item) {
+                IMapController mapController = mMapView.getController();
+                mapController.setCenter(item.getPoint());
+                mapController.zoomTo(mMapView.getMaxZoomLevel());
+                return true;
+              }
+
+              @Override
+              public boolean onItemLongPress(final int index, final OverlayItem item) {
+                return false;
+              }
+            }, mResourceProxy);
+
+          mMyLocationOverlay.setFocusItemsOnTap(true);
+          mMyLocationOverlay.setFocusedItem(0);
+
+          mMapView.getOverlays().add(mMyLocationOverlay);
+
+          mMapView.getController().setZoom(10);
+          IGeoPoint geoPoint = mMyLocationOverlay.getFocusedItem().getPoint();
+          mMapView.getController().animateTo(geoPoint);
+        }
+      }
+    });
+
+    mRotationGestureOverlay = new RotationGestureOverlay(context, mMapView);
+    mRotationGestureOverlay.setEnabled(false);
+    mMapView.getOverlays().add(mRotationGestureOverlay);
+
+    MinimapOverlay miniMapOverlay = new MinimapOverlay(context,
+      mMapView.getTileRequestCompleteHandler());
+    mMapView.getOverlays().add(miniMapOverlay);
+  }
+
+}

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleFactory.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleFactory.java
@@ -22,7 +22,8 @@ public final class SampleFactory {
                     new SampleMilitaryIcons(),
                     new SampleMapBox(),
 					new SampleJumboCache(),
-                    new SampleCustomTileSource()};
+                    new SampleCustomTileSource(),
+										new SampleAnimatedZoomToLocation()};
 	}
 
 	public BaseSampleFragment getSample(int index) {

--- a/osmdroid-android/src/main/java/org/osmdroid/api/IMapController.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/api/IMapController.java
@@ -18,6 +18,7 @@ public interface IMapController {
 	boolean zoomInFixing(int xPixel, int yPixel);
 	boolean zoomOut();
 	boolean zoomOutFixing(int xPixel, int yPixel);
+	boolean zoomTo(int zoomLevel);
 	void zoomToSpan(int latSpanE6, int lonSpanE6);
 	
 	/**

--- a/osmdroid-android/src/main/java/org/osmdroid/api/IMapController.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/api/IMapController.java
@@ -15,10 +15,8 @@ public interface IMapController {
 	void stopAnimation(boolean jumpToFinish);
 	void stopPanning();
 	boolean zoomIn();
-	@Deprecated
 	boolean zoomInFixing(int xPixel, int yPixel);
 	boolean zoomOut();
-	@Deprecated
 	boolean zoomOutFixing(int xPixel, int yPixel);
 	boolean zoomTo(int zoomLevel);
 	boolean zoomToFixing(int zoomLevel, int xPixel, int yPixel);

--- a/osmdroid-android/src/main/java/org/osmdroid/api/IMapController.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/api/IMapController.java
@@ -15,10 +15,13 @@ public interface IMapController {
 	void stopAnimation(boolean jumpToFinish);
 	void stopPanning();
 	boolean zoomIn();
+	@Deprecated
 	boolean zoomInFixing(int xPixel, int yPixel);
 	boolean zoomOut();
+	@Deprecated
 	boolean zoomOutFixing(int xPixel, int yPixel);
 	boolean zoomTo(int zoomLevel);
+	boolean zoomToFixing(int zoomLevel, int xPixel, int yPixel);
 	void zoomToSpan(int latSpanE6, int lonSpanE6);
 	
 	/**

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapController.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapController.java
@@ -275,7 +275,7 @@ public class MapController implements IMapController, OnFirstLayoutListener {
 	 */
 	@Override
 	public boolean zoomOut() {
-		return zoomTo(mMapView.getZoomLevel(false) + 1);
+		return zoomTo(mMapView.getZoomLevel(false) - 1);
 	}
 
 	@Override

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapController.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapController.java
@@ -12,9 +12,9 @@ import org.osmdroid.views.MapView.OnFirstLayoutListener;
 import org.osmdroid.views.util.MyMath;
 
 import android.animation.Animator;
-import android.animation.AnimatorListenerAdapter;
 import android.animation.ValueAnimator;
 import android.animation.ValueAnimator.AnimatorUpdateListener;
+import android.annotation.TargetApi;
 import android.graphics.Point;
 import android.graphics.Rect;
 import android.os.Build;
@@ -66,25 +66,28 @@ public class MapController implements IMapController, OnFirstLayoutListener {
 			mMapView.addOnFirstLayoutListener(this);
 		}
 
+
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+			ZoomAnimatorListener zoomAnimatorListener = new ZoomAnimatorListener(this);
 			mZoomInAnimation = ValueAnimator.ofFloat(1f, 2f);
-			mZoomInAnimation.addListener(new MyZoomAnimatorListener());
-			mZoomInAnimation.addUpdateListener(new MyZoomAnimatorUpdateListener());
+			mZoomInAnimation.addListener(zoomAnimatorListener);
+			mZoomInAnimation.addUpdateListener(zoomAnimatorListener);
 			mZoomInAnimation.setDuration(ANIMATION_DURATION_SHORT);
 
 			mZoomOutAnimation = ValueAnimator.ofFloat(1f, 0.5f);
-			mZoomOutAnimation.addListener(new MyZoomAnimatorListener());
-			mZoomOutAnimation.addUpdateListener(new MyZoomAnimatorUpdateListener());
+			mZoomOutAnimation.addListener(zoomAnimatorListener);
+			mZoomOutAnimation.addUpdateListener(zoomAnimatorListener);
 			mZoomOutAnimation.setDuration(ANIMATION_DURATION_SHORT);
 		} else {
+			ZoomAnimationListener zoomAnimationListener = new ZoomAnimationListener(this);
 			mZoomInAnimationOld = new ScaleAnimation(1, 2, 1, 2, Animation.RELATIVE_TO_SELF, 0.5f,
 					Animation.RELATIVE_TO_SELF, 0.5f);
 			mZoomOutAnimationOld = new ScaleAnimation(1, 0.5f, 1, 0.5f, Animation.RELATIVE_TO_SELF,
 					0.5f, Animation.RELATIVE_TO_SELF, 0.5f);
 			mZoomInAnimationOld.setDuration(ANIMATION_DURATION_SHORT);
 			mZoomOutAnimationOld.setDuration(ANIMATION_DURATION_SHORT);
-			mZoomInAnimationOld.setAnimationListener(new MyZoomAnimationListener());
-			mZoomOutAnimationOld.setAnimationListener(new MyZoomAnimationListener());
+			mZoomInAnimationOld.setAnimationListener(zoomAnimationListener);
+			mZoomOutAnimationOld.setAnimationListener(zoomAnimationListener);
 		}
 	}
 	
@@ -239,7 +242,7 @@ public class MapController implements IMapController, OnFirstLayoutListener {
 	 */
 	@Override
 	public boolean zoomIn() {
-		return zoomInFixing(mMapView.getWidth() / 2, mMapView.getHeight() / 2);
+		return zoomTo(mMapView.getZoomLevel(false) + 1);
 	}
 
 	@Override
@@ -272,7 +275,7 @@ public class MapController implements IMapController, OnFirstLayoutListener {
 	 */
 	@Override
 	public boolean zoomOut() {
-		return zoomOutFixing(mMapView.getWidth() / 2, mMapView.getHeight() / 2);
+		return zoomTo(mMapView.getZoomLevel(false) + 1);
 	}
 
 	@Override
@@ -302,7 +305,11 @@ public class MapController implements IMapController, OnFirstLayoutListener {
 
 	@Override
 	public boolean zoomTo(int zoomLevel) {
+		return zoomToFixing(zoomLevel, mMapView.getWidth() / 2, mMapView.getHeight() / 2);
+	}
 
+	@Override
+	public boolean zoomToFixing(int zoomLevel, int xPixel, int yPixel) {
 		zoomLevel = zoomLevel > mMapView.getMaxZoomLevel() ? mMapView.getMaxZoomLevel() : zoomLevel;
 		zoomLevel = zoomLevel < mMapView.getMinZoomLevel() ? mMapView.getMinZoomLevel() : zoomLevel;
 
@@ -310,7 +317,7 @@ public class MapController implements IMapController, OnFirstLayoutListener {
 		boolean canZoom = zoomLevel < currentZoomLevel && mMapView.canZoomOut() ||
 			zoomLevel > currentZoomLevel && mMapView.canZoomIn();
 
-		mMapView.mMultiTouchScalePoint.set(mMapView.getWidth() / 2, mMapView.getHeight() / 2);
+		mMapView.mMultiTouchScalePoint.set(xPixel, yPixel);
 		if (canZoom) {
 			if (mMapView.mListener != null) {
 				mMapView.mListener.onZoom(new ZoomEvent(mMapView, zoomLevel));
@@ -320,21 +327,39 @@ public class MapController implements IMapController, OnFirstLayoutListener {
 				return false;
 			} else {
 				mMapView.mTargetZoomLevel.set(zoomLevel);
+
+				float difference = zoomLevel < currentZoomLevel ?
+					currentZoomLevel - zoomLevel :
+					zoomLevel - currentZoomLevel;
+
+				float end = zoomLevel < currentZoomLevel ?
+					1f/(float) Math.pow(difference, 2f) :
+					(float) Math.pow(difference, 2f);
+
+				end = difference == 1f ?
+					(zoomLevel < currentZoomLevel ? 0.5f : 2f) : end;
+
 				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-					float end = zoomLevel < currentZoomLevel ?
-						1f/(float) Math.pow((float)currentZoomLevel - (float)zoomLevel, 2f) :
-						(float) Math.pow((float)zoomLevel - (float)currentZoomLevel, 2f);
-
+					ZoomAnimatorListener zoomAnimatorListener = new ZoomAnimatorListener(this);
 					ValueAnimator zoomToAnimator = ValueAnimator.ofFloat(1f, end);
-					zoomToAnimator.addListener(new MyZoomAnimatorListener());
-					zoomToAnimator.addUpdateListener(new MyZoomAnimatorUpdateListener());
-					zoomToAnimator.setDuration(ANIMATION_DURATION_SHORT * 2);
-
+					zoomToAnimator.addListener(zoomAnimatorListener);
+					zoomToAnimator.addUpdateListener(zoomAnimatorListener);
+					zoomToAnimator.setDuration(ANIMATION_DURATION_SHORT);
 
 					mCurrentAnimator = zoomToAnimator;
 					zoomToAnimator.start();
 				} else {
 					mMapView.startAnimation(mZoomInAnimationOld);
+					ScaleAnimation scaleAnimation;
+
+					scaleAnimation = new ScaleAnimation(
+						1f, end, //X
+						1f, end, //Y
+						Animation.RELATIVE_TO_SELF, 0.5f, //Pivot X
+						Animation.RELATIVE_TO_SELF, 0.5f); //Pivot Y
+					scaleAnimation.setDuration(ANIMATION_DURATION_SHORT);
+					scaleAnimation.setAnimationListener(new ZoomAnimationListener(this));
+
 				}
 				return true;
 			}
@@ -342,6 +367,7 @@ public class MapController implements IMapController, OnFirstLayoutListener {
 			return false;
 		}
 	}
+
 
 	protected void onAnimationStart() {
 		mMapView.mIsAnimating.set(true);
@@ -370,44 +396,64 @@ public class MapController implements IMapController, OnFirstLayoutListener {
 		}
 	}
 
-	protected class MyZoomAnimatorListener extends AnimatorListenerAdapter {
+	@TargetApi(11)
+	private class ZoomAnimatorListener
+		implements Animator.AnimatorListener, AnimatorUpdateListener {
 
-		@Override
-		public void onAnimationStart(Animator animation) {
-			MapController.this.onAnimationStart();
-			super.onAnimationStart(animation);
+		private MapController mMapController;
+
+		public ZoomAnimatorListener(MapController mapController) {
+			mMapController = mapController;
 		}
 
 		@Override
-		public void onAnimationEnd(Animator animation) {
-			MapController.this.onAnimationEnd();
-			super.onAnimationEnd(animation);
+		public void onAnimationStart(Animator animator) {
+			mMapController.onAnimationStart();
+		}
+
+		@Override
+		public void onAnimationEnd(Animator animator) {
+			mMapController.onAnimationEnd();
+		}
+
+		@Override
+		public void onAnimationCancel(Animator animator) {
+			//noOp
+		}
+
+		@Override
+		public void onAnimationRepeat(Animator animator) {
+			//noOp
+		}
+
+		@Override
+		public void onAnimationUpdate(ValueAnimator valueAnimator) {
+			mMapController.mMapView.mMultiTouchScale = (float) valueAnimator.getAnimatedValue();
+			mMapController.mMapView.invalidate();
 		}
 	}
 
-	protected class MyZoomAnimatorUpdateListener implements AnimatorUpdateListener {
-		@Override
-		public void onAnimationUpdate(ValueAnimator animation) {
-			mMapView.mMultiTouchScale = (Float) animation.getAnimatedValue();
-			mMapView.invalidate();
-		}
-	}
+	protected class ZoomAnimationListener implements AnimationListener {
 
-	protected class MyZoomAnimationListener implements AnimationListener {
+		private MapController mMapController;
+
+		public ZoomAnimationListener(MapController mapController) {
+			mMapController = mapController;
+		}
 
 		@Override
 		public void onAnimationStart(Animation animation) {
-			MapController.this.onAnimationStart();
+			mMapController.onAnimationStart();
 		}
 
 		@Override
 		public void onAnimationEnd(Animation animation) {
-			MapController.this.onAnimationEnd();
+			mMapController.onAnimationEnd();
 		}
 
 		@Override
 		public void onAnimationRepeat(Animation animation) {
-			// Nothing to do here...
+			//noOp
 		}
 	}
 
@@ -484,7 +530,7 @@ public class MapController implements IMapController, OnFirstLayoutListener {
 	/**
 	* sets inverted tile mode. true = inverted colors, false = normal rendering
 	* This is an Osmdroid specific feature
-	* @param b
+	* @param value
 	* @since 4.4
 	* @author Alex
 	*/

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapController.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapController.java
@@ -428,7 +428,7 @@ public class MapController implements IMapController, OnFirstLayoutListener {
 
 		@Override
 		public void onAnimationUpdate(ValueAnimator valueAnimator) {
-			mMapController.mMapView.mMultiTouchScale = (float) valueAnimator.getAnimatedValue();
+			mMapController.mMapView.mMultiTouchScale = (Float) valueAnimator.getAnimatedValue();
 			mMapController.mMapView.invalidate();
 		}
 	}

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapControllerOld.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapControllerOld.java
@@ -276,6 +276,11 @@ public class MapControllerOld implements IMapController, MapViewConstants {
 		return false;
 	}
 
+	@Override
+	public boolean zoomToFixing(int zoomLevel, int xPixel, int yPixel) {
+		return false;
+	}
+
 	boolean isinverted=false;
 	@Override
 	public boolean isInvertedTiles() {

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapControllerOld.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapControllerOld.java
@@ -271,6 +271,11 @@ public class MapControllerOld implements IMapController, MapViewConstants {
 		return mOsmv.zoomOutFixing(xPixel, yPixel);
 	}
 
+	@Override
+	public boolean zoomTo(int zoomLevel) {
+		return false;
+	}
+
 	boolean isinverted=false;
 	@Override
 	public boolean isInvertedTiles() {

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
@@ -376,7 +376,7 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
 	 * center of zoom level 0.<br>
 	 * Suggestion: Check getScreenRect(null).getHeight() &gt; 0
 	 */
-	public void zoomToBoundingBox(final BoundingBoxE6 boundingBox) {
+	public void zoomToBoundingBox(final BoundingBoxE6 boundingBox, final boolean animated) {
 		final BoundingBoxE6 currentBox = getBoundingBox();
 
 		// Calculated required zoom based on latitude span
@@ -400,9 +400,15 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
 
 
 		// Zoom to boundingBox center, at calculated maximum allowed zoom level
-		getController().setZoom((int)(
+		if(animated) {
+			getController().zoomTo((int) (
 				requiredLatitudeZoom < requiredLongitudeZoom ?
-				requiredLatitudeZoom : requiredLongitudeZoom));
+					requiredLatitudeZoom : requiredLongitudeZoom));
+		} else {
+			getController().setZoom((int) (
+				requiredLatitudeZoom < requiredLongitudeZoom ?
+					requiredLatitudeZoom : requiredLongitudeZoom));
+		}
 
 		getController().setCenter(
 				new GeoPoint(boundingBox.getCenter().getLatitudeE6(), boundingBox.getCenter()

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
@@ -370,6 +370,11 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
 		return this.mZoomLevel;
 	}
 
+	@Deprecated
+	public void zoomToBoundingBox(final BoundingBoxE6 boundingBox) {
+		zoomToBoundingBox(boundingBox, false);
+	}
+
 	/**
 	 * Zoom the map to enclose the specified bounding box, as closely as possible. Must be called
 	 * after display layout is complete, or screen dimensions are not known, and will always zoom to
@@ -496,11 +501,13 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
 		return getController().zoomIn();
 	}
 
+	@Deprecated
 	boolean zoomInFixing(final IGeoPoint point) {
 		Point coords = getProjection().toPixels(point, null);
 		return getController().zoomInFixing(coords.x, coords.y);
 	}
 
+	@Deprecated
 	boolean zoomInFixing(final int xPixel, final int yPixel) {
 		return getController().zoomInFixing(xPixel, yPixel);
 	}
@@ -512,11 +519,13 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
 		return getController().zoomOut();
 	}
 
+	@Deprecated
 	boolean zoomOutFixing(final IGeoPoint point) {
 		Point coords = getProjection().toPixels(point, null);
 		return zoomOutFixing(coords.x, coords.y);
 	}
 
+	@Deprecated
 	boolean zoomOutFixing(final int xPixel, final int yPixel) {
 		return getController().zoomOutFixing(xPixel, yPixel);
 	}

--- a/osmdroid-third-party/src/main/java/org/osmdroid/google/wrapper/MapController.java
+++ b/osmdroid-third-party/src/main/java/org/osmdroid/google/wrapper/MapController.java
@@ -55,6 +55,16 @@ public class MapController implements IMapController {
 	}
 
 	@Override
+	public boolean zoomTo(int zoomLevel) {
+		return setZoom(zoomLevel) > 0;
+	}
+
+	@Override
+	public boolean zoomToFixing(int zoomLevel, int xPixel, int yPixel) {
+		return setZoom(zoomLevel) > 0;
+	}
+
+	@Override
 	public void zoomToSpan(final int pLatSpanE6, final int pLonSpanE6) {
 		mController.zoomToSpan(pLatSpanE6, pLonSpanE6);
 	}


### PR DESCRIPTION
Added an animated zoomTo() method as well as implemented it in the zoomToBoundingBox() by providing an animate flag.

The existing zoomIn() and zoomOut() methods call the new zoomToFixing() method.

Additionally, the ZoomAnimatorListener was renamed and now includes the @TargetApi() annotation which is required due to the listener only being available in a newer API.
