### PR TITLE
#250 fixed memory leak in NetworkAvailabliltyCheck

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
@@ -149,7 +149,7 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
 			final ITileSource tileSource = getTileSourceFromAttributes(attrs);
 			tileProvider = isInEditMode()
 					? new MapTileProviderArray(tileSource, null, new MapTileModuleProviderBase[0])
-					: new MapTileProviderBasic(context, tileSource);
+					: new MapTileProviderBasic(context.getApplicationContext(), tileSource);
 		}
 
 		mTileRequestCompleteHandler = tileRequestCompleteHandler == null


### PR DESCRIPTION
`MapTileProviderBasic` is created with application context instead.