### PR TITLE
OSMapViewer Code Cleanup - Permissions and other fixes.

### DIFF
--- a/OpenStreetMapViewer/build.gradle
+++ b/OpenStreetMapViewer/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "org.osmdroid.example"
         minSdkVersion 8
         targetSdkVersion 23
-        versionCode 16
-        versionName "5.0-SNAPSHOT"
+        versionCode 18
+        versionName "5.1-SNAPSHOT"
     }
     buildTypes {
         release {

--- a/OpenStreetMapViewer/src/main/AndroidManifest.xml
+++ b/OpenStreetMapViewer/src/main/AndroidManifest.xml
@@ -12,11 +12,14 @@
         android:largeScreens="true"
         android:normalScreens="true" />
 
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <!-- PROTECTION_NORMAL permissions, automatically granted -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
+
+    <!-- DANGEROUS PERMISSIONS, must request -->
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <uses-feature

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/MapActivity.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/MapActivity.java
@@ -1,9 +1,6 @@
 // Created by plusminus on 00:23:14 - 03.10.2008
 package org.osmdroid;
 
-import android.app.AlertDialog;
-import android.app.Dialog;
-import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.FragmentManager;
@@ -14,52 +11,21 @@ import android.support.v4.app.FragmentManager;
  * @author Manuel Stahl
  *
  */
-public class MapActivity extends FragmentActivity
-{
-
-    private static final int DIALOG_ABOUT_ID = 1;
-	private static final String MAP_FRAGMENT_TAG = "org.osmdroid.MAP_FRAGMENT_TAG";
+public class MapActivity extends FragmentActivity {
+    private static final String MAP_FRAGMENT_TAG = "org.osmdroid.MAP_FRAGMENT_TAG";
 
     // ===========================================================
     // Constructors
     // ===========================================================
     /** Called when the activity is first created. */
     @Override
-    public void onCreate(final Bundle savedInstanceState)
-    {
+    public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
         this.setContentView(org.osmdroid.R.layout.main);
-
         FragmentManager fm = this.getSupportFragmentManager();
-
 		if (fm.findFragmentByTag(MAP_FRAGMENT_TAG) == null) {
 			MapFragment mapFragment = MapFragment.newInstance();
 			fm.beginTransaction().add(org.osmdroid.R.id.map_container, mapFragment, MAP_FRAGMENT_TAG).commit();
 		}
-    }
-
-    @Override
-    protected Dialog onCreateDialog(final int id)
-    {
-        Dialog dialog;
-
-        switch (id) {
-            case DIALOG_ABOUT_ID:
-                return new AlertDialog.Builder(MapActivity.this).setIcon(org.osmdroid.R.drawable.icon)
-                        .setTitle(org.osmdroid.R.string.app_name).setMessage(org.osmdroid.R.string.about_message)
-                        .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(final DialogInterface dialog, final int whichButton)
-                            {
-                                //
-                            }
-                        }).create();
-
-            default:
-                dialog = null;
-                break;
-        }
-        return dialog;
     }
 }

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/MapFragment.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/MapFragment.java
@@ -1,22 +1,10 @@
 // Created by plusminus on 00:23:14 - 03.10.2008
 package org.osmdroid;
 
-import org.osmdroid.constants.OpenStreetMapConstants;
-import org.osmdroid.samplefragments.BaseSampleFragment;
-import org.osmdroid.samplefragments.SampleFactory;
-import org.osmdroid.tileprovider.tilesource.ITileSource;
-import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
-import org.osmdroid.views.MapView;
-import org.osmdroid.views.overlay.MinimapOverlay;
-import org.osmdroid.views.overlay.ScaleBarOverlay;
-import org.osmdroid.views.overlay.compass.CompassOverlay;
-import org.osmdroid.views.overlay.compass.InternalCompassOrientationProvider;
-import org.osmdroid.views.overlay.gestures.RotationGestureOverlay;
-import org.osmdroid.views.overlay.mylocation.GpsMyLocationProvider;
-import org.osmdroid.views.overlay.mylocation.MyLocationNewOverlay;
-
 import android.annotation.TargetApi;
+import android.app.AlertDialog;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.Bundle;
@@ -31,6 +19,20 @@ import android.view.MenuItem.OnMenuItemClickListener;
 import android.view.SubMenu;
 import android.view.View;
 import android.view.ViewGroup;
+
+import org.osmdroid.constants.OpenStreetMapConstants;
+import org.osmdroid.samplefragments.BaseSampleFragment;
+import org.osmdroid.samplefragments.SampleFactory;
+import org.osmdroid.tileprovider.tilesource.ITileSource;
+import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
+import org.osmdroid.views.MapView;
+import org.osmdroid.views.overlay.MinimapOverlay;
+import org.osmdroid.views.overlay.ScaleBarOverlay;
+import org.osmdroid.views.overlay.compass.CompassOverlay;
+import org.osmdroid.views.overlay.compass.InternalCompassOrientationProvider;
+import org.osmdroid.views.overlay.gestures.RotationGestureOverlay;
+import org.osmdroid.views.overlay.mylocation.GpsMyLocationProvider;
+import org.osmdroid.views.overlay.mylocation.MyLocationNewOverlay;
 
 /**
  * Default map view activity.
@@ -64,8 +66,7 @@ public class MapFragment extends Fragment implements OpenStreetMapConstants {
      private ResourceProxy mResourceProxy;
 
      public static MapFragment newInstance() {
-          MapFragment fragment = new MapFragment();
-          return fragment;
+         return new MapFragment();
      }
 
      @Override
@@ -154,7 +155,7 @@ public class MapFragment extends Fragment implements OpenStreetMapConstants {
      public void onResume() {
           super.onResume();
           final String tileSourceName = mPrefs.getString(PREFS_TILE_SOURCE,
-               TileSourceFactory.DEFAULT_TILE_SOURCE.name());
+                  TileSourceFactory.DEFAULT_TILE_SOURCE.name());
           try {
                final ITileSource tileSource = TileSourceFactory.getTileSource(tileSourceName);
                mMapView.setTileSource(tileSource);
@@ -217,7 +218,16 @@ public class MapFragment extends Fragment implements OpenStreetMapConstants {
 
           switch (item.getItemId()) {
                case MENU_ABOUT:
-                    getActivity().showDialog(DIALOG_ABOUT_ID);
+                    AlertDialog.Builder builder = new AlertDialog.Builder(getActivity())
+                            .setTitle(org.osmdroid.R.string.app_name).setMessage(org.osmdroid.R.string.about_message)
+                            .setIcon(org.osmdroid.R.drawable.icon)
+                            .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+                               public void onClick(DialogInterface dialog, int whichButton) {
+                                    //
+                               }
+                            }
+                    );
+                    builder.create().show();
                     return true;
           }
           return super.onOptionsItemSelected(item);

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleAnimatedZoomToLocation.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleAnimatedZoomToLocation.java
@@ -52,25 +52,25 @@ public class SampleAnimatedZoomToLocation extends BaseSampleFragment {
       public void onLocationChanged(Location location, IMyLocationProvider source) {
         mGpsMyLocationProvider.stopLocationProvider();
         if(mMyLocationOverlay == null) {
-          final ArrayList<OverlayItem> items = new ArrayList<OverlayItem>();
+          final ArrayList<OverlayItem> items = new ArrayList<>();
           items.add(new OverlayItem("Me", "My Location",
             new GeoPoint(location)));
 
-          mMyLocationOverlay = new ItemizedOverlayWithFocus<OverlayItem>(items,
-            new ItemizedIconOverlay.OnItemGestureListener<OverlayItem>() {
-              @Override
-              public boolean onItemSingleTapUp(final int index, final OverlayItem item) {
-                IMapController mapController = mMapView.getController();
-                mapController.setCenter(item.getPoint());
-                mapController.zoomTo(mMapView.getMaxZoomLevel());
-                return true;
-              }
+          mMyLocationOverlay = new ItemizedOverlayWithFocus<>(items,
+                  new ItemizedIconOverlay.OnItemGestureListener<OverlayItem>() {
+            @Override
+            public boolean onItemSingleTapUp(final int index, final OverlayItem item) {
+              IMapController mapController = mMapView.getController();
+              mapController.setCenter(item.getPoint());
+              mapController.zoomTo(mMapView.getMaxZoomLevel());
+              return true;
+            }
 
-              @Override
-              public boolean onItemLongPress(final int index, final OverlayItem item) {
-                return false;
-              }
-            }, mResourceProxy);
+            @Override
+            public boolean onItemLongPress(final int index, final OverlayItem item) {
+              return false;
+            }
+          }, mResourceProxy);
 
           mMyLocationOverlay.setFocusItemsOnTap(true);
           mMyLocationOverlay.setFocusedItem(0);

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleFactory.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleFactory.java
@@ -14,16 +14,18 @@ public final class SampleFactory {
 	}
 
 	private SampleFactory() {
-		mSamples = new BaseSampleFragment[] { new SampleWithMinimapItemizedOverlayWithFocus(),
-                    new SampleWithMinimapItemizedOverlayWithScale(),
-				    new SampleLimitedScrollArea(), new SampleFragmentXmlLayout(), new SampleOsmPath(),
-                    new SampleInvertedTiles_NightMode(), new SampleOfflineOnly(),
-                    new SampleAlternateCacheDir(),
-                    new SampleMilitaryIcons(),
-                    new SampleMapBox(),
-					new SampleJumboCache(),
-                    new SampleCustomTileSource(),
-										new SampleAnimatedZoomToLocation()};
+		mSamples = new BaseSampleFragment[] {
+				new SampleWithMinimapItemizedOverlayWithFocus(),
+                new SampleWithMinimapItemizedOverlayWithScale(),
+                new SampleLimitedScrollArea(), new SampleFragmentXmlLayout(), new SampleOsmPath(),
+                new SampleInvertedTiles_NightMode(), new SampleOfflineOnly(),
+                new SampleAlternateCacheDir(),
+                new SampleMilitaryIcons(),
+                new SampleMapBox(),
+                new SampleJumboCache(),
+                new SampleCustomTileSource(),
+				new SampleAnimatedZoomToLocation()
+        };
 	}
 
 	public BaseSampleFragment getSample(int index) {

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleJumboCache.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleJumboCache.java
@@ -5,19 +5,9 @@
  */
 package org.osmdroid.samplefragments;
 
-import android.content.Context;
-import android.graphics.Canvas;
-import android.graphics.Color;
-import android.graphics.Paint;
-import android.graphics.Point;
-import android.graphics.Rect;
 import android.os.Bundle;
-import android.view.Menu;
-import android.view.MenuInflater;
-import android.view.MenuItem;
 import android.widget.Toast;
 
-import org.osmdroid.constants.OpenStreetMapConstants;
 import org.osmdroid.tileprovider.constants.OpenStreetMapTileProviderConstants;
 import org.osmdroid.views.overlay.Overlay;
 import org.osmdroid.views.overlay.TilesOverlay;

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleOfflineOnly.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleOfflineOnly.java
@@ -2,16 +2,16 @@ package org.osmdroid.samplefragments;
 
 import android.os.Environment;
 import android.widget.Toast;
-import java.io.File;
-import java.util.Set;
 
 import org.osmdroid.tileprovider.modules.ArchiveFileFactory;
 import org.osmdroid.tileprovider.modules.IArchiveFile;
 import org.osmdroid.tileprovider.modules.OfflineTileProvider;
 import org.osmdroid.tileprovider.tilesource.FileBasedTileSource;
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
-import org.osmdroid.tileprovider.tilesource.XYTileSource;
 import org.osmdroid.tileprovider.util.SimpleRegisterReceiver;
+
+import java.io.File;
+import java.util.Set;
 
 /**
  * An example on how to setup osmdroid to only use offline map archives, how to

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samples/SampleLoader.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samples/SampleLoader.java
@@ -1,8 +1,6 @@
 // Created by plusminus on 18:23:13 - 03.10.2008
 package org.osmdroid.samples;
 
-import java.util.ArrayList;
-
 import android.Manifest;
 import android.app.ListActivity;
 import android.content.Intent;
@@ -17,6 +15,8 @@ import android.widget.Toast;
 
 import org.osmdroid.MapActivity;
 
+import java.util.ArrayList;
+
 public class SampleLoader extends ListActivity {
 	// ===========================================================
 	// Constants
@@ -25,12 +25,7 @@ public class SampleLoader extends ListActivity {
 	// ===========================================================
 	// Fields
 	// ===========================================================
-
-	final int INTERNET=1;
-	final int NETSTATE=2;
 	final int LOCATION=3;
-	final int LOCATIONC=4;
-	final int WIFI=5;
 	final int STORAGE=6;
 	// ===========================================================
 	// Constructors
@@ -41,207 +36,66 @@ public class SampleLoader extends ListActivity {
 	public void onCreate(final Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 
-		// Assume thisActivity is the current activity
-		int permissionCheck = ContextCompat.checkSelfPermission(this,
-				Manifest.permission.INTERNET);
-		if (permissionCheck != PackageManager.PERMISSION_GRANTED){
-			// Should we show an explanation?
-			if (ActivityCompat.shouldShowRequestPermissionRationale(this,
-					Manifest.permission.INTERNET)) {
+		// Request permissions to support Android Marshmallow and above devices
+		checkPermissions();
 
-				// Show an expanation to the user *asynchronously* -- don't block
-				// this thread waiting for the user's response! After the user
-				// sees the explanation, try again to request the permission.
-				Toast.makeText(this, "Need internet access to get map tiles if working with online sources", Toast.LENGTH_LONG).show();
-
-			} else {
-
-				// No explanation needed, we can request the permission.
-
-				ActivityCompat.requestPermissions(this,
-						new String[]{Manifest.permission.INTERNET},
-						INTERNET);
-
-				// MY_PERMISSIONS_REQUEST_READ_CONTACTS is an
-				// app-defined int constant. The callback method gets the
-				// result of the request.
-			}
-		}
-
-		permissionCheck = ContextCompat.checkSelfPermission(this,
-				Manifest.permission.ACCESS_NETWORK_STATE);
-
-		if (permissionCheck != PackageManager.PERMISSION_GRANTED){
-			// Should we show an explanation?
-			if (ActivityCompat.shouldShowRequestPermissionRationale(this,
-					Manifest.permission.ACCESS_NETWORK_STATE)) {
-
-				// Show an expanation to the user *asynchronously* -- don't block
-				// this thread waiting for the user's response! After the user
-				// sees the explanation, try again to request the permission.
-				Toast.makeText(this, "Need to check network state", Toast.LENGTH_LONG).show();
-
-			} else {
-
-				// No explanation needed, we can request the permission.
-
-				ActivityCompat.requestPermissions(this,
-						new String[]{Manifest.permission.ACCESS_NETWORK_STATE},
-						NETSTATE);
-
-				// MY_PERMISSIONS_REQUEST_READ_CONTACTS is an
-				// app-defined int constant. The callback method gets the
-				// result of the request.
-			}
-		}
-
-		permissionCheck = ContextCompat.checkSelfPermission(this,
-				Manifest.permission.ACCESS_FINE_LOCATION);
-		if (permissionCheck != PackageManager.PERMISSION_GRANTED){
-			// Should we show an explanation?
-			if (ActivityCompat.shouldShowRequestPermissionRationale(this,
-					Manifest.permission.ACCESS_FINE_LOCATION)) {
-
-				// Show an expanation to the user *asynchronously* -- don't block
-				// this thread waiting for the user's response! After the user
-				// sees the explanation, try again to request the permission.
-				Toast.makeText(this, "Need your location to place an icon on the map", Toast.LENGTH_LONG).show();
-
-			} else {
-
-				// No explanation needed, we can request the permission.
-
-				ActivityCompat.requestPermissions(this,
-						new String[]{Manifest.permission.ACCESS_FINE_LOCATION},
-						LOCATION);
-
-				// MY_PERMISSIONS_REQUEST_READ_CONTACTS is an
-				// app-defined int constant. The callback method gets the
-				// result of the request.
-			}
-		}
-
-		permissionCheck = ContextCompat.checkSelfPermission(this,
-				Manifest.permission.ACCESS_COARSE_LOCATION);
-		if (permissionCheck != PackageManager.PERMISSION_GRANTED){
-			// Should we show an explanation?
-			if (ActivityCompat.shouldShowRequestPermissionRationale(this,
-					Manifest.permission.ACCESS_COARSE_LOCATION)) {
-
-				// Show an expanation to the user *asynchronously* -- don't block
-				// this thread waiting for the user's response! After the user
-				// sees the explanation, try again to request the permission.
-				Toast.makeText(this, "Need your location to place an icon on the map", Toast.LENGTH_LONG).show();
-
-			} else {
-
-				// No explanation needed, we can request the permission.
-
-				ActivityCompat.requestPermissions(this,
-						new String[]{Manifest.permission.ACCESS_COARSE_LOCATION},
-						LOCATIONC);
-
-				// MY_PERMISSIONS_REQUEST_READ_CONTACTS is an
-				// app-defined int constant. The callback method gets the
-				// result of the request.
-			}
-		}
-
-		permissionCheck = ContextCompat.checkSelfPermission(this,
-				Manifest.permission.ACCESS_WIFI_STATE);
-		if (permissionCheck != PackageManager.PERMISSION_GRANTED){
-			// Should we show an explanation?
-			if (ActivityCompat.shouldShowRequestPermissionRationale(this,
-					Manifest.permission.ACCESS_WIFI_STATE)) {
-
-				// Show an expanation to the user *asynchronously* -- don't block
-				// this thread waiting for the user's response! After the user
-				// sees the explanation, try again to request the permission.
-				Toast.makeText(this, "Access WIFI state", Toast.LENGTH_LONG).show();
-
-			} else {
-
-				// No explanation needed, we can request the permission.
-
-				ActivityCompat.requestPermissions(this,
-						new String[]{Manifest.permission.ACCESS_WIFI_STATE},
-						WIFI);
-
-				// MY_PERMISSIONS_REQUEST_READ_CONTACTS is an
-				// app-defined int constant. The callback method gets the
-				// result of the request.
-			}
-		}
-
-		permissionCheck = ContextCompat.checkSelfPermission(this,
-				Manifest.permission.WRITE_EXTERNAL_STORAGE);
-		if (permissionCheck != PackageManager.PERMISSION_GRANTED){
-			// Should we show an explanation?
-			if (ActivityCompat.shouldShowRequestPermissionRationale(this,
-					Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
-
-				// Show an expanation to the user *asynchronously* -- don't block
-				// this thread waiting for the user's response! After the user
-				// sees the explanation, try again to request the permission.
-				Toast.makeText(this, "We store tiles to your devices storage to reduce data usage and for reading offline tile stores", Toast.LENGTH_LONG).show();
-
-			} else {
-
-				// No explanation needed, we can request the permission.
-
-				ActivityCompat.requestPermissions(this,
-						new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
-						STORAGE);
-
-				// MY_PERMISSIONS_REQUEST_READ_CONTACTS is an
-				// app-defined int constant. The callback method gets the
-				// result of the request.
-			}
-		}
-		
-
-		final ArrayList<String> list = new ArrayList<String>();
-
-          list.add("OSMDroid Sample map (Start Here)");
+		// Generate a ListView with Sample Maps
+		final ArrayList<String> list = new ArrayList<>();
+		list.add("OSMDroid Sample map (Start Here)");
 		list.add("OSMapView with Minimap, ZoomControls, Animations, Scale Bar and MyLocationOverlay");
 		list.add("OSMapView with ItemizedOverlay");
 		list.add("OSMapView with Minimap and ZoomControls");
 		list.add("Sample with tiles overlay");
 		list.add("Sample with tiles overlay and custom tile source");
-          list.add("Sample with Custom Resources");
+		list.add("Sample with Custom Resources");
+		this.setListAdapter(new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, list));
+	}
 
-		this.setListAdapter(new ArrayAdapter<String>(this, android.R.layout.simple_list_item_1,
-				list));
+	private void checkPermissions() {
+		int permissionCheck;
+
+		permissionCheck = ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION);
+		if (permissionCheck != PackageManager.PERMISSION_GRANTED){
+			// Should we show an explanation?
+			if (ActivityCompat.shouldShowRequestPermissionRationale(this,Manifest.permission.ACCESS_FINE_LOCATION)) {
+				// Show an explanation to the user *asynchronously* -- don't block
+				// this thread waiting for the user's response! After the user
+				// sees the explanation, try again to request the permission.
+				Toast.makeText(this, "Need your location to place an icon on the map", Toast.LENGTH_LONG).show();
+			} else {
+				// No explanation needed, we can request the permission.
+				ActivityCompat.requestPermissions(this,
+						new String[]{Manifest.permission.ACCESS_FINE_LOCATION}, LOCATION);
+
+				// MY_PERMISSIONS_REQUEST_READ_CONTACTS is an
+				// app-defined int constant. The callback method gets the
+				// result of the request.
+			}
+		}
+
+		permissionCheck = ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+		if (permissionCheck != PackageManager.PERMISSION_GRANTED){
+			// Should we show an explanation?
+			if (ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+				// Show an expanation to the user *asynchronously* -- don't block
+				// this thread waiting for the user's response! After the user
+				// sees the explanation, try again to request the permission.
+				Toast.makeText(this, "We store tiles to your devices storage to reduce data usage and for reading offline tile stores", Toast.LENGTH_LONG).show();
+			} else {
+				// No explanation needed, we can request the permission.
+				ActivityCompat.requestPermissions(this,
+						new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
+						STORAGE);
+				// MY_PERMISSIONS_REQUEST_READ_CONTACTS is an
+				// app-defined int constant. The callback method gets the
+				// result of the request.
+			}
+		}
 	}
 
 	@Override
-	public void onRequestPermissionsResult(int requestCode,
-										   String permissions[], int[] grantResults) {
+	public void onRequestPermissionsResult(int requestCode, String permissions[], int[] grantResults) {
 		switch (requestCode) {
-			case INTERNET:{
-				// If request is cancelled, the result arrays are empty.
-				if (grantResults.length > 0
-						&& grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-					// permission was granted, yay!
-				} else {
-					// permission denied, boo! Disable the
-					// functionality that depends on this permission.
-					Toast.makeText(this,"Online map sources will be unavailable", Toast.LENGTH_LONG).show();
-				}
-				return;
-			}
-			case NETSTATE: {
-				// If request is cancelled, the result arrays are empty.
-				if (grantResults.length > 0
-						&& grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-					// permission was granted, yay!
-				} else {
-					// permission denied, boo! Disable the
-					// functionality that depends on this permission.
-					Toast.makeText(this,"Online map sources will be unavailable", Toast.LENGTH_LONG).show();
-				}
-				return;
-			}
 			case LOCATION:{
 				// If request is cancelled, the result arrays are empty.
 				if (grantResults.length > 0
@@ -250,22 +104,8 @@ public class SampleLoader extends ListActivity {
 				} else {
 					// permission denied, boo! Disable the
 					// functionality that depends on this permission.
-					Toast.makeText(this,"My location will be unavailable via GPS", Toast.LENGTH_LONG).show();
+					Toast.makeText(this,"Location permission is required for user location on map.", Toast.LENGTH_LONG).show();
 				}
-				return;
-			}
-			case LOCATIONC:
-			{
-				// If request is cancelled, the result arrays are empty.
-				if (grantResults.length > 0
-						&& grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-					// permission was granted, yay!
-				} else {
-					// permission denied, boo! Disable the
-					// functionality that depends on this permission.
-					Toast.makeText(this,"My location will be unavailable via Network providers", Toast.LENGTH_LONG).show();
-				}
-				return;
 			}
 			case STORAGE:{
 				// If request is cancelled, the result arrays are empty.
@@ -275,28 +115,9 @@ public class SampleLoader extends ListActivity {
 				} else {
 					// permission denied, boo! Disable the
 					// functionality that depends on this permission.
-					Toast.makeText(this,"Offline map data and caching will be unavailable", Toast.LENGTH_LONG).show();
+					Toast.makeText(this,"Storage permision is needed for offline map data caching.", Toast.LENGTH_LONG).show();
 				}
-				return;
 			}
-			case WIFI:{
-				// If request is cancelled, the result arrays are empty.
-				if (grantResults.length > 0
-						&& grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-
-					// permission was granted, yay!
-
-
-				} else {
-
-					// permission denied, boo! Disable the
-					// functionality that depends on this permission.
-					Toast.makeText(this,"Data usage may not be optimized.", Toast.LENGTH_LONG).show();
-
-				}
-				return;
-			}
-
 			// other 'case' lines to check for other
 			// permissions this app might request
 		}
@@ -309,13 +130,12 @@ public class SampleLoader extends ListActivity {
 	// ===========================================================
 	// Methods from SuperClass/Interfaces
 	// ===========================================================
-
 	@Override
 	protected void onListItemClick(final ListView l, final View v, final int position, final long id) {
 		switch (position) {
-          case 0:
-               this.startActivity(new Intent(this, MapActivity.class));
-               break;
+		case 0:
+		   this.startActivity(new Intent(this, MapActivity.class));
+		   break;
 		case 1:
 			this.startActivity(new Intent(this, SampleExtensive.class));
 			break;

--- a/OpenStreetMapViewer/src/main/res/layout/main.xml
+++ b/OpenStreetMapViewer/src/main/res/layout/main.xml
@@ -2,14 +2,11 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/parent_container"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" >
+    android:layout_height="match_parent">
 
     <FrameLayout
         android:id="@+id/map_container"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        >
-        
-    </FrameLayout>
+        android:layout_height="match_parent"/>
 
 </RelativeLayout>

--- a/OpenStreetMapViewer/src/main/res/layout/mapview.xml
+++ b/OpenStreetMapViewer/src/main/res/layout/mapview.xml
@@ -8,7 +8,6 @@
         android:id="@+id/mapview"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tilesource="Mapnik"
-        />
+        tilesource="Mapnik" />
 
 </RelativeLayout>

--- a/OpenStreetMapViewer/src/main/res/values/strings.xml
+++ b/OpenStreetMapViewer/src/main/res/values/strings.xml
@@ -8,7 +8,7 @@
 	<string name="offline">Offline mode</string>
 	<string name="samples">Samples</string>
 	<string name="about">About</string>
-	<string name="about_message">This software uses map data provided by &lt;b&gt;OpenStreetMap.org&lt;/b&gt;</string>
+	<string name="about_message">This software uses map data provided by OpenStreetMap.org</string>
 
 	<string name="first_fix_message">Got the first fix</string>
 


### PR DESCRIPTION
Went through many files trying to clean up readability.

For SampleLoader, I cleaned up the permission system as it was requesting many permissions which are automatically granted. The project only requires two permission groups Location & Storage, helping simplify the sample code. In addition, I grouped AndroidManifest permissions into groups for easy understanding of permissions and expectations.

Updated deprecated code in MapActivity to be used directly inside its Fragment. (Dialog)
Updated build.gradle to match AndroidManifest.xml versioning.
Minor formatting cleanup in various files.