### PR TITLE
Tile Caching to Include an Expires header instead of Last Modified Date

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTile.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTile.java
@@ -1,5 +1,6 @@
 package org.osmdroid.tileprovider;
 
+import org.osmdroid.tileprovider.constants.OpenStreetMapTileProviderConstants;
 import org.osmdroid.tileprovider.modules.MapTileModuleProviderBase;
 import org.osmdroid.tileprovider.util.StreamUtils;
 import org.osmdroid.views.overlay.TilesOverlay;
@@ -9,6 +10,7 @@ import java.io.InputStream;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 
 /**
  * A map tile is distributed using the observer pattern. The tile is delivered by a tile provider
@@ -80,11 +82,13 @@ public class MapTile {
 		this.expires = expires;
 	}
 
+
 	public boolean readHeaders(InputStream inputStream) throws IOException {
 		return readHeaders(this, inputStream);
 	}
 
 	private static boolean readHeaders(MapTile mapTile, InputStream inputStream) throws IOException {
+		//It is important to read headers in the same order in which they were written
 		return readExpiresHeader(mapTile, inputStream);
 	}
 
@@ -93,7 +97,9 @@ public class MapTile {
 
 		try {
 			final String expires = StreamUtils.readString(inputStream);
-			final SimpleDateFormat dateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z");
+			final SimpleDateFormat dateFormat =
+				new SimpleDateFormat(OpenStreetMapTileProviderConstants.HTTP_EXPIRES_HEADER_FORMAT,
+					Locale.US);
 			final Date dateExpires = dateFormat.parse(expires);
 
 			if (mapTile != null) {

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTile.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTile.java
@@ -125,6 +125,6 @@ public class MapTile {
 	}
 
 	public static void skipOverHeaders(InputStream inputStream) throws IOException {
-		readExpiresHeader(null, inputStream);
+		readHeaders(null, inputStream);
 	}
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTile.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTile.java
@@ -3,6 +3,8 @@ package org.osmdroid.tileprovider;
 import org.osmdroid.tileprovider.modules.MapTileModuleProviderBase;
 import org.osmdroid.views.overlay.TilesOverlay;
 
+import java.util.Date;
+
 /**
  * A map tile is distributed using the observer pattern. The tile is delivered by a tile provider
  * (i.e. a descendant of {@link MapTileModuleProviderBase} or
@@ -19,6 +21,7 @@ public class MapTile {
 	private final int x;
 	private final int y;
 	private final int zoomLevel;
+	private Date expires;
 
 	public MapTile(final int zoomLevel, final int tileX, final int tileY) {
 		this.zoomLevel = zoomLevel;
@@ -62,5 +65,13 @@ public class MapTile {
 		code *= 37 + x;
 		code *= 37 + y;
 		return code;
+	}
+
+	public Date getExpires() {
+		return expires;
+	}
+
+	public void setExpires(Date expires) {
+		this.expires = expires;
 	}
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTile.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTile.java
@@ -7,6 +7,7 @@ import org.osmdroid.views.overlay.TilesOverlay;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -80,6 +81,18 @@ public class MapTile {
 
 	public void setExpires(Date expires) {
 		this.expires = expires;
+	}
+
+	public void writeHeaders(OutputStream outputStream) throws IOException {
+		writeExpiresHeader(outputStream);
+	}
+
+	private void writeExpiresHeader(OutputStream outputStream) throws IOException {
+		SimpleDateFormat dateFormat =
+			new SimpleDateFormat(OpenStreetMapTileProviderConstants.HTTP_EXPIRES_HEADER_FORMAT,
+				Locale.US);
+
+		StreamUtils.writeString(outputStream, dateFormat.format(expires));
 	}
 
 

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTile.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTile.java
@@ -1,8 +1,13 @@
 package org.osmdroid.tileprovider;
 
 import org.osmdroid.tileprovider.modules.MapTileModuleProviderBase;
+import org.osmdroid.tileprovider.util.StreamUtils;
 import org.osmdroid.views.overlay.TilesOverlay;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 
 /**
@@ -73,5 +78,34 @@ public class MapTile {
 
 	public void setExpires(Date expires) {
 		this.expires = expires;
+	}
+
+	public boolean readHeaders(InputStream inputStream) throws IOException {
+		return readHeaders(this, inputStream);
+	}
+
+	private static boolean readHeaders(MapTile mapTile, InputStream inputStream) throws IOException {
+		return readExpiresHeader(mapTile, inputStream);
+	}
+
+	private static boolean readExpiresHeader(MapTile mapTile, InputStream inputStream)
+		throws IOException {
+
+		try {
+			final String expires = StreamUtils.readString(inputStream);
+			final SimpleDateFormat dateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z");
+			final Date dateExpires = dateFormat.parse(expires);
+
+			if (mapTile != null) {
+				mapTile.setExpires(dateExpires);
+			}
+			return true;
+		} catch (ParseException e) {
+			return false;
+		}
+	}
+
+	public static void skipOverHeaders(InputStream inputStream) throws IOException {
+		readExpiresHeader(null, inputStream);
 	}
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/constants/OpenStreetMapTileProviderConstants.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/constants/OpenStreetMapTileProviderConstants.java
@@ -67,6 +67,13 @@ public class OpenStreetMapTileProviderConstants {
 	public static final String TILE_PATH_EXTENSION = ".tile";
 
 	/**
+	 * Tile properties file extension
+	 */
+	public static final String TILE_PROPERTIES_EXTENSION = ".properties";
+
+	public static final String PROPERTY_EXPIRES = "expires";
+
+	/**
 	 * Initial tile cache size. The size will be increased as required by calling
 	 * {@link LRUMapTileCache#ensureCapacity(int)} The tile cache will always be at least 3x3.
 	 */

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/constants/OpenStreetMapTileProviderConstants.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/constants/OpenStreetMapTileProviderConstants.java
@@ -157,4 +157,7 @@ public class OpenStreetMapTileProviderConstants {
      public static void setOfflineMapsPath(String path){
           OSMDROID_PATH = new File(path);
      }
+
+	public static final String HTTP_EXPIRES_HEADER = "Expires";
+	public static final String HTTP_EXPIRES_HEADER_FORMAT = "EEE, dd MMM yyyy HH:mm:ss z";
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileAssetsProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileAssetsProvider.java
@@ -141,9 +141,6 @@ public class MapTileAssetsProvider extends MapTileFileStorageProviderBase {
 			try {
 				is = mAssets.open(tileSource.getTileRelativeFilenameString(tile));
 
-				tile.readHeaders(is);
-				is.reset();
-
 				final Drawable drawable = tileSource.getDrawable(is);
 				if (drawable != null) {
 					ExpirableBitmapDrawable.setDrawableExpired(drawable);

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileAssetsProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileAssetsProvider.java
@@ -137,7 +137,7 @@ public class MapTileAssetsProvider extends MapTileFileStorageProviderBase {
 
 			try {
 				InputStream is = mAssets.open(tileSource.getTileRelativeFilenameString(tile));
-				final Drawable drawable = tileSource.getDrawable(is);
+				final Drawable drawable = tileSource.getDrawable(tile, is);
 				if (drawable != null) {
 					ExpirableBitmapDrawable.setDrawableExpired(drawable);
 				}

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileDownloader.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileDownloader.java
@@ -218,7 +218,11 @@ public class MapTileDownloader extends MapTileModuleProviderBase {
 					mFilesystemCache.saveFile(tileSource, tile, byteStream);
 					byteStream.reset();
 				}
-				final Drawable result = tileSource.getDrawable(tile, byteStream);
+
+				tile.readHeaders(byteStream);
+				byteStream.reset();
+
+				final Drawable result = tileSource.getDrawable(byteStream);
 
 				return result;
 			} catch (final UnknownHostException e) {

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileDownloader.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileDownloader.java
@@ -216,8 +216,6 @@ public class MapTileDownloader extends MapTileModuleProviderBase {
 				}
 				tile.setExpires(dateExpires);
 
-				tile.writeHeaders(out);
-
 				StreamUtils.copy(in, out);
 				out.flush();
 				final byte[] data = dataStream.toByteArray();
@@ -228,9 +226,6 @@ public class MapTileDownloader extends MapTileModuleProviderBase {
 					mFilesystemCache.saveFile(tileSource, tile, byteStream);
 					byteStream.reset();
 				}
-
-				tile.readHeaders(byteStream);
-				byteStream.reset();
 
 				final Drawable result = tileSource.getDrawable(byteStream);
 

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileDownloader.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileDownloader.java
@@ -10,6 +10,7 @@ import java.io.OutputStream;
 import java.net.UnknownHostException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -199,17 +200,23 @@ public class MapTileDownloader extends MapTileModuleProviderBase {
 				final ByteArrayOutputStream dataStream = new ByteArrayOutputStream();
 				out = new BufferedOutputStream(dataStream, StreamUtils.IO_BUFFER_SIZE);
 
-				String expires = c.getHeaderField(OpenStreetMapTileProviderConstants.HTTP_EXPIRES_HEADER);
+				Date dateExpires;
+				final String expires = c.getHeaderField(OpenStreetMapTileProviderConstants.HTTP_EXPIRES_HEADER);
 				if(expires == null) {
-					SimpleDateFormat dateFormat =
-						new SimpleDateFormat(OpenStreetMapTileProviderConstants.HTTP_EXPIRES_HEADER_FORMAT,
-							Locale.US);
 					Calendar calendar = Calendar.getInstance();
 					calendar.add(Calendar.MILLISECOND,
 						(int) OpenStreetMapTileProviderConstants.DEFAULT_MAXIMUM_CACHED_FILE_AGE);
-					expires = dateFormat.format(calendar.getTime());
+					dateExpires = calendar.getTime();
+				} else {
+					SimpleDateFormat dateFormat =
+						new SimpleDateFormat(OpenStreetMapTileProviderConstants.HTTP_EXPIRES_HEADER_FORMAT,
+							Locale.US);
+
+					dateExpires = dateFormat.parse(expires);
 				}
-				StreamUtils.writeString(out, expires);
+				tile.setExpires(dateExpires);
+
+				tile.writeHeaders(out);
 
 				StreamUtils.copy(in, out);
 				out.flush();

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileDownloader.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileDownloader.java
@@ -10,6 +10,7 @@ import java.io.OutputStream;
 import java.net.UnknownHostException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.osmdroid.tileprovider.BitmapPool;
@@ -198,9 +199,11 @@ public class MapTileDownloader extends MapTileModuleProviderBase {
 				final ByteArrayOutputStream dataStream = new ByteArrayOutputStream();
 				out = new BufferedOutputStream(dataStream, StreamUtils.IO_BUFFER_SIZE);
 
-				String expires = c.getHeaderField("Expires");
-				if(expires == null) { //Expire yesterday
-					SimpleDateFormat dateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z");
+				String expires = c.getHeaderField(OpenStreetMapTileProviderConstants.HTTP_EXPIRES_HEADER);
+				if(expires == null) {
+					SimpleDateFormat dateFormat =
+						new SimpleDateFormat(OpenStreetMapTileProviderConstants.HTTP_EXPIRES_HEADER_FORMAT,
+							Locale.US);
 					Calendar calendar = Calendar.getInstance();
 					calendar.add(Calendar.MILLISECOND,
 						(int) OpenStreetMapTileProviderConstants.DEFAULT_MAXIMUM_CACHED_FILE_AGE);

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileDownloader.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileDownloader.java
@@ -8,6 +8,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.UnknownHostException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.osmdroid.tileprovider.BitmapPool;
@@ -191,11 +193,21 @@ public class MapTileDownloader extends MapTileModuleProviderBase {
 					return null;
 				}
 
-				
 				in = c.getInputStream();
 
 				final ByteArrayOutputStream dataStream = new ByteArrayOutputStream();
 				out = new BufferedOutputStream(dataStream, StreamUtils.IO_BUFFER_SIZE);
+
+				String expires = c.getHeaderField("Expires");
+				if(expires == null) { //Expire yesterday
+					SimpleDateFormat dateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z");
+					Calendar calendar = Calendar.getInstance();
+					calendar.add(Calendar.MILLISECOND,
+						(int) OpenStreetMapTileProviderConstants.DEFAULT_MAXIMUM_CACHED_FILE_AGE);
+					expires = dateFormat.format(calendar.getTime());
+				}
+				StreamUtils.writeString(out, expires);
+
 				StreamUtils.copy(in, out);
 				out.flush();
 				final byte[] data = dataStream.toByteArray();
@@ -206,7 +218,7 @@ public class MapTileDownloader extends MapTileModuleProviderBase {
 					mFilesystemCache.saveFile(tileSource, tile, byteStream);
 					byteStream.reset();
 				}
-				final Drawable result = tileSource.getDrawable(byteStream);
+				final Drawable result = tileSource.getDrawable(tile, byteStream);
 
 				return result;
 			} catch (final UnknownHostException e) {

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileFileArchiveProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileFileArchiveProvider.java
@@ -224,15 +224,17 @@ public class MapTileFileArchiveProvider extends MapTileFileStorageProviderBase {
 					if (OpenStreetMapTileProviderConstants.DEBUGMODE) {
 						Log.d(IMapView.LOGTAG,"Use tile from archive: " + pTile);
 					}
-					final Drawable drawable = tileSource.getDrawable(pTile, inputStream);
+
+					pTile.readHeaders(inputStream);
+					inputStream.reset();
+
+					final Drawable drawable = tileSource.getDrawable(inputStream);
 					return drawable;
 				}
 			} catch (final Throwable e) {
 				Log.e(IMapView.LOGTAG,"Error loading tile", e);
 			} finally {
-				if (inputStream != null) {
-					StreamUtils.closeStream(inputStream);
-				}
+				StreamUtils.closeStream(inputStream);
 			}
 
 			return null;

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileFileArchiveProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileFileArchiveProvider.java
@@ -224,7 +224,7 @@ public class MapTileFileArchiveProvider extends MapTileFileStorageProviderBase {
 					if (OpenStreetMapTileProviderConstants.DEBUGMODE) {
 						Log.d(IMapView.LOGTAG,"Use tile from archive: " + pTile);
 					}
-					final Drawable drawable = tileSource.getDrawable(inputStream);
+					final Drawable drawable = tileSource.getDrawable(pTile, inputStream);
 					return drawable;
 				}
 			} catch (final Throwable e) {

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileFileArchiveProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileFileArchiveProvider.java
@@ -225,9 +225,6 @@ public class MapTileFileArchiveProvider extends MapTileFileStorageProviderBase {
 						Log.d(IMapView.LOGTAG,"Use tile from archive: " + pTile);
 					}
 
-					pTile.readHeaders(inputStream);
-					inputStream.reset();
-
 					final Drawable drawable = tileSource.getDrawable(inputStream);
 					return drawable;
 				}

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileFilesystemProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileFilesystemProvider.java
@@ -155,7 +155,7 @@ public class MapTileFilesystemProvider extends MapTileFileStorageProviderBase {
 					// Check to see if file has expired
 					Date tileExpires = tile.getExpires();
 					if (tileExpires != null) {
-						tileExpires.setTime(file.lastModified());
+						tileExpires.setTime(file.lastModified() + mMaximumCachedFileAge);
 					}
 
 					final boolean fileExpired = tileExpires.before(new Date());

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileFilesystemProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileFilesystemProvider.java
@@ -153,7 +153,12 @@ public class MapTileFilesystemProvider extends MapTileFileStorageProviderBase {
 					final Drawable drawable = tileSource.getDrawable(tile, file.getPath());
 
 					// Check to see if file has expired
-					final boolean fileExpired = tile.getExpires().before(new Date());
+					Date tileExpires = tile.getExpires();
+					if (tileExpires != null) {
+						tileExpires.setTime(file.lastModified());
+					}
+
+					final boolean fileExpired = tileExpires.before(new Date());
 
 					if (fileExpired && drawable != null) {
 						if (OpenStreetMapTileProviderConstants.DEBUGMODE) {

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileFilesystemProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileFilesystemProvider.java
@@ -1,6 +1,7 @@
 package org.osmdroid.tileprovider.modules;
 
 import java.io.File;
+import java.util.Date;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.osmdroid.tileprovider.ExpirableBitmapDrawable;
@@ -149,12 +150,10 @@ public class MapTileFilesystemProvider extends MapTileFileStorageProviderBase {
 			if (file.exists()) {
 
 				try {
-					final Drawable drawable = tileSource.getDrawable(file.getPath());
+					final Drawable drawable = tileSource.getDrawable(tile, file.getPath());
 
 					// Check to see if file has expired
-					final long now = System.currentTimeMillis();
-					final long lastModified = file.lastModified();
-					final boolean fileExpired = lastModified < now - mMaximumCachedFileAge;
+					final boolean fileExpired = tile.getExpires().before(new Date());
 
 					if (fileExpired && drawable != null) {
 						if (OpenStreetMapTileProviderConstants.DEBUGMODE) {

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/TileWriter.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/TileWriter.java
@@ -96,6 +96,7 @@ public class TileWriter implements IFilesystemCache {
 		}
 
 		BufferedOutputStream outputStream = null;
+		BufferedOutputStream propertiesOutputStream = null;
 		try {
 			outputStream = new BufferedOutputStream(new FileOutputStream(file.getPath()),
 					StreamUtils.IO_BUFFER_SIZE);
@@ -106,12 +107,20 @@ public class TileWriter implements IFilesystemCache {
 			if (mUsedCacheSpace > OpenStreetMapTileProviderConstants.TILE_MAX_CACHE_SIZE_BYTES) {
 				cutCurrentCache(); // TODO perhaps we should do this in the background
 			}
+
+			final File propertiesFile = new File(OpenStreetMapTileProviderConstants.TILE_PATH_BASE,
+				pTileSource.getTileRelativeFilenameString(pTile)
+					+ OpenStreetMapTileProviderConstants.TILE_PROPERTIES_EXTENSION);
+
+			propertiesOutputStream = new BufferedOutputStream(new FileOutputStream(propertiesFile),
+				StreamUtils.IO_BUFFER_SIZE);
+			pTile.writeProperties(propertiesOutputStream);
+
 		} catch (final IOException e) {
 			return false;
 		} finally {
-			if (outputStream != null) {
-				StreamUtils.closeStream(outputStream);
-			}
+			StreamUtils.closeStream(outputStream);
+			StreamUtils.closeStream(propertiesOutputStream);
 		}
 		return true;
 	}

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/TileWriter.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/TileWriter.java
@@ -99,6 +99,7 @@ public class TileWriter implements IFilesystemCache {
 		try {
 			outputStream = new BufferedOutputStream(new FileOutputStream(file.getPath()),
 					StreamUtils.IO_BUFFER_SIZE);
+
 			final long length = StreamUtils.copy(pStream, outputStream);
 
 			mUsedCacheSpace += length;

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/BitmapTileSourceBase.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/BitmapTileSourceBase.java
@@ -175,18 +175,15 @@ public abstract class BitmapTileSourceBase implements ITileSource {
 		return null;
 	}
 
-	private void readExpiresHeader(MapTile aTile, InputStream inputStream) throws IOException {
+	private boolean readExpiresHeader(MapTile aTile, InputStream inputStream) throws IOException {
 		try {
 			String expires = StreamUtils.readString(inputStream);
 			SimpleDateFormat dateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z");
 			Date dateExpires = dateFormat.parse(expires);
 			aTile.setExpires(dateExpires);
+			return true;
 		} catch (ParseException e) {
-			Calendar calendar = Calendar.getInstance();
-			calendar.add(Calendar.MILLISECOND,
-				(int) OpenStreetMapTileProviderConstants.DEFAULT_MAXIMUM_CACHED_FILE_AGE);
-			aTile.setExpires(calendar.getTime());
-			Log.e(IMapView.LOGTAG,"ParseException loading bitmap Expires date header");
+			return false;
 		}
 	}
 

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/BitmapTileSourceBase.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/BitmapTileSourceBase.java
@@ -100,8 +100,6 @@ public abstract class BitmapTileSourceBase implements ITileSource {
 			inputStream = new BufferedInputStream(new FileInputStream(aFilePath),
 				StreamUtils.IO_BUFFER_SIZE);
 
-			MapTile.skipOverHeaders(inputStream);
-
 			final Bitmap bitmap = BitmapFactory.decodeStream(inputStream, null, bitmapOptions); //BitmapFactory.decodeFile(aFilePath, bitmapOptions);
 			if (bitmap != null) {
 				StreamUtils.closeStream(inputStream);
@@ -119,8 +117,6 @@ public abstract class BitmapTileSourceBase implements ITileSource {
 			System.gc();
 		} catch (final FileNotFoundException e) {
 			Log.e(IMapView.LOGTAG,"FileNotFoundException loading bitmap: " + aFilePath);
-		} catch (final IOException e) {
-			Log.e(IMapView.LOGTAG,"IOException loading bitmap: " + aFilePath);
 		} finally {
 			StreamUtils.closeStream(inputStream);
 		}
@@ -145,8 +141,6 @@ public abstract class BitmapTileSourceBase implements ITileSource {
 	public Drawable getDrawable(final InputStream aFileInputStream) throws LowMemoryException {
 
 		try {
-			MapTile.skipOverHeaders(aFileInputStream);
-
 			// default implementation will load the file as a bitmap and create
 			// a BitmapDrawable from it
 			BitmapFactory.Options bitmapOptions = new BitmapFactory.Options();
@@ -160,8 +154,6 @@ public abstract class BitmapTileSourceBase implements ITileSource {
 			Log.e(IMapView.LOGTAG,"OutOfMemoryError loading bitmap");
 			System.gc();
 			throw new LowMemoryException(e);
-		} catch (final IOException e) {
-			Log.e(IMapView.LOGTAG,"IOException loading bitmap");
 		}
 
 		return null;

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/ITileSource.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/ITileSource.java
@@ -39,11 +39,13 @@ public interface ITileSource {
 	/**
 	 * Get a rendered Drawable from the specified file path.
 	 *
+	 * @param aTile
+	 * 						a tile
 	 * @param aFilePath
 	 *            a file path
 	 * @return the rendered Drawable
 	 */
-	Drawable getDrawable(String aFilePath) throws LowMemoryException;
+	Drawable getDrawable(MapTile aTile, String aFilePath) throws LowMemoryException;
 
 	/**
 	 * Get a rendered Drawable from the specified InputStream.
@@ -52,7 +54,7 @@ public interface ITileSource {
 	 *            an InputStream
 	 * @return the rendered Drawable
 	 */
-	Drawable getDrawable(InputStream aTileInputStream) throws LowMemoryException;
+	Drawable getDrawable(MapTile aTile, InputStream aTileInputStream) throws LowMemoryException;
 
 	/**
 	 * Get the minimum zoom level this tile source can provide.

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/ITileSource.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/ITileSource.java
@@ -39,13 +39,11 @@ public interface ITileSource {
 	/**
 	 * Get a rendered Drawable from the specified file path.
 	 *
-	 * @param aTile
-	 * 						a tile
 	 * @param aFilePath
 	 *            a file path
 	 * @return the rendered Drawable
 	 */
-	Drawable getDrawable(MapTile aTile, String aFilePath) throws LowMemoryException;
+	Drawable getDrawable(String aFilePath) throws LowMemoryException;
 
 	/**
 	 * Get a rendered Drawable from the specified InputStream.
@@ -54,7 +52,7 @@ public interface ITileSource {
 	 *            an InputStream
 	 * @return the rendered Drawable
 	 */
-	Drawable getDrawable(MapTile aTile, InputStream aTileInputStream) throws LowMemoryException;
+	Drawable getDrawable(InputStream aTileInputStream) throws LowMemoryException;
 
 	/**
 	 * Get the minimum zoom level this tile source can provide.

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/StreamUtils.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/StreamUtils.java
@@ -3,9 +3,14 @@ package org.osmdroid.tileprovider.util;
 
 import android.util.Log;
 import java.io.Closeable;
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.osmdroid.api.IMapView;
 
 public class StreamUtils {
@@ -80,6 +85,111 @@ public class StreamUtils {
 				Log.e(IMapView.LOGTAG,"Could not close stream", e);
 			}
 		}
+	}
+
+	/**
+	 * Simple wrapper around {@link InputStream#read()} that throws EOFException
+	 * instead of returning -1.
+	 */
+	private static int read(InputStream is) throws IOException {
+		int b = is.read();
+		if (b == -1) {
+			throw new EOFException();
+		}
+		return b;
+	}
+
+	public static void writeInt(OutputStream os, int n) throws IOException {
+		os.write((n >> 0) & 0xff);
+		os.write((n >> 8) & 0xff);
+		os.write((n >> 16) & 0xff);
+		os.write((n >> 24) & 0xff);
+	}
+
+	public static int readInt(InputStream is) throws IOException {
+		int n = 0;
+		n |= (read(is) << 0);
+		n |= (read(is) << 8);
+		n |= (read(is) << 16);
+		n |= (read(is) << 24);
+		return n;
+	}
+
+	public static void writeLong(OutputStream os, long n) throws IOException {
+		os.write((byte)(n >>> 0));
+		os.write((byte)(n >>> 8));
+		os.write((byte)(n >>> 16));
+		os.write((byte)(n >>> 24));
+		os.write((byte)(n >>> 32));
+		os.write((byte)(n >>> 40));
+		os.write((byte)(n >>> 48));
+		os.write((byte)(n >>> 56));
+	}
+
+	public static long readLong(InputStream is) throws IOException {
+		long n = 0;
+		n |= ((read(is) & 0xFFL) << 0);
+		n |= ((read(is) & 0xFFL) << 8);
+		n |= ((read(is) & 0xFFL) << 16);
+		n |= ((read(is) & 0xFFL) << 24);
+		n |= ((read(is) & 0xFFL) << 32);
+		n |= ((read(is) & 0xFFL) << 40);
+		n |= ((read(is) & 0xFFL) << 48);
+		n |= ((read(is) & 0xFFL) << 56);
+		return n;
+	}
+
+	public static void writeString(OutputStream os, String s) throws IOException {
+		byte[] b = s.getBytes("UTF-8");
+		writeLong(os, b.length);
+		os.write(b, 0, b.length);
+	}
+
+	public static String readString(InputStream is) throws IOException {
+		int n = (int) readLong(is);
+		byte[] b = streamToBytes(is, n);
+		return new String(b, "UTF-8");
+	}
+
+	public static void writeStringStringMap(Map<String, String> map, OutputStream os) throws IOException {
+		if (map != null) {
+			writeInt(os, map.size());
+			for (Map.Entry<String, String> entry : map.entrySet()) {
+				writeString(os, entry.getKey());
+				writeString(os, entry.getValue());
+			}
+		} else {
+			writeInt(os, 0);
+		}
+	}
+
+	public static Map<String, String> readStringStringMap(InputStream is) throws IOException {
+		int size = readInt(is);
+		Map<String, String> result = (size == 0)
+			? Collections.<String, String>emptyMap()
+			: new HashMap<String, String>(size);
+		for (int i = 0; i < size; i++) {
+			String key = readString(is).intern();
+			String value = readString(is).intern();
+			result.put(key, value);
+		}
+		return result;
+	}
+
+	/**
+	 * Reads the contents of an InputStream into a byte[].
+	 * */
+	private static byte[] streamToBytes(InputStream in, int length) throws IOException {
+		byte[] bytes = new byte[length];
+		int count;
+		int pos = 0;
+		while (pos < length && ((count = in.read(bytes, pos, length - pos)) != -1)) {
+			pos += count;
+		}
+		if (pos != length) {
+			throw new IOException("Expected " + length + " bytes, read " + pos + " bytes");
+		}
+		return bytes;
 	}
 
 	// ===========================================================

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/StreamUtils.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/StreamUtils.java
@@ -179,7 +179,7 @@ public class StreamUtils {
 	/**
 	 * Reads the contents of an InputStream into a byte[].
 	 * */
-	private static byte[] streamToBytes(InputStream in, int length) throws IOException {
+	public static byte[] streamToBytes(InputStream in, int length) throws IOException {
 		byte[] bytes = new byte[length];
 		int count;
 		int pos = 0;


### PR DESCRIPTION
I've modified the caching process include an `Expires` header at the top of each cached tile. This replaces, for the most part, the `file.lastModifiedDate()` check. 

The idea is that if an `Expires` header is received by the `MapTileDownloader`, the date is added as a header to the tile file. If there was no `Expires` header, then the `OpenStreetMapTileProviderConstants.DEFAULT_MAXIMUM_CACHED_FILE_AGE` is used instead.

If there are existing files with no Expires headers, then the original `file.lastModifiedDate()` condition is used to determine whether the file has expired or not.

I'm not sure if this would be something that could be included in the project as I think simply setting your own maximum cached file age is enough generally. However it may be useful if you'd like server to determine how long files should be cached.

P.S. I added code to the `StreamUtils` class which comes directly from the `DiskBasedCache` class from the Android Volley framework. I'm not 100% sure where to include a reference to the framework project?