### PR TITLE
Fixed gradle build error for support:compatibility 

### DIFF
--- a/OpenStreetMapViewer/build.gradle
+++ b/OpenStreetMapViewer/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "23.0.2"
 
     defaultConfig {
         applicationId "org.osmdroid.example"
@@ -27,7 +27,6 @@ android {
         abortOnError false
     }
 }
-
 
 dependencies {
     compile 'com.android.support:support-v4:23+'

--- a/OpenStreetMapViewer/src/main/AndroidManifest.xml
+++ b/OpenStreetMapViewer/src/main/AndroidManifest.xml
@@ -38,8 +38,8 @@
 		<activity android:icon="@drawable/icon"
 			  android:label="Open Map" android:name="org.osmdroid.samples.SampleLoader">
 			<intent-filter>
-				<action android:name="android.intent.action.MAIN"></action>
-				<category android:name="android.intent.category.LAUNCHER"></category>
+				<action android:name="android.intent.action.MAIN"/>
+				<category android:name="android.intent.category.LAUNCHER"/>
 			</intent-filter>
 		</activity>
 		<activity android:name="org.osmdroid.samples.SampleWithMinimapItemizedoverlay">
@@ -74,8 +74,8 @@
 		</activity>
 		<activity android:name="org.osmdroid.samples.SampleWithTilesOverlayAndCustomTileSource">
 			<intent-filter>
-				<action android:name="android.intent.action.VIEW"></action>
-				<category android:name="android.intent.category.DEFAULT"></category>
+				<action android:name="android.intent.action.VIEW"/>
+				<category android:name="android.intent.category.DEFAULT"/>
 			</intent-filter>
 		</activity>
 

--- a/OpenStreetMapViewer/src/main/AndroidManifest.xml
+++ b/OpenStreetMapViewer/src/main/AndroidManifest.xml
@@ -1,84 +1,106 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-		package="org.osmdroid"
-		android:versionCode="18" android:versionName="5.1-SNAPSHOT">
+    package="org.osmdroid"
+    android:versionCode="18"
+    android:versionName="5.1-SNAPSHOT">
 
-	<uses-sdk android:minSdkVersion="8" android:targetSdkVersion="23" />
-	<supports-screens android:largeScreens="true" android:normalScreens="true" android:anyDensity="true" />
+    <uses-sdk
+        android:minSdkVersion="8"
+        android:targetSdkVersion="23" />
+    <supports-screens
+        android:anyDensity="true"
+        android:largeScreens="true"
+        android:normalScreens="true" />
 
-	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
-	<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
-	<uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-	<uses-permission android:name="android.permission.INTERNET" />
-	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
-	<uses-feature android:name="android.hardware.location.network" android:required="false" />
-	<uses-feature android:name="android.hardware.location.gps" android:required="false" />
-	<uses-feature android:name="android.hardware.telephony" android:required="false" />
-	<uses-feature android:name="android.hardware.wifi" android:required="false" />
+    <uses-feature
+        android:name="android.hardware.location.network"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.location.gps"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.telephony"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.wifi"
+        android:required="false" />
 
-	<application
-		android:icon="@drawable/icon"
-		android:label="@string/app_name"
-		android:hardwareAccelerated="true">
+    <application
+        android:hardwareAccelerated="true"
+        android:icon="@drawable/icon"
+        android:label="@string/app_name">
 
-		<!-- all applications based on this code should get their own Bing key -->
-		<meta-data android:name="BING_KEY" android:value="ApEqyap8rTa4WTNCNv-3pAGQc7XUsHS6595tuDI3MHR59QlahJ5bqYGYhMYJq6Ae" />
+        <!-- all applications based on this code should get their own Bing key -->
+        <meta-data
+            android:name="BING_KEY"
+            android:value="ApEqyap8rTa4WTNCNv-3pAGQc7XUsHS6595tuDI3MHR59QlahJ5bqYGYhMYJq6Ae" />
 
-		<uses-library android:name="com.google.android.maps" android:required="false" />
+        <uses-library
+            android:name="com.google.android.maps"
+            android:required="false" />
 
-		<activity android:icon="@drawable/icon"
-			android:label="Open Map" android:name="org.osmdroid.MapActivity">
-			<intent-filter>
-				<action android:name="android.intent.action.VIEW" />
-				<category android:name="android.intent.category.DEFAULT" />
-			</intent-filter>
-		</activity>
-		<activity android:icon="@drawable/icon"
-			  android:label="Open Map" android:name="org.osmdroid.samples.SampleLoader">
-			<intent-filter>
-				<action android:name="android.intent.action.MAIN"/>
-				<category android:name="android.intent.category.LAUNCHER"/>
-			</intent-filter>
-		</activity>
-		<activity android:name="org.osmdroid.samples.SampleWithMinimapItemizedoverlay">
-			<intent-filter>
-				<action android:name="android.intent.action.VIEW" />
-				<category android:name="android.intent.category.DEFAULT" />
-			</intent-filter>
-		</activity>
-		<activity android:name="org.osmdroid.samples.SampleExtensive">
-			<intent-filter>
-				<action android:name="android.intent.action.VIEW" />
-				<category android:name="android.intent.category.DEFAULT" />
-			</intent-filter>
-		</activity>
-		<activity android:name="org.osmdroid.samples.SampleResourceOverride">
-			<intent-filter>
-				<action android:name="android.intent.action.VIEW" />
-				<category android:name="android.intent.category.DEFAULT" />
-			</intent-filter>
-		</activity>
-		<activity android:name="org.osmdroid.samples.SampleWithMinimapZoomcontrols">
-			<intent-filter>
-				<action android:name="android.intent.action.VIEW" />
-				<category android:name="android.intent.category.DEFAULT" />
-			</intent-filter>
-		</activity>
-		<activity android:name="org.osmdroid.samples.SampleWithTilesOverlay">
-			<intent-filter>
-				<action android:name="android.intent.action.VIEW" />
-				<category android:name="android.intent.category.DEFAULT" />
-			</intent-filter>
-		</activity>
-		<activity android:name="org.osmdroid.samples.SampleWithTilesOverlayAndCustomTileSource">
-			<intent-filter>
-				<action android:name="android.intent.action.VIEW"/>
-				<category android:name="android.intent.category.DEFAULT"/>
-			</intent-filter>
-		</activity>
+        <activity
+            android:name="org.osmdroid.MapActivity"
+            android:icon="@drawable/icon"
+            android:label="Open Map">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+        <activity
+            android:name="org.osmdroid.samples.SampleLoader"
+            android:icon="@drawable/icon"
+            android:label="Open Map">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <activity android:name="org.osmdroid.samples.SampleWithMinimapItemizedoverlay">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+        <activity android:name="org.osmdroid.samples.SampleExtensive">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+        <activity android:name="org.osmdroid.samples.SampleResourceOverride">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+        <activity android:name="org.osmdroid.samples.SampleWithMinimapZoomcontrols">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+        <activity android:name="org.osmdroid.samples.SampleWithTilesOverlay">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+        <activity android:name="org.osmdroid.samples.SampleWithTilesOverlayAndCustomTileSource">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
 
-	</application>
+    </application>
 
 </manifest>

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,11 @@
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
     repositories {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
+        classpath 'com.android.tools.build:gradle:1.5.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/osmdroid-android/build.gradle
+++ b/osmdroid-android/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "23.0.2"
     defaultConfig {
         minSdkVersion 8
         targetSdkVersion 23
@@ -21,10 +21,7 @@ android {
     }
 }
 
-
-
 dependencies {
-
     testCompile group: 'junit', name: 'junit', version: '4.8.2'
     //compile(group: 'org.apache.httpcomponents', name: 'httpmime', version: '4.0.1') {}
     //compile(group: 'org.apache.james', name: 'apache-mime4j', version: '0.6') {}

--- a/osmdroid-third-party/build.gradle
+++ b/osmdroid-third-party/build.gradle
@@ -2,9 +2,8 @@ description = 'OSMdroid Android 3rd Party'
 apply plugin: 'com.android.library'
 
 android {
-
     compileSdkVersion "Google Inc.:Google APIs:23"
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "23.0.2"
     defaultConfig {
         minSdkVersion 9
         targetSdkVersion 23
@@ -22,10 +21,7 @@ android {
     }
 }
 
-
-
 dependencies {
-
     testCompile group: 'junit', name: 'junit', version: '4.8.2'
     compile project(':osmdroid-android')
     //compile(group: 'org.apache.james', name: 'apache-mime4j', version: '0.6') {}

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,7 +3,6 @@ include ':osmdroid-android'
 include ':osmdroid-third-party'
 include ':OpenStreetMapViewer'
 //include ':GoogleWrapperSample'
-include ':osmdroid-packager'
 //include ':osmdroid-android-it'
 
 project(':osmdroid-android').projectDir = "$rootDir/osmdroid-android" as File


### PR DESCRIPTION
Current project features a build error as it is unable to resolve **support:compatibility** in the **OpenStreetMapViewer\build.gradle**. This error is referenced in issue #194.

> Error:(32, 13) Failed to resolve: android.support:compatibility-v4:23+

This is resolved by replacing the dependency:
> compile 'android.support:compatibility-v4:23+'

with

> compile 'com.android.support:support-v4:23+'