### PR TITLE
Bug/#335 fix for a whole lot of memory leaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,9 +109,9 @@ before_script:
   - adb shell chmod 777 /mnt/sdcard
   - adb shell mkdir /sdcard/osmdroid/
   - adb push osmdroid-forge-app/world.map /sdcard/osmdroid/world.map
-  - adb push resources/usgsbase.gemf /sdcard/osmdroid/usgsbase.gemf
-  - adb push resources/usgstopo.sqlite /sdcard/osmdroid/usgstopo.sqlite
-  - adb push resources/usgssat.zip /sdcard/osmdroid/usgssat.zip
+  #- adb push resources/usgsbase.gemf /sdcard/osmdroid/usgsbase.gemf
+  #- adb push resources/usgstopo.sqlite /sdcard/osmdroid/usgstopo.sqlite
+  #- adb push resources/usgssat.zip /sdcard/osmdroid/usgssat.zip
 
 #build
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,17 +54,17 @@ env:
     #note when changing these, updating the gradle build file for the GoogleWrapper project
     # first env var is just for display purposes
     #api8 with google
-    - API=8g ANDROID_TARGET=12  ANDROID_ABI=armeabi
+    - API=8g ANDROID_TARGET=13  ANDROID_ABI=armeabi
     #api8
     - API=8 ANDROID_TARGET=1  ANDROID_ABI=armeabi
     #api10
     - API=10 ANDROID_TARGET=2  ANDROID_ABI=armeabi
     #api10 with google
-    - API=10g ANDROID_TARGET=13  ANDROID_ABI=armeabi
+    - API=10g ANDROID_TARGET=14  ANDROID_ABI=armeabi
     #api15
     - API=15 ANDROID_TARGET=3  ANDROID_ABI=armeabi-v7a
     #api15 with google
-    - API=15g ANDROID_TARGET=14  ANDROID_ABI=armeabi-v7a
+    - API=15g ANDROID_TARGET=15  ANDROID_ABI=armeabi-v7a
     #api19
     - API=19 ANDROID_TARGET=7  ANDROID_ABI=armeabi-v7a
     #api19 with google

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ env:
     #api10
     - API=10 ANDROID_TARGET=2  ANDROID_ABI=armeabi
     #api10 with google
-    - API=10g ANDROID_TARGET=14  ANDROID_ABI=armeabi
+    - API=10g ANDROID_TARGET=13  ANDROID_ABI=armeabi
     #api15
     - API=15 ANDROID_TARGET=3  ANDROID_ABI=armeabi-v7a
     #api15 with google
@@ -109,6 +109,9 @@ before_script:
   - adb shell chmod 777 /mnt/sdcard
   - adb shell mkdir /sdcard/osmdroid/
   - adb push osmdroid-forge-app/world.map /sdcard/osmdroid/world.map
+  - adb push resources/usgsbase.gemf /sdcard/osmdroid/usgsbase.gemf
+  - adb push resources/usgstopo.sqlite /sdcard/osmdroid/usgstopo.sqlite
+  - adb push resources/usgssat.zip /sdcard/osmdroid/usgssat.zip
 
 #build
 script:

--- a/GoogleWrapperSample/build.gradle
+++ b/GoogleWrapperSample/build.gradle
@@ -49,7 +49,7 @@ project.gradle.taskGraph.whenReady {
     //this is just for Travis CI builds, since this package needs at least api 9 with google apis
     //ignore the following build targets 1,2,3,7, 12
     if (System.getenv("ANDROID_TARGET")!=null){
-        if ("12".equalsIgnoreCase(System.getenv("ANDROID_TARGET").trim()) ||
+        if ("13".equalsIgnoreCase(System.getenv("ANDROID_TARGET").trim()) ||
                 "1".equalsIgnoreCase(System.getenv("ANDROID_TARGET").trim())||
                 "2".equalsIgnoreCase(System.getenv("ANDROID_TARGET").trim())||
                 "3".equalsIgnoreCase(System.getenv("ANDROID_TARGET").trim())||

--- a/GoogleWrapperSample/build.gradle
+++ b/GoogleWrapperSample/build.gradle
@@ -54,10 +54,10 @@ project.gradle.taskGraph.whenReady {
                 "3".equalsIgnoreCase(System.getenv("ANDROID_TARGET").trim())||
                 "7".equalsIgnoreCase(System.getenv("ANDROID_TARGET").trim())) {
             println "Skipping android instrumentation test since the API level doesn't match this project"
-            connectedDebugAndroidTest {
-                ignoreFailures = true
 
-            }
+            installDebug { actions = []; }
+            connectedDebugAndroidTest { actions = []; }
+           
         }
     }
 }

--- a/GoogleWrapperSample/build.gradle
+++ b/GoogleWrapperSample/build.gradle
@@ -60,3 +60,54 @@ project.gradle.taskGraph.whenReady {
         }
     }
 }
+
+
+android.applicationVariants.all { variant ->
+    if (variant.getBuildType().name == "debug") {
+        task "configDevice${variant.name.capitalize()}" (type: Exec){
+            dependsOn variant.install
+
+            group = 'nameofyourtaskgroup'
+            description = 'Describe your task here.'
+
+            def adb = android.getAdbExe().toString()
+            def mypermission = 'android.permission.ACCESS_FINE_LOCATION'
+            commandLine "$adb shell pm grant ${variant.applicationId} $mypermission".split(' ')
+        }
+        variant.testVariant.connectedInstrumentTest.dependsOn "configDevice${variant.name.capitalize()}"
+    }
+}
+
+
+android.applicationVariants.all { variant ->
+    if (variant.getBuildType().name == "debug") {
+        task "configDevice2${variant.name.capitalize()}" (type: Exec){
+            dependsOn variant.install
+
+            group = 'nameofyourtaskgroup'
+            description = 'Describe your task here.'
+
+            def adb = android.getAdbExe().toString()
+            def mypermission = 'android.permission.WRITE_EXTERNAL_STORAGE '
+            commandLine "$adb shell pm grant ${variant.applicationId} $mypermission".split(' ')
+        }
+        variant.testVariant.connectedInstrumentTest.dependsOn "configDevice${variant.name.capitalize()}"
+    }
+}
+
+
+android.applicationVariants.all { variant ->
+    if (variant.getBuildType().name == "debug") {
+        task "configDevice3${variant.name.capitalize()}" (type: Exec){
+            dependsOn variant.install
+
+            group = 'nameofyourtaskgroup'
+            description = 'Describe your task here.'
+
+            def adb = android.getAdbExe().toString()
+            def mypermission = 'android.permission.READ_EXTERNAL_STORAGE '
+            commandLine "$adb shell pm grant ${variant.applicationId} $mypermission".split(' ')
+        }
+        variant.testVariant.connectedInstrumentTest.dependsOn "configDevice${variant.name.capitalize()}"
+    }
+}

--- a/GoogleWrapperSample/build.gradle
+++ b/GoogleWrapperSample/build.gradle
@@ -53,6 +53,7 @@ project.gradle.taskGraph.whenReady {
                 "2".equalsIgnoreCase(System.getenv("ANDROID_TARGET").trim())||
                 "3".equalsIgnoreCase(System.getenv("ANDROID_TARGET").trim())||
                 "7".equalsIgnoreCase(System.getenv("ANDROID_TARGET").trim())) {
+            println "Skipping android instrumentation test since the API level doesn't match this project"
             connectedDebugAndroidTest {
                 ignoreFailures = true
 

--- a/GoogleWrapperSample/build.gradle
+++ b/GoogleWrapperSample/build.gradle
@@ -53,11 +53,11 @@ project.gradle.taskGraph.whenReady {
                 "2".equalsIgnoreCase(System.getenv("ANDROID_TARGET").trim())||
                 "3".equalsIgnoreCase(System.getenv("ANDROID_TARGET").trim())||
                 "7".equalsIgnoreCase(System.getenv("ANDROID_TARGET").trim())) {
-            println "Skipping android instrumentation test since the API level doesn't match this project"
+            println "Skipping GoogleWrapperSample instrumentation test since the API level doesn't match this project"
 
             installDebug { actions = []; }
             connectedDebugAndroidTest { actions = []; }
-           
+
         }
     }
 }

--- a/GoogleWrapperSample/src/main/java/org/osmdroid/google/sample/MainActivity.java
+++ b/GoogleWrapperSample/src/main/java/org/osmdroid/google/sample/MainActivity.java
@@ -13,6 +13,9 @@ import android.widget.ArrayAdapter;
 import android.widget.ListView;
 import android.widget.Toast;
 
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GoogleApiAvailability;
+
 import org.osmdroid.google.wrapper.v2.MapFactory;
 
 import java.util.ArrayList;
@@ -23,6 +26,7 @@ import java.util.Map;
 public class MainActivity extends ListActivity {
     boolean isV1Supported = false;
     boolean isV2Supported = false;
+    boolean isGooglePlayServicesInstalled = false;
 
     /**
      * Called when the activity is first created.
@@ -36,6 +40,13 @@ public class MainActivity extends ListActivity {
             checkPermissions();
         }
 
+
+        GoogleApiAvailability api = GoogleApiAvailability.getInstance();
+        int code = api.isGooglePlayServicesAvailable(this);
+        if (code == ConnectionResult.SUCCESS) {
+            // Do Your Stuff Here
+            isGooglePlayServicesInstalled=true;
+        }
         isV1Supported = MapFactory.isGoogleMapsV1Supported();
         isV2Supported = MapFactory.isGoogleMapsV2Supported(this);
 
@@ -54,7 +65,7 @@ public class MainActivity extends ListActivity {
     protected void onListItemClick(final ListView l, final View v, final int position, final long id) {
         switch (position) {
             case 0:
-                if (isV2Supported) {
+                if (isGooglePlayServicesInstalled && isV2Supported) {
                     this.startActivity(new Intent(this, MapsActivity.class));
                 } else
                     Toast.makeText(this, "Not available on your device", Toast.LENGTH_LONG).show();
@@ -63,13 +74,13 @@ public class MainActivity extends ListActivity {
                 this.startActivity(new Intent(this, OsmMapActivity.class));
                 break;
             case 2:
-                if (isV1Supported) {
+                if (isGooglePlayServicesInstalled && isV1Supported) {
                     this.startActivity(new Intent(this, Googlev1WrapperSample.class));
                 } else
                     Toast.makeText(this, "Not available on your device", Toast.LENGTH_LONG).show();
                 break;
             case 3:
-                if (isV2Supported) {
+                if (isGooglePlayServicesInstalled && isV2Supported) {
                     this.startActivity(new Intent(this, Googlev2WrapperSample.class));
                 } else
                     Toast.makeText(this, "Not available on your device", Toast.LENGTH_LONG).show();

--- a/OpenStreetMapViewer/build.gradle
+++ b/OpenStreetMapViewer/build.gradle
@@ -42,3 +42,113 @@ task copyTestClasses(type: Copy) {
 }
 
 preBuild.dependsOn copyTestClasses
+
+/*
+android.applicationVariants.all { variant ->
+    if (variant.getBuildType().name == "debug") {
+        variant.connectedInstrumentTest.doFirst {
+        //task "configDevice${variant.name.capitalize()}" (type: Exec){
+          //  dependsOn variant.install
+
+            //group = 'setPermissions'
+            //description = 'Sets API23 style permissions.'
+
+            def adb = android.getAdbExe().toString()
+            def mypermission = 'android.permission.INTERNET'
+            exec {
+                commandLine "echo adb shell pm grant ${variant.applicationId} $mypermission".split(' ')
+                commandLine "$adb shell pm grant ${variant.applicationId} $mypermission".split(' ')
+            }
+
+
+            mypermission = 'android.permission.ACCESS_FINE_LOCATION'
+            exec {
+                commandLine "echo adb shell pm grant ${variant.applicationId} $mypermission".split(' ')
+                commandLine "$adb shell pm grant ${variant.applicationId} $mypermission".split(' ')
+            }
+
+
+
+            mypermission = 'android.permission.WRITE_EXTERNAL_STORAGE'
+            exec {
+                commandLine "echo adb shell pm grant ${variant.applicationId} $mypermission".split(' ')
+                commandLine "$adb shell pm grant ${variant.applicationId} $mypermission".split(' ')
+            }
+
+        }
+        //variant.testVariant.connectedInstrumentTest.dependsOn "configDevice${variant.name.capitalize()}"
+    }
+}*/
+/*
+def adb = android.getAdbExe().toString()
+
+task nameofyourtask(type: Exec, dependsOn: 'installDebug') { // or install{productFlavour}{buildType}
+    group = 'nameofyourtaskgroup'
+    description = 'Describe your task here.'
+    def mypermission = 'android.permission.ACCESS_FINE_LOCATION'
+    commandLine "$adb shell pm grant ${variant.applicationId} $mypermission".split(' ')
+}
+task nameofyourtask2(type: Exec, dependsOn: 'installDebug') { // or install{productFlavour}{buildType}
+    group = 'nameofyourtaskgroup'
+    description = 'Describe your task here.'
+    def mypermission = 'android.permission.WRITE_EXTERNAL_STORAGE'
+    commandLine "$adb shell pm grant ${variant.applicationId} $mypermission".split(' ')
+}
+
+tasks.whenTaskAdded { task ->
+    if (task.name.startsWith('connectedDebugAndroidTest')) { // or connected{productFlavour}{buildType}AndroidTest
+        task.dependsOn nameofyourtask
+        task.dependsOn nameofyourtask2
+    }
+}*/
+
+
+android.applicationVariants.all { variant ->
+    if (variant.getBuildType().name == "debug") {
+        task "configDevice${variant.name.capitalize()}" (type: Exec){
+            dependsOn variant.install
+
+            group = 'nameofyourtaskgroup'
+            description = 'Describe your task here.'
+
+            def adb = android.getAdbExe().toString()
+            def mypermission = 'android.permission.ACCESS_FINE_LOCATION'
+            commandLine "$adb shell pm grant ${variant.applicationId} $mypermission".split(' ')
+        }
+        variant.testVariant.connectedInstrumentTest.dependsOn "configDevice${variant.name.capitalize()}"
+    }
+}
+
+
+android.applicationVariants.all { variant ->
+    if (variant.getBuildType().name == "debug") {
+        task "configDevice2${variant.name.capitalize()}" (type: Exec){
+            dependsOn variant.install
+
+            group = 'nameofyourtaskgroup'
+            description = 'Describe your task here.'
+
+            def adb = android.getAdbExe().toString()
+            def mypermission = 'android.permission.WRITE_EXTERNAL_STORAGE '
+            commandLine "$adb shell pm grant ${variant.applicationId} $mypermission".split(' ')
+        }
+        variant.testVariant.connectedInstrumentTest.dependsOn "configDevice${variant.name.capitalize()}"
+    }
+}
+
+
+android.applicationVariants.all { variant ->
+    if (variant.getBuildType().name == "debug") {
+        task "configDevice3${variant.name.capitalize()}" (type: Exec){
+            dependsOn variant.install
+
+            group = 'nameofyourtaskgroup'
+            description = 'Describe your task here.'
+
+            def adb = android.getAdbExe().toString()
+            def mypermission = 'android.permission.READ_EXTERNAL_STORAGE '
+            commandLine "$adb shell pm grant ${variant.applicationId} $mypermission".split(' ')
+        }
+        variant.testVariant.connectedInstrumentTest.dependsOn "configDevice${variant.name.capitalize()}"
+    }
+}

--- a/OpenStreetMapViewer/build.gradle
+++ b/OpenStreetMapViewer/build.gradle
@@ -20,6 +20,11 @@ android {
     lintOptions {
         abortOnError false
     }
+    sourceSets {
+        androidTest {
+            java.srcDirs = ['../osmdroid-android-it/src/main/java']
+        }
+    }
 }
 
 apply from: 'https://raw.githubusercontent.com/chrisdoyle/gradle-fury/master/gradle/android-support.gradle'
@@ -27,81 +32,23 @@ apply from: 'https://raw.githubusercontent.com/chrisdoyle/gradle-fury/master/gra
 dependencies {
     compile 'com.android.support:support-v4:23+'
     compile project(':osmdroid-android')
+
+    //crash logging
+    compile 'ch.acra:acra:4.7.0'
+
+    //memory leak testing
+    debugCompile 'com.squareup.leakcanary:leakcanary-android:1.4-beta2'
+    releaseCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.4-beta2'
+    testCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.4-beta2'
+
+    //on device testing
     androidTestCompile 'com.android.support:support-annotations:23+'
     androidTestCompile 'com.android.support.test:runner:0.4.+'
     androidTestCompile 'com.android.support.test:rules:0.4.+'
 }
 
 
-//copy the instrumentation tests from the maven osmdroid-android-it src folder
-task copyTestClasses(type: Copy) {
-    description 'Copies the osmdroid-android-it maven test classes to androidTest folder.'
-    from ("${rootDir}/osmdroid-android-it/src/main/java")
-    into "./src/androidTest/java"
-
-}
-
-preBuild.dependsOn copyTestClasses
-
-/*
-android.applicationVariants.all { variant ->
-    if (variant.getBuildType().name == "debug") {
-        variant.connectedInstrumentTest.doFirst {
-        //task "configDevice${variant.name.capitalize()}" (type: Exec){
-          //  dependsOn variant.install
-
-            //group = 'setPermissions'
-            //description = 'Sets API23 style permissions.'
-
-            def adb = android.getAdbExe().toString()
-            def mypermission = 'android.permission.INTERNET'
-            exec {
-                commandLine "echo adb shell pm grant ${variant.applicationId} $mypermission".split(' ')
-                commandLine "$adb shell pm grant ${variant.applicationId} $mypermission".split(' ')
-            }
-
-
-            mypermission = 'android.permission.ACCESS_FINE_LOCATION'
-            exec {
-                commandLine "echo adb shell pm grant ${variant.applicationId} $mypermission".split(' ')
-                commandLine "$adb shell pm grant ${variant.applicationId} $mypermission".split(' ')
-            }
-
-
-
-            mypermission = 'android.permission.WRITE_EXTERNAL_STORAGE'
-            exec {
-                commandLine "echo adb shell pm grant ${variant.applicationId} $mypermission".split(' ')
-                commandLine "$adb shell pm grant ${variant.applicationId} $mypermission".split(' ')
-            }
-
-        }
-        //variant.testVariant.connectedInstrumentTest.dependsOn "configDevice${variant.name.capitalize()}"
-    }
-}*/
-/*
-def adb = android.getAdbExe().toString()
-
-task nameofyourtask(type: Exec, dependsOn: 'installDebug') { // or install{productFlavour}{buildType}
-    group = 'nameofyourtaskgroup'
-    description = 'Describe your task here.'
-    def mypermission = 'android.permission.ACCESS_FINE_LOCATION'
-    commandLine "$adb shell pm grant ${variant.applicationId} $mypermission".split(' ')
-}
-task nameofyourtask2(type: Exec, dependsOn: 'installDebug') { // or install{productFlavour}{buildType}
-    group = 'nameofyourtaskgroup'
-    description = 'Describe your task here.'
-    def mypermission = 'android.permission.WRITE_EXTERNAL_STORAGE'
-    commandLine "$adb shell pm grant ${variant.applicationId} $mypermission".split(' ')
-}
-
-tasks.whenTaskAdded { task ->
-    if (task.name.startsWith('connectedDebugAndroidTest')) { // or connected{productFlavour}{buildType}AndroidTest
-        task.dependsOn nameofyourtask
-        task.dependsOn nameofyourtask2
-    }
-}*/
-
+//the following sets the required permissions for API 23+ devices and AVDs
 
 android.applicationVariants.all { variant ->
     if (variant.getBuildType().name == "debug") {

--- a/OpenStreetMapViewer/pom.xml
+++ b/OpenStreetMapViewer/pom.xml
@@ -30,6 +30,10 @@
             <groupId>android.support</groupId>
             <artifactId>compatibility-v4</artifactId>
         </dependency>
+        <dependency>
+            <groupId>ch.acra</groupId>
+            <artifactId>acra</artifactId>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/OpenStreetMapViewer/src/main/AndroidManifest.xml
+++ b/OpenStreetMapViewer/src/main/AndroidManifest.xml
@@ -39,7 +39,7 @@
     <application
         android:name=".OsmApplication"
         android:hardwareAccelerated="true"
-        android:largeHeap="false"
+        android:largeHeap="true"
         android:icon="@drawable/icon"
         android:label="@string/app_name">
 

--- a/OpenStreetMapViewer/src/main/AndroidManifest.xml
+++ b/OpenStreetMapViewer/src/main/AndroidManifest.xml
@@ -37,8 +37,9 @@
         android:required="false" />
 
     <application
+        android:name=".OsmApplication"
         android:hardwareAccelerated="true"
-        android:largeHeap="true"
+        android:largeHeap="false"
         android:icon="@drawable/icon"
         android:label="@string/app_name">
 

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/OsmApplication.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/OsmApplication.java
@@ -1,0 +1,122 @@
+package org.osmdroid;
+
+import android.app.Application;
+import android.content.Context;
+import android.os.Environment;
+import android.util.Log;
+
+import com.squareup.leakcanary.LeakCanary;
+
+import org.acra.ACRA;
+import org.acra.annotation.ReportsCrashes;
+import org.acra.collector.CrashReportData;
+import org.acra.sender.ReportSender;
+import org.acra.sender.ReportSenderException;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+/**
+ * This is the base application for the sample app. We only use to catch errors during development cycles
+ * Created by alex on 7/4/16.
+ */
+@ReportsCrashes( formUri = "")
+public class OsmApplication extends Application{
+
+    @Override
+    public void onCreate(){
+        super.onCreate();
+        LeakCanary.install(this);
+        Thread.currentThread().setUncaughtExceptionHandler(new OsmUncaughtExceptionHandler());
+    }
+
+    @Override
+    protected void attachBaseContext(Context base) {
+        super.attachBaseContext(base);
+
+
+
+        // Initialise ACRA
+        ACRA.init(this);
+        ACRA.getErrorReporter().setReportSender(new ErrorFileWriter());
+
+
+
+    }
+
+    public static class OsmUncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
+        @Override
+        public void uncaughtException(Thread thread, Throwable ex) {
+            Log.e("UncaughtException", "Got an uncaught exception: "+ex.toString());
+            if(ex.getClass().equals(OutOfMemoryError.class))
+            {
+                writeHprof();
+            }
+            ex.printStackTrace();
+        }
+    }
+
+    /**
+     * writes the current heap to the file system at /sdcard/osmdroid/trace-{timestamp}.hprof
+     */
+    public static void writeHprof(){
+        try {
+            android.os.Debug.dumpHprofData(Environment.getExternalStorageDirectory().getAbsolutePath() + "/osmdroid/trace-" + System.currentTimeMillis()+ ".hprof");
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+
+    /**
+     * Writes hard crash stack traces to a file on the SD card.
+     */
+    private static class ErrorFileWriter implements ReportSender {
+
+        @Override
+        public void send(Context context, CrashReportData crashReportData) throws ReportSenderException {
+            SimpleDateFormat sdf = new SimpleDateFormat("yyyy_MM_dd_HH_mm_ss",
+                    Locale.US);
+            String timeStamp = sdf.format(new Date());
+            String rootDirectory = Environment.getExternalStorageDirectory()
+                    .getAbsolutePath();
+            File f = new File(rootDirectory
+                    + File.separatorChar
+                    + "TCE"
+                    + File.separatorChar
+                    + "logs"
+                    + File.separatorChar
+                    + "crash"
+                    + File.separatorChar);
+            f.mkdirs();
+            f = new File(rootDirectory
+                    + File.separatorChar
+                    + "TCE"
+                    + File.separatorChar
+                    + "logs"
+                    + File.separatorChar
+                    + "crash"
+                    + File.separatorChar
+                    + "CRASH_"
+                    + BuildConfig.APPLICATION_ID+ "_"
+                    + timeStamp + ".log");
+            f.delete();
+
+            try {
+                f.createNewFile();
+                PrintWriter pw = new PrintWriter(new FileWriter(f));
+                pw.println(crashReportData.toString());
+                pw.close();
+            } catch (Exception exc) {
+                exc.printStackTrace();
+            }
+
+
+        }
+    }
+}

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/StarterMapFragment.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/StarterMapFragment.java
@@ -76,6 +76,8 @@ public class StarterMapFragment extends Fragment implements OpenStreetMapConstan
      @Override
      public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
 
+         //Note! we are programmatically construction the map view
+         //be sure to handle application lifecycle correct (see note in on pause)
           mMapView = new MapView(inflater.getContext());
         // Call this method to turn off hardware acceleration at the View level but only if you run into problems ( please report them too!)
           // setHardwareAccelerationOff();
@@ -158,6 +160,9 @@ public class StarterMapFragment extends Fragment implements OpenStreetMapConstan
 
           this.mLocationOverlay.disableMyLocation();
 
+         //this part terminates all of the overlays and background threads for osmdroid
+         //only needed when you programmatically create the map
+          mMapView.onDetach();
 
           super.onPause();
      }

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/StarterMapFragment.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/StarterMapFragment.java
@@ -160,12 +160,18 @@ public class StarterMapFragment extends Fragment implements OpenStreetMapConstan
 
           this.mLocationOverlay.disableMyLocation();
 
-         //this part terminates all of the overlays and background threads for osmdroid
-         //only needed when you programmatically create the map
-          mMapView.onDetach();
 
           super.onPause();
      }
+
+    @Override
+    public void onDestroyView(){
+        super.onDestroyView();
+        //this part terminates all of the overlays and background threads for osmdroid
+        //only needed when you programmatically create the map
+        mMapView.onDetach();
+
+    }
 
      @Override
      public void onResume() {

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/BaseSampleFragment.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/BaseSampleFragment.java
@@ -4,13 +4,14 @@ import org.osmdroid.views.MapView;
 
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
 public abstract class BaseSampleFragment extends Fragment {
 
-	public static final String TAG = "OpenMap";
+	public static final String TAG = "osmBaseFrag";
 	public abstract String getSampleTitle();
 
 	// ===========================================================
@@ -22,18 +23,20 @@ public abstract class BaseSampleFragment extends Fragment {
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
+		Log.d(TAG, "onCreate");
 	}
 
 	@Override
 	public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
 		mMapView = new MapView(inflater.getContext());
-
+		Log.d(TAG, "onCreateView");
 		return mMapView;
 	}
 
 	@Override
 	public void onActivityCreated(Bundle savedInstanceState) {
 		super.onActivityCreated(savedInstanceState);
+		Log.d(TAG, "onActivityCreated");
 		addOverlays();
 
 		mMapView.setBuiltInZoomControls(true);
@@ -42,10 +45,18 @@ public abstract class BaseSampleFragment extends Fragment {
 	}
 
 	@Override
-	public void onDetach(){
-		super.onDetach();
+	public void onDestroyView(){
+		super.onDestroyView();
+		Log.d(TAG, "onDetach");
 		mMapView.onDetach();
 		mMapView=null;
+	}
+
+	@Override
+	public void onDestroy(){
+		super.onDestroy();
+		Log.d(TAG, "onDestroy");
+
 	}
 
 	/**

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/FragmentSamples.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/FragmentSamples.java
@@ -24,7 +24,7 @@ public class FragmentSamples extends ListFragment {
     }
 
     @Override
-    public void onActivityCreated(Bundle savedInstanceState) {
+    public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         // Generate a ListView with Sample Maps

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/FragmentSamples.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/FragmentSamples.java
@@ -27,6 +27,17 @@ public class FragmentSamples extends ListFragment {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+
+    }
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+
+        //the following block of code took me an entire weekend to track down the root cause.
+        //if the code block is in onCreate, it will leak. onActivityCreated = no leak.
+        //makes no sense, but that's Android for you.
+
         // Generate a ListView with Sample Maps
         final ArrayList<String> list = new ArrayList<>();
         // Put samples next
@@ -34,7 +45,10 @@ public class FragmentSamples extends ListFragment {
             final BaseSampleFragment f = sampleFactory.getSample(a);
             list.add(f.getSampleTitle());
         }
-        ArrayAdapter<String> adapter = new ArrayAdapter<>(getActivity(),
+        //changed from getActivity to Application context per http://www.slideshare.net/AliMuzaffar2/android-preventing-common-memory-leaks
+        //prior to that, we had a memory leak that would only show on long running tests. the issue is that the array adapter
+        //wasn't being gc'd.
+        ArrayAdapter<String> adapter = new ArrayAdapter<>(getActivity().getApplicationContext(),
                 android.R.layout.simple_list_item_1, list);
         setListAdapter(adapter);
     }
@@ -57,5 +71,10 @@ public class FragmentSamples extends ListFragment {
         FragmentManager fm = getFragmentManager();
         fm.popBackStack();
         System.gc();
+    }
+
+    @Override
+    public void onDestroyView(){
+        super.onDestroyView();
     }
 }

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleAnimateTo.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleAnimateTo.java
@@ -33,6 +33,7 @@ public class SampleAnimateTo extends SampleGridlines {
     @Override
     public void onResume() {
         super.onResume();
+        alive=true;
         //some explanation here.
         //we using a timer task with a delayed start up to move the map around. during CI tests
         //this fragment can crash the app if you navigate away from the fragment before the initial fire

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleAnimateTo.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleAnimateTo.java
@@ -26,7 +26,7 @@ public class SampleAnimateTo extends SampleGridlines {
     @Override
     public void addOverlays() {
         super.addOverlays();
-        //this part will recalculate and render the lat/lon gridlines
+        mMapView.getController().setZoom(10);
 
     }
 
@@ -70,7 +70,7 @@ public class SampleAnimateTo extends SampleGridlines {
                             double lat = rand.nextDouble() * 180 - 90;
                             double lon = rand.nextDouble() * 360 - 180;
                             mMapView.getController().animateTo(new GeoPoint(lat, lon));
-                            Toast.makeText(getActivity(), "Animate to " + SampleMapEventListener.df.format(lat) + "," + SampleMapEventListener.df.format(lon), Toast.LENGTH_LONG).show();
+                            Toast.makeText(getActivity(), "Animate to " + SampleMapEventListener.df.format(lat) + "," + SampleMapEventListener.df.format(lon), Toast.LENGTH_SHORT).show();
                         }
                     }
                 });

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleCustomIconDirectedLocationOverlay.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleCustomIconDirectedLocationOverlay.java
@@ -5,6 +5,7 @@
  */
 package org.osmdroid.samplefragments;
 
+import android.app.Activity;
 import android.content.Context;
 import android.graphics.drawable.BitmapDrawable;
 import android.location.Location;
@@ -71,7 +72,9 @@ public class SampleCustomIconDirectedLocationOverlay extends BaseSampleFragment 
             TimerTask changeIcon = new TimerTask() {
                 @Override
                 public void run() {
-                    getActivity().runOnUiThread(new Runnable() {
+                    Activity act = getActivity();
+                    if (act!=null)
+                    act.runOnUiThread(new Runnable() {
                         @Override
                         public void run() {
                             try {

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleCustomTileSource.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleCustomTileSource.java
@@ -1,7 +1,6 @@
 package org.osmdroid.samplefragments;
 
-import org.osmdroid.tileprovider.MapTile;
-import org.osmdroid.tileprovider.tilesource.OnlineTileSourceBase;
+import org.osmdroid.samplefragments.models.USGSTileSource;
 
 /**
  * Simple how to for setting a custom tile source

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleCustomTileSource.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleCustomTileSource.java
@@ -16,14 +16,7 @@ public class SampleCustomTileSource extends BaseSampleFragment{
      }
       @Override
      public void addOverlays() {
-          mMapView.setTileSource(new OnlineTileSourceBase("USGS Topo", 0, 18, 256, "", 
-               new String[] { "http://basemap.nationalmap.gov/ArcGIS/rest/services/USGSTopo/MapServer/tile/" }) {
-               @Override
-               public String getTileURLString(MapTile aTile) {
-                    return getBaseUrl() + aTile.getZoomLevel() + "/" + aTile.getY() + "/" + aTile.getX()
-				+ mImageFilenameEnding;
-               }
-          });
+          mMapView.setTileSource(new USGSTileSource());
           
      }
      

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleFactory.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleFactory.java
@@ -16,31 +16,57 @@ public final class SampleFactory {
 
 	private SampleFactory() {
 		mSamples = new Class[] {
+				//0
 				SampleWithMinimapItemizedOverlayWithFocus.class,
+				//1
                 SampleWithMinimapItemizedOverlayWithScale.class,
+				//2
                 SampleLimitedScrollArea.class,
+				//3
                 SampleFragmentXmlLayout.class,
+				//4
                 SampleOsmPath.class,
+				//5
                 SampleInvertedTiles_NightMode.class,
+				//6
                 SampleOfflineOnly.class,
+				//7
                 SampleAlternateCacheDir.class,
+				//7
                 SampleMilitaryIcons.class,
+				//8
                 SampleMapBox.class,
+				//9
                 SampleJumboCache.class,
+				//10
                 SampleCustomTileSource.class,
+				//11
 				SampleAnimatedZoomToLocation.class,
+				//12
 				SampleWhackyColorFilter.class,
+				//13
 				SampleCustomIconDirectedLocationOverlay.class,
+				//14
 				SampleAssetsOnly.class,
+				//15
 				SampleSqliteOnly.class,
+				//16
 				SampleCacheDownloader.class,
+				//17
 				SampleCacheDownloaderCustomUI.class,
+				//18
 				SampleGridlines.class,
+				//19
 				SampleMapEventListener.class,
+				//20
 				SampleAnimateTo.class,
+				//21
 				SampleHeadingCompassUp.class,
+				//22
 				SampleSplitScreen.class,
+				//23
 				SampleMapBootListener.class,
+				//24
 				SampleFollowMe.class
         };
 	}

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleFollowMe.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleFollowMe.java
@@ -17,7 +17,6 @@ import android.widget.ImageButton;
 import org.osmdroid.R;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.MapView;
-import org.osmdroid.views.overlay.MinimapOverlay;
 import org.osmdroid.views.overlay.ScaleBarOverlay;
 import org.osmdroid.views.overlay.compass.CompassOverlay;
 import org.osmdroid.views.overlay.compass.InternalCompassOrientationProvider;
@@ -36,7 +35,6 @@ public class SampleFollowMe extends BaseSampleFragment implements LocationListen
 
     private MyLocationNewOverlay mLocationOverlay;
     private CompassOverlay mCompassOverlay;
-    private MinimapOverlay mMinimapOverlay;
     private ScaleBarOverlay mScaleBarOverlay;
     private RotationGestureOverlay mRotationGestureOverlay;
     protected ImageButton btCenterMap;
@@ -48,8 +46,7 @@ public class SampleFollowMe extends BaseSampleFragment implements LocationListen
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View v = inflater.inflate(R.layout.sample_followme, null);
         mMapView = (MapView) v.findViewById(org.osmdroid.R.id.mapview);
-        lm = (LocationManager) getActivity().getSystemService(Context.LOCATION_SERVICE);
-        lm.requestLocationUpdates(LocationManager.GPS_PROVIDER,0l,0f,this);
+
         return v;
 
     }
@@ -117,6 +114,25 @@ public class SampleFollowMe extends BaseSampleFragment implements LocationListen
         });
 
     }
+
+    @Override
+    public void onPause(){
+        super.onPause();
+        lm.removeUpdates(this);
+        mCompassOverlay.disableCompass();
+        mLocationOverlay.disableFollowLocation();
+        mLocationOverlay.disableMyLocation();
+        mScaleBarOverlay.enableScaleBar();
+    }
+    @Override
+    public void onResume(){
+        super.onResume();
+        lm = (LocationManager) getActivity().getSystemService(Context.LOCATION_SERVICE);
+        lm.requestLocationUpdates(LocationManager.GPS_PROVIDER,0l,0f,this);
+        mLocationOverlay.enableFollowLocation();
+        mLocationOverlay.enableMyLocation();
+        mScaleBarOverlay.disableScaleBar();
+    }
     @Override
     public String getSampleTitle() {
         return "Follow Me";
@@ -140,5 +156,18 @@ public class SampleFollowMe extends BaseSampleFragment implements LocationListen
     @Override
     public void onProviderDisabled(String provider) {
 
+    }
+    @Override
+    public void onDestroyView(){
+        super.onDestroyView();
+        lm=null;
+        currentLocation=null;
+
+        mLocationOverlay=null;
+        mCompassOverlay=null;
+        mScaleBarOverlay=null;
+        mRotationGestureOverlay=null;
+        btCenterMap=null;
+        btFollowMe=null;
     }
 }

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleFollowMe.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleFollowMe.java
@@ -1,12 +1,15 @@
 package org.osmdroid.samplefragments;
 
+import android.Manifest;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.location.Location;
 import android.location.LocationListener;
 import android.location.LocationManager;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.support.v4.app.ActivityCompat;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -40,7 +43,7 @@ public class SampleFollowMe extends BaseSampleFragment implements LocationListen
     protected ImageButton btCenterMap;
     protected ImageButton btFollowMe;
     private LocationManager lm;
-    private Location currentLocation=null;
+    private Location currentLocation = null;
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -90,8 +93,8 @@ public class SampleFollowMe extends BaseSampleFragment implements LocationListen
             @Override
             public void onClick(View v) {
                 Log.i(TAG, "centerMap clicked ");
-                if (currentLocation!=null) {
-                    GeoPoint myPosition = new GeoPoint(currentLocation.getLatitude(),currentLocation.getLongitude());
+                if (currentLocation != null) {
+                    GeoPoint myPosition = new GeoPoint(currentLocation.getLatitude(), currentLocation.getLongitude());
                     mMapView.getController().animateTo(myPosition);
                 }
             }
@@ -116,9 +119,13 @@ public class SampleFollowMe extends BaseSampleFragment implements LocationListen
     }
 
     @Override
-    public void onPause(){
+    public void onPause() {
         super.onPause();
-        lm.removeUpdates(this);
+        if (ActivityCompat.checkSelfPermission(getActivity(), Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED ||
+                ActivityCompat.checkSelfPermission(getActivity(), Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
+            lm.removeUpdates(this);
+        }
+
         mCompassOverlay.disableCompass();
         mLocationOverlay.disableFollowLocation();
         mLocationOverlay.disableMyLocation();
@@ -128,7 +135,11 @@ public class SampleFollowMe extends BaseSampleFragment implements LocationListen
     public void onResume(){
         super.onResume();
         lm = (LocationManager) getActivity().getSystemService(Context.LOCATION_SERVICE);
-        lm.requestLocationUpdates(LocationManager.GPS_PROVIDER,0l,0f,this);
+        if (ActivityCompat.checkSelfPermission(getActivity(), Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED ||
+                ActivityCompat.checkSelfPermission(getActivity(), Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
+            lm.requestLocationUpdates(LocationManager.GPS_PROVIDER,0l,0f,this);
+        }
+
         mLocationOverlay.enableFollowLocation();
         mLocationOverlay.enableMyLocation();
         mScaleBarOverlay.disableScaleBar();

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleGridlines.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleGridlines.java
@@ -58,10 +58,10 @@ public class SampleGridlines extends BaseSampleFragment implements MapListener {
 
     @Override
     public void onDestroyView(){
-        super.onDestroyView();
+
         activeLatLonGrid.onDetach(mMapView);
         activeLatLonGrid=null;
-
+        super.onDestroyView();
     }
 
 }

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleGridlines.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleGridlines.java
@@ -45,6 +45,8 @@ public class SampleGridlines extends BaseSampleFragment implements MapListener {
 
     private void updateGridlines(){
 
+        if (mMapView==null)
+            return; //happens during unit tests with rapid recycling of the fragment
         if (activeLatLonGrid != null) {
             mMapView.getOverlayManager().remove(activeLatLonGrid);
             activeLatLonGrid.onDetach(mMapView);

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleGridlines.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleGridlines.java
@@ -2,6 +2,7 @@ package org.osmdroid.samplefragments;
 
 import android.util.Log;
 
+import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.overlay.FolderOverlay;
 import org.osmdroid.events.MapListener;
 import org.osmdroid.events.ScrollEvent;
@@ -25,6 +26,8 @@ public class SampleGridlines extends BaseSampleFragment implements MapListener {
 
     @Override
     protected void addOverlays() {
+        mMapView.getController().setCenter(new GeoPoint(0d,0d));
+        mMapView.getController().setZoom(5);
         mMapView.setTilesScaledToDpi(true);
         mMapView.setMapListener(this);
         mMapView.getController().setZoom(3);

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleGridlines.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleGridlines.java
@@ -43,8 +43,10 @@ public class SampleGridlines extends BaseSampleFragment implements MapListener {
 
     private void updateGridlines(){
 
-        if (activeLatLonGrid != null)
-            mMapView.getOverlays().remove(activeLatLonGrid);
+        if (activeLatLonGrid != null) {
+            mMapView.getOverlayManager().remove(activeLatLonGrid);
+            activeLatLonGrid.onDetach(mMapView);
+        }
         activeLatLonGrid = LatLonGridlineOverlay.getLatLonGrid(getActivity(), mMapView);
         mMapView.getOverlays().add(activeLatLonGrid);
 

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleHeadingCompassUp.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleHeadingCompassUp.java
@@ -68,7 +68,7 @@ public class SampleHeadingCompassUp extends BaseSampleFragment implements Locati
         super.onResume();
 
         //lock the device in current screen orientation
-        int orientation = getActivity().getRequestedOrientation();
+        int orientation;
         int rotation = ((WindowManager) getActivity().getSystemService(
                 Context.WINDOW_SERVICE)).getDefaultDisplay().getRotation();
         switch (rotation) {
@@ -125,7 +125,24 @@ public class SampleHeadingCompassUp extends BaseSampleFragment implements Locati
     }
 
     @Override
+    public void onDestroyView(){
+        super.onDestroyView();
+        compass.destroy();
+        overlay.disableMyLocation();
+        overlay.disableFollowLocation();
+        overlay.onDetach(mMapView);
+        mMapView.onDetach();
+        mMapView=null;
+        overlay=null;
+        compass=null;
+        textViewCurrentLocation=null;
+
+    }
+
+    @Override
     public void onLocationChanged(Location location) {
+        if (mMapView==null)
+            return;
         //after the first fix, schedule the task to change the icon
         //mMapView.getController().setCenter(new GeoPoint(location.getLatitude(), location.getLongitude()));
         mMapView.invalidate();
@@ -160,6 +177,7 @@ public class SampleHeadingCompassUp extends BaseSampleFragment implements Locati
 
         GeomagneticField gf = new GeomagneticField(lat, lon, alt, timeOfFix);
         trueNorth = orientationToMagneticNorth + gf.getDeclination();
+        gf=null;
         synchronized (trueNorth) {
             if (trueNorth > 360.0f) {
                 trueNorth = trueNorth - 360.0f;
@@ -191,10 +209,12 @@ public class SampleHeadingCompassUp extends BaseSampleFragment implements Locati
             getActivity().runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
-                    textViewCurrentLocation.setText("GPS Speed: " + gpsspeed + "m/s  GPS Bearing: " + gpsbearing +
-                            "\nDevice Orientation: " + (int) deviceOrientation + "  Compass heading: " + (int) orientationToMagneticNorth + "\n" +
-                            "True north: " + trueNorth.intValue() + " Map Orientation: " + (int) mMapView.getMapOrientation() + "\n" +
-                            screen_orientation);
+                    if (getActivity()!=null && textViewCurrentLocation!=null) {
+                        textViewCurrentLocation.setText("GPS Speed: " + gpsspeed + "m/s  GPS Bearing: " + gpsbearing +
+                                "\nDevice Orientation: " + (int) deviceOrientation + "  Compass heading: " + (int) orientationToMagneticNorth + "\n" +
+                                "True north: " + trueNorth.intValue() + " Map Orientation: " + (int) mMapView.getMapOrientation() + "\n" +
+                                screen_orientation);
+                    }
                 }
             });
         }

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleHeadingCompassUp.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleHeadingCompassUp.java
@@ -131,7 +131,8 @@ public class SampleHeadingCompassUp extends BaseSampleFragment implements Locati
         overlay.disableMyLocation();
         overlay.disableFollowLocation();
         overlay.onDetach(mMapView);
-        mMapView.onDetach();
+        if (mMapView!=null)
+            mMapView.onDetach();
         mMapView=null;
         overlay=null;
         compass=null;

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleLimitedScrollArea.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleLimitedScrollArea.java
@@ -30,10 +30,10 @@ public class SampleLimitedScrollArea extends BaseSampleFragment {
 
 	public static final String TITLE = "Limited scroll area";
 
-	private static final int MENU_LIMIT_SCROLLING_ID = Menu.FIRST;
+	private final int MENU_LIMIT_SCROLLING_ID = Menu.FIRST;
 
-	private static final BoundingBoxE6 sCentralParkBoundingBox;
-	private static final Paint sPaint;
+	private BoundingBoxE6 sCentralParkBoundingBox;
+	private  Paint sPaint;
 
 	// ===========================================================
 	// Fields
@@ -41,7 +41,8 @@ public class SampleLimitedScrollArea extends BaseSampleFragment {
 
 	private ShadeAreaOverlay mShadeAreaOverlay;
 
-	static {
+	public SampleLimitedScrollArea()
+	{
 		sCentralParkBoundingBox = new BoundingBoxE6(40.796788,
 			-73.949232, 40.768094, -73.981762);
 		sPaint = new Paint();
@@ -55,11 +56,8 @@ public class SampleLimitedScrollArea extends BaseSampleFragment {
 	// ===========================================================
 	// Constructors
 	// ===========================================================
-	/** Called when the activity is first created. */
-	@Override
-	public void onActivityCreated(Bundle savedInstanceState) {
-		super.onActivityCreated(savedInstanceState);
-	}
+
+
 
 	@Override
 	protected void addOverlays() {
@@ -137,6 +135,7 @@ public class SampleLimitedScrollArea extends BaseSampleFragment {
 		final GeoPoint mBottomRight;
 		final Point mTopLeftPoint = new Point();
 		final Point mBottomRightPoint = new Point();
+		Rect area=null;
 		public ShadeAreaOverlay(Context ctx) {
 			super(ctx);
 			mTopLeft = new GeoPoint(sCentralParkBoundingBox.getLatNorthE6(),
@@ -152,11 +151,13 @@ public class SampleLimitedScrollArea extends BaseSampleFragment {
 
 			final Projection proj = osmv.getProjection();
 
-			proj.toPixels(mTopLeft, mTopLeftPoint);
-			proj.toPixels(mBottomRight, mBottomRightPoint);
+			if (area==null) {
+				proj.toPixels(mTopLeft, mTopLeftPoint);
+				proj.toPixels(mBottomRight, mBottomRightPoint);
 
-			Rect area = new Rect(mTopLeftPoint.x, mTopLeftPoint.y, mBottomRightPoint.x,
-					mBottomRightPoint.y);
+				area = new Rect(mTopLeftPoint.x, mTopLeftPoint.y, mBottomRightPoint.x,
+						mBottomRightPoint.y);
+			}
 			c.drawRect(area, sPaint);
 		}
 	}

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleMapBox.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleMapBox.java
@@ -2,6 +2,7 @@ package org.osmdroid.samplefragments;
 
 import android.app.AlertDialog;
 import android.content.DialogInterface;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.EditText;
@@ -17,6 +18,7 @@ import org.osmdroid.tileprovider.tilesource.MapBoxTileSource;
 public class SampleMapBox   extends BaseSampleFragment {
 
     AlertDialog alertDialog=null;
+    View promptsView=null;
 
     @Override
     public String getSampleTitle() {
@@ -47,7 +49,7 @@ public class SampleMapBox   extends BaseSampleFragment {
 
         // get prompts.xml view
         LayoutInflater li = LayoutInflater.from(getActivity());
-        View promptsView = li.inflate(R.layout.mapbox_prompt, null);
+         promptsView = li.inflate(R.layout.mapbox_prompt, null);
 
         AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(
                 getActivity());
@@ -98,6 +100,15 @@ public class SampleMapBox   extends BaseSampleFragment {
         super.onPause();
         if (alertDialog!=null && alertDialog.isShowing()){
             alertDialog.dismiss();
+        }
+    }
+
+    @Override
+    public void onDestroyView(){
+        super.onDestroyView();
+        if (alertDialog!=null && alertDialog.isShowing()){
+            alertDialog.dismiss();
+            alertDialog=null;
         }
     }
 

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleMilitaryIcons.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleMilitaryIcons.java
@@ -1,7 +1,10 @@
 package org.osmdroid.samplefragments;
 
 import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -9,6 +12,9 @@ import android.view.MenuItem;
 import android.widget.Toast;
 
 import org.osmdroid.api.IGeoPoint;
+import org.osmdroid.tileprovider.BitmapPool;
+import org.osmdroid.tileprovider.MapTile;
+import org.osmdroid.tileprovider.ReusableBitmapDrawable;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.overlay.ItemizedIconOverlay;
 import org.osmdroid.views.overlay.ItemizedOverlayWithFocus;
@@ -100,8 +106,8 @@ public class SampleMilitaryIcons extends BaseSampleFragment {
                mMyLocationOverlay.setFocusItemsOnTap(true);
                mMyLocationOverlay.setFocusedItem(0);
 
-               //generates 500 randomized points
-               addIcons(500);
+               //generates 50 randomized points
+               addIcons(50);
 
                mMapView.getOverlays().add(mMyLocationOverlay);
 
@@ -112,9 +118,9 @@ public class SampleMilitaryIcons extends BaseSampleFragment {
 
           /* MiniMap */
           {
-               MinimapOverlay miniMapOverlay = new MinimapOverlay(context,
-                    mMapView.getTileRequestCompleteHandler());
-               mMapView.getOverlays().add(miniMapOverlay);
+         //      MinimapOverlay miniMapOverlay = new MinimapOverlay(context,
+           //         mMapView.getTileRequestCompleteHandler());
+             //  mMapView.getOverlays().add(miniMapOverlay);
           }
 
           // Zoom and center on the focused item.
@@ -192,6 +198,30 @@ public class SampleMilitaryIcons extends BaseSampleFragment {
           Toast.makeText(getActivity(), count + " icons added! Current size: " + mMyLocationOverlay.size(), Toast.LENGTH_LONG).show();
 
      }
+
+     @Override
+     public void onDestroyView(){
+          super.onDestroyView();
+
+          for (int i=0; i < icons.size(); i++) {
+               Drawable drawable = icons.get(i);
+               // Only recycle if we are running on a project less than 2.3.3 Gingerbread.
+               if (Build.VERSION.SDK_INT < Build.VERSION_CODES.GINGERBREAD) {
+                    if (drawable instanceof BitmapDrawable) {
+                         final Bitmap bitmap = ((BitmapDrawable) drawable).getBitmap();
+                         if (bitmap != null) {
+                              bitmap.recycle();
+                         }
+                    }
+               }
+               if (drawable instanceof ReusableBitmapDrawable)
+                    BitmapPool.getInstance().returnDrawableToPool((ReusableBitmapDrawable) drawable);
+          }
+          icons.clear();
+          System.gc();
+     }
+
+
 
      // ===========================================================
      // Methods

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleMilitaryIcons.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleMilitaryIcons.java
@@ -196,26 +196,6 @@ public class SampleMilitaryIcons extends BaseSampleFragment {
      public void onDestroyView(){
           //itemOverlay.onDetach(mMapView);
           super.onDestroyView();
-/*
-          synchronized (icons) {
-               for (int i = 0; i < icons.size(); i++) {
-                    Drawable drawable = icons.get(i);
-                    // Only recycle if we are running on a project less than 2.3.3 Gingerbread.
-                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.GINGERBREAD) {
-                         if (drawable instanceof BitmapDrawable) {
-                              final Bitmap bitmap = ((BitmapDrawable) drawable).getBitmap();
-                              if (bitmap != null) {
-                                   bitmap.recycle();
-                              }
-                         }
-                    }
-                    if (drawable instanceof ReusableBitmapDrawable)
-                         BitmapPool.getInstance().returnDrawableToPool((ReusableBitmapDrawable) drawable);
-               }
-               icons.clear();
-          }
-          System.gc();*/
-
      }
 
 

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleMilitaryIcons.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleMilitaryIcons.java
@@ -13,12 +13,10 @@ import android.widget.Toast;
 
 import org.osmdroid.api.IGeoPoint;
 import org.osmdroid.tileprovider.BitmapPool;
-import org.osmdroid.tileprovider.MapTile;
 import org.osmdroid.tileprovider.ReusableBitmapDrawable;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.overlay.ItemizedIconOverlay;
 import org.osmdroid.views.overlay.ItemizedOverlayWithFocus;
-import org.osmdroid.views.overlay.MinimapOverlay;
 import org.osmdroid.views.overlay.OverlayItem;
 import org.osmdroid.views.overlay.gestures.RotationGestureOverlay;
 
@@ -47,10 +45,10 @@ public class SampleMilitaryIcons extends BaseSampleFragment {
 	// ===========================================================
      // Fields
      // ===========================================================
-     private ItemizedOverlayWithFocus<OverlayItem> mMyLocationOverlay;
+     private ItemizedOverlayWithFocus<OverlayItem> itemOverlay;
      private RotationGestureOverlay mRotationGestureOverlay;
      private OverlayItem overlayItem;
-     List<Drawable> icons = new ArrayList<>(4);
+     private List<Drawable> icons = new ArrayList<>(4);
 
      @Override
      public String getSampleTitle() {
@@ -60,13 +58,6 @@ public class SampleMilitaryIcons extends BaseSampleFragment {
 	// ===========================================================
      // Constructors
      // ===========================================================
-     /**
-      * Called when the activity is first created.
-      */
-     @Override
-     public void onActivityCreated(Bundle savedInstanceState) {
-          super.onActivityCreated(savedInstanceState);
-     }
 
      @Override
      protected void addOverlays() {
@@ -83,7 +74,7 @@ public class SampleMilitaryIcons extends BaseSampleFragment {
           /* Itemized Overlay */
           {
                /* OnTapListener for the Markers, shows a simple Toast. */
-               mMyLocationOverlay = new ItemizedOverlayWithFocus<>(new ArrayList<OverlayItem>(),
+               itemOverlay = new ItemizedOverlayWithFocus<>(new ArrayList<OverlayItem>(),
                        new ItemizedIconOverlay.OnItemGestureListener<OverlayItem>() {
                             @Override
                             public boolean onItemSingleTapUp(final int index, final OverlayItem item) {
@@ -103,13 +94,13 @@ public class SampleMilitaryIcons extends BaseSampleFragment {
                                  return false;
                             }
                        }, context);
-               mMyLocationOverlay.setFocusItemsOnTap(true);
-               mMyLocationOverlay.setFocusedItem(0);
+               itemOverlay.setFocusItemsOnTap(true);
+               itemOverlay.setFocusedItem(0);
 
                //generates 50 randomized points
                addIcons(50);
 
-               mMapView.getOverlays().add(mMyLocationOverlay);
+               mMapView.getOverlays().add(itemOverlay);
 
                mRotationGestureOverlay = new RotationGestureOverlay(context, mMapView);
                mRotationGestureOverlay.setEnabled(false);
@@ -125,11 +116,11 @@ public class SampleMilitaryIcons extends BaseSampleFragment {
 
           // Zoom and center on the focused item.
           mMapView.getController().setZoom(5);
-          IGeoPoint geoPoint = mMyLocationOverlay.getFocusedItem().getPoint();
+          IGeoPoint geoPoint = itemOverlay.getFocusedItem().getPoint();
           mMapView.getController().animateTo(geoPoint);
 
           setHasOptionsMenu(true);
-          Toast.makeText(context, "Icon selection and location are random!", Toast.LENGTH_LONG).show();
+          Toast.makeText(context, "Icon selection and location are random!", Toast.LENGTH_SHORT).show();
      }
 
 	// ===========================================================
@@ -194,31 +185,37 @@ public class SampleMilitaryIcons extends BaseSampleFragment {
                items.add(overlayItem);
 
           }
-          mMyLocationOverlay.addItems(items);
-          Toast.makeText(getActivity(), count + " icons added! Current size: " + mMyLocationOverlay.size(), Toast.LENGTH_LONG).show();
+          itemOverlay.addItems(items);
+          mMapView.invalidate();
+          Toast.makeText(getActivity(), count + " icons added! Current size: " + itemOverlay.size(), Toast.LENGTH_SHORT).show();
 
      }
 
+
      @Override
      public void onDestroyView(){
+          //itemOverlay.onDetach(mMapView);
           super.onDestroyView();
-
-          for (int i=0; i < icons.size(); i++) {
-               Drawable drawable = icons.get(i);
-               // Only recycle if we are running on a project less than 2.3.3 Gingerbread.
-               if (Build.VERSION.SDK_INT < Build.VERSION_CODES.GINGERBREAD) {
-                    if (drawable instanceof BitmapDrawable) {
-                         final Bitmap bitmap = ((BitmapDrawable) drawable).getBitmap();
-                         if (bitmap != null) {
-                              bitmap.recycle();
+/*
+          synchronized (icons) {
+               for (int i = 0; i < icons.size(); i++) {
+                    Drawable drawable = icons.get(i);
+                    // Only recycle if we are running on a project less than 2.3.3 Gingerbread.
+                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.GINGERBREAD) {
+                         if (drawable instanceof BitmapDrawable) {
+                              final Bitmap bitmap = ((BitmapDrawable) drawable).getBitmap();
+                              if (bitmap != null) {
+                                   bitmap.recycle();
+                              }
                          }
                     }
+                    if (drawable instanceof ReusableBitmapDrawable)
+                         BitmapPool.getInstance().returnDrawableToPool((ReusableBitmapDrawable) drawable);
                }
-               if (drawable instanceof ReusableBitmapDrawable)
-                    BitmapPool.getInstance().returnDrawableToPool((ReusableBitmapDrawable) drawable);
+               icons.clear();
           }
-          icons.clear();
-          System.gc();
+          System.gc();*/
+
      }
 
 

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleOfflineOnly.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleOfflineOnly.java
@@ -85,7 +85,7 @@ public class SampleOfflineOnly extends BaseSampleFragment {
                                 this.mMapView.setTileSource(TileSourceFactory.DEFAULT_TILE_SOURCE);
                             }
 
-                            Toast.makeText(getActivity(), "Using " + list[i].getAbsolutePath() + " " + source, Toast.LENGTH_LONG).show();
+                            Toast.makeText(getActivity(), "Using " + list[i].getAbsolutePath() + " " + source, Toast.LENGTH_SHORT).show();
                             this.mMapView.invalidate();
                             return;
                         } catch (Exception ex) {
@@ -94,9 +94,9 @@ public class SampleOfflineOnly extends BaseSampleFragment {
                     }
                 }
             }
-            Toast.makeText(getActivity(), f.getAbsolutePath() + " did not have any files I can open! Try using MOBAC", Toast.LENGTH_LONG).show();
+            Toast.makeText(getActivity(), f.getAbsolutePath() + " did not have any files I can open! Try using MOBAC", Toast.LENGTH_SHORT).show();
         } else {
-            Toast.makeText(getActivity(), f.getAbsolutePath() + " dir not found!", Toast.LENGTH_LONG).show();
+            Toast.makeText(getActivity(), f.getAbsolutePath() + " dir not found!", Toast.LENGTH_SHORT).show();
         }
 
     }

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleOfflineOnly.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleOfflineOnly.java
@@ -16,83 +16,89 @@ import java.util.Set;
 /**
  * An example on how to setup osmdroid to only use offline map archives, how to
  * query the map archives for the available tile sources
- * @since 5.0
+ *
  * @author alex
+ * @since 5.0
  */
 public class SampleOfflineOnly extends BaseSampleFragment {
 
-     @Override
-     public String getSampleTitle() {
-          return "Offline Only Tiles";
-     }
-     
-     @Override
-     public void addOverlays() {
-          //not even needed!
-          this.mMapView.setUseDataConnection(false);
+    @Override
+    public String getSampleTitle() {
+        return "Offline Only Tiles";
+    }
 
-          //first we'll look at the default location for tiles that we support
-          File f = new File(Environment.getExternalStorageDirectory().getAbsolutePath() + "/osmdroid/");
-          if (f.exists()){
-          
-               File[] list = f.listFiles();
-               for (int i=0; i < list.length; i++){
-                    if (list[i].isDirectory())
-                         continue;
-                    String name = list[i].getName().toLowerCase();
-                    if (!name.contains("."))
-                         continue; //skip files without an extension
-                    name=name.substring(name.lastIndexOf(".")+1);
-                    if (name.length() ==0)
-                         continue;
-                    if (ArchiveFileFactory.isFileExtensionRegistered(name)) {
-                         try {
+    @Override
+    public void addOverlays() {
+        //not even needed!
+        this.mMapView.setUseDataConnection(false);
 
-                              //ok found a file we support and have a driver for the format, for this demo, we'll just use the first one
+        //first we'll look at the default location for tiles that we support
+        File f = new File(Environment.getExternalStorageDirectory().getAbsolutePath() + "/osmdroid/");
+        if (f.exists()) {
 
-                              //create the offline tile provider, it will only do offline file archives
-                              //again using the first file
-                              OfflineTileProvider tileProvider= new OfflineTileProvider(new SimpleRegisterReceiver(getActivity()),
-                                      new File[]{list[i]});
-                              //tell osmdroid to use that provider instead of the default rig which is (asserts, cache, files/archives, online
-                              mMapView.setTileProvider(tileProvider);
-
-                              //this bit enables us to find out what tiles sources are available. note, that this action may take some time to run
-                              //and should be ran asynchronously. we've put it inline for simplicity
-
-                              String source="";
-                              IArchiveFile[] archives= tileProvider.getArchives();
-                              if (archives.length > 0){
-                                   //cheating a bit here, get the first archive file and ask for the tile sources names it contains
-                                   Set<String> tileSources = archives[0].getTileSources();
-                                   //presumably, this would be a great place to tell your users which tiles sources are available
-                                   if (!tileSources.isEmpty()) {
-                                        //ok good, we found at least one tile source, create a basic file based tile source using that name
-                                        //and set it. If we don't set it, osmdroid will attempt to use the default source, which is "MAPNIK",
-                                        //which probably won't match your offline tile source, unless it's MAPNIK
-                                        source = tileSources.iterator().next();
-                                        this.mMapView.setTileSource(FileBasedTileSource.getSource(source));
-                                   }
-                                   else{
-                                        this.mMapView.setTileSource(TileSourceFactory.DEFAULT_TILE_SOURCE);
-                                   }
-
-                              } else
-                                   this.mMapView.setTileSource(TileSourceFactory.DEFAULT_TILE_SOURCE);
-
-                              Toast.makeText(getActivity(), "Using " + list[i].getAbsolutePath() + " " + source, Toast.LENGTH_LONG).show();
-                              this.mMapView.invalidate();
-                              return;
-                         } catch (Exception ex) {
-                              ex.printStackTrace();
-                         }
+            File[] list = f.listFiles();
+            if (list != null) {
+                for (int i = 0; i < list.length; i++) {
+                    if (list[i].isDirectory()) {
+                        continue;
                     }
-               }
-               Toast.makeText(getActivity(), f.getAbsolutePath() +  " did not have any files I can open! Try using MOBAC", Toast.LENGTH_LONG).show();
-          } else{
-               Toast.makeText(getActivity(), f.getAbsolutePath() + " dir not found!", Toast.LENGTH_LONG).show();
-          }
-          
-	}
-     
+                    String name = list[i].getName().toLowerCase();
+                    if (!name.contains(".")) {
+                        continue; //skip files without an extension
+                    }
+                    name = name.substring(name.lastIndexOf(".") + 1);
+                    if (name.length() == 0) {
+                        continue;
+                    }
+                    if (ArchiveFileFactory.isFileExtensionRegistered(name)) {
+                        try {
+
+                            //ok found a file we support and have a driver for the format, for this demo, we'll just use the first one
+
+                            //create the offline tile provider, it will only do offline file archives
+                            //again using the first file
+                            OfflineTileProvider tileProvider = new OfflineTileProvider(new SimpleRegisterReceiver(getActivity()),
+                                    new File[]{list[i]});
+                            //tell osmdroid to use that provider instead of the default rig which is (asserts, cache, files/archives, online
+                            mMapView.setTileProvider(tileProvider);
+
+                            //this bit enables us to find out what tiles sources are available. note, that this action may take some time to run
+                            //and should be ran asynchronously. we've put it inline for simplicity
+
+                            String source = "";
+                            IArchiveFile[] archives = tileProvider.getArchives();
+                            if (archives.length > 0) {
+                                //cheating a bit here, get the first archive file and ask for the tile sources names it contains
+                                Set<String> tileSources = archives[0].getTileSources();
+                                //presumably, this would be a great place to tell your users which tiles sources are available
+                                if (!tileSources.isEmpty()) {
+                                    //ok good, we found at least one tile source, create a basic file based tile source using that name
+                                    //and set it. If we don't set it, osmdroid will attempt to use the default source, which is "MAPNIK",
+                                    //which probably won't match your offline tile source, unless it's MAPNIK
+                                    source = tileSources.iterator().next();
+                                    this.mMapView.setTileSource(FileBasedTileSource.getSource(source));
+                                } else {
+                                    this.mMapView.setTileSource(TileSourceFactory.DEFAULT_TILE_SOURCE);
+                                }
+
+                            } else {
+                                this.mMapView.setTileSource(TileSourceFactory.DEFAULT_TILE_SOURCE);
+                            }
+
+                            Toast.makeText(getActivity(), "Using " + list[i].getAbsolutePath() + " " + source, Toast.LENGTH_LONG).show();
+                            this.mMapView.invalidate();
+                            return;
+                        } catch (Exception ex) {
+                            ex.printStackTrace();
+                        }
+                    }
+                }
+            }
+            Toast.makeText(getActivity(), f.getAbsolutePath() + " did not have any files I can open! Try using MOBAC", Toast.LENGTH_LONG).show();
+        } else {
+            Toast.makeText(getActivity(), f.getAbsolutePath() + " dir not found!", Toast.LENGTH_LONG).show();
+        }
+
+    }
+
 }

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleOsmPath.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleOsmPath.java
@@ -26,10 +26,10 @@ public class SampleOsmPath extends BaseSampleFragment {
 
 	public static final String TITLE = "OsmPath drawing";
 
-	private static final BoundingBoxE6 sCentralParkBoundingBox;
-	private static final Paint sPaint;
+	private BoundingBoxE6 sCentralParkBoundingBox;
+	private Paint sPaint;
 
-	static {
+	public SampleOsmPath() {
 		sCentralParkBoundingBox = new BoundingBoxE6(40.796788, -73.949232, 40.768094, -73.981762);
 
 		sPaint = new Paint();

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleSqliteOnly.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleSqliteOnly.java
@@ -87,7 +87,7 @@ public class SampleSqliteOnly extends BaseSampleFragment {
                                 this.mMapView.setTileSource(TileSourceFactory.DEFAULT_TILE_SOURCE);
                             }
 
-                            Toast.makeText(getActivity(), "Using " + list[i].getAbsolutePath() + " " + source, Toast.LENGTH_LONG).show();
+                            Toast.makeText(getActivity(), "Using " + list[i].getAbsolutePath() + " " + source, Toast.LENGTH_SHORT).show();
                             this.mMapView.invalidate();
                             return;
                         } catch (Exception ex) {
@@ -96,9 +96,9 @@ public class SampleSqliteOnly extends BaseSampleFragment {
                     }
                 }
             }
-            Toast.makeText(getActivity(), f.getAbsolutePath() + " did not have any files I can open! Try using MOBAC", Toast.LENGTH_LONG).show();
+            Toast.makeText(getActivity(), f.getAbsolutePath() + " did not have any files I can open! Try using MOBAC", Toast.LENGTH_SHORT).show();
         } else {
-            Toast.makeText(getActivity(), f.getAbsolutePath() + " dir not found!", Toast.LENGTH_LONG).show();
+            Toast.makeText(getActivity(), f.getAbsolutePath() + " dir not found!", Toast.LENGTH_SHORT).show();
         }
 
 

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleSqliteOnly.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleSqliteOnly.java
@@ -3,13 +3,9 @@ package org.osmdroid.samplefragments;
 import android.os.Environment;
 import android.widget.Toast;
 
-import org.osmdroid.tileprovider.MapTileProviderArray;
 import org.osmdroid.tileprovider.constants.OpenStreetMapTileProviderConstants;
 import org.osmdroid.tileprovider.modules.ArchiveFileFactory;
 import org.osmdroid.tileprovider.modules.IArchiveFile;
-import org.osmdroid.tileprovider.modules.MapTileAssetsProvider;
-import org.osmdroid.tileprovider.modules.MapTileFileArchiveProvider;
-import org.osmdroid.tileprovider.modules.MapTileModuleProviderBase;
 import org.osmdroid.tileprovider.modules.OfflineTileProvider;
 import org.osmdroid.tileprovider.tilesource.FileBasedTileSource;
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
@@ -32,71 +28,76 @@ public class SampleSqliteOnly extends BaseSampleFragment {
 
     @Override
     public void addOverlays() {
-        OpenStreetMapTileProviderConstants.DEBUGMODE=true;
-        OpenStreetMapTileProviderConstants.DEBUG_TILE_PROVIDERS=true;
+        OpenStreetMapTileProviderConstants.DEBUGMODE = true;
+        OpenStreetMapTileProviderConstants.DEBUG_TILE_PROVIDERS = true;
         this.mMapView.setUseDataConnection(false);
 
         //first we'll look at the default location for tiles that we support
         File f = new File(Environment.getExternalStorageDirectory().getAbsolutePath() + "/osmdroid/");
-        if (f.exists()){
+        if (f.exists()) {
 
             File[] list = f.listFiles();
-            for (int i=0; i < list.length; i++){
-                if (list[i].isDirectory())
-                    continue;
-                String name = list[i].getName().toLowerCase();
-                if (!name.contains("."))
-                    continue; //skip files without an extension
-                name=name.substring(name.lastIndexOf(".")+1);
-                if (name.length() ==0)
-                    continue;
-                //narrow it down to only sqlite tiles
-                if (ArchiveFileFactory.isFileExtensionRegistered(name) &&
-                        name.equals("sqlite")) {
-                    try {
+            if (list != null) {
+                for (int i = 0; i < list.length; i++) {
+                    if (list[i].isDirectory()) {
+                        continue;
+                    }
+                    String name = list[i].getName().toLowerCase();
+                    if (!name.contains(".")) {
+                        continue; //skip files without an extension
+                    }
+                    name = name.substring(name.lastIndexOf(".") + 1);
+                    if (name.length() == 0) {
+                        continue;
+                    }
+                    //narrow it down to only sqlite tiles
+                    if (ArchiveFileFactory.isFileExtensionRegistered(name) &&
+                            name.equals("sqlite")) {
+                        try {
 
-                        //ok found a file we support and have a driver for the format, for this demo, we'll just use the first one
+                            //ok found a file we support and have a driver for the format, for this demo, we'll just use the first one
 
-                        //create the offline tile provider, it will only do offline file archives
-                        //again using the first file
-                        OfflineTileProvider tileProvider= new OfflineTileProvider(new SimpleRegisterReceiver(getActivity()),
-                                new File[]{list[i]});
-                        //tell osmdroid to use that provider instead of the default rig which is (asserts, cache, files/archives, online
-                        mMapView.setTileProvider(tileProvider);
+                            //create the offline tile provider, it will only do offline file archives
+                            //again using the first file
+                            OfflineTileProvider tileProvider = new OfflineTileProvider(new SimpleRegisterReceiver(getActivity()),
+                                    new File[]{list[i]});
+                            //tell osmdroid to use that provider instead of the default rig which is (asserts, cache, files/archives, online
+                            mMapView.setTileProvider(tileProvider);
 
-                        //this bit enables us to find out what tiles sources are available. note, that this action may take some time to run
-                        //and should be ran asynchronously. we've put it inline for simplicity
+                            //this bit enables us to find out what tiles sources are available. note, that this action may take some time to run
+                            //and should be ran asynchronously. we've put it inline for simplicity
 
-                        String source="";
-                        IArchiveFile[] archives= tileProvider.getArchives();
-                        if (archives.length > 0){
-                            //cheating a bit here, get the first archive file and ask for the tile sources names it contains
-                            Set<String> tileSources = archives[0].getTileSources();
-                            //presumably, this would be a great place to tell your users which tiles sources are available
-                            if (!tileSources.isEmpty()) {
-                                //ok good, we found at least one tile source, create a basic file based tile source using that name
-                                //and set it. If we don't set it, osmdroid will attempt to use the default source, which is "MAPNIK",
-                                //which probably won't match your offline tile source, unless it's MAPNIK
-                                source = tileSources.iterator().next();
-                                this.mMapView.setTileSource(FileBasedTileSource.getSource(source));
-                            }
-                            else{
+                            String source = "";
+                            IArchiveFile[] archives = tileProvider.getArchives();
+                            if (archives.length > 0) {
+                                //cheating a bit here, get the first archive file and ask for the tile sources names it contains
+                                Set<String> tileSources = archives[0].getTileSources();
+                                //presumably, this would be a great place to tell your users which tiles sources are available
+                                if (!tileSources.isEmpty()) {
+                                    //ok good, we found at least one tile source, create a basic file based tile source using that name
+                                    //and set it. If we don't set it, osmdroid will attempt to use the default source, which is "MAPNIK",
+                                    //which probably won't match your offline tile source, unless it's MAPNIK
+                                    source = tileSources.iterator().next();
+                                    this.mMapView.setTileSource(FileBasedTileSource.getSource(source));
+                                } else {
+                                    this.mMapView.setTileSource(TileSourceFactory.DEFAULT_TILE_SOURCE);
+                                }
+
+                            } else {
                                 this.mMapView.setTileSource(TileSourceFactory.DEFAULT_TILE_SOURCE);
                             }
 
-                        } else
-                            this.mMapView.setTileSource(TileSourceFactory.DEFAULT_TILE_SOURCE);
-
-                        Toast.makeText(getActivity(), "Using " + list[i].getAbsolutePath() + " " + source, Toast.LENGTH_LONG).show();
-                        this.mMapView.invalidate();
-                        return;
-                    } catch (Exception ex) {
-                        ex.printStackTrace();
+                            Toast.makeText(getActivity(), "Using " + list[i].getAbsolutePath() + " " + source, Toast.LENGTH_LONG).show();
+                            this.mMapView.invalidate();
+                            return;
+                        } catch (Exception ex) {
+                            ex.printStackTrace();
+                        }
                     }
                 }
             }
-            Toast.makeText(getActivity(), f.getAbsolutePath() +  " did not have any files I can open! Try using MOBAC", Toast.LENGTH_LONG).show();
-        } else{
+            Toast.makeText(getActivity(), f.getAbsolutePath() + " did not have any files I can open! Try using MOBAC", Toast.LENGTH_LONG).show();
+        } else {
             Toast.makeText(getActivity(), f.getAbsolutePath() + " dir not found!", Toast.LENGTH_LONG).show();
         }
 

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleWhackyColorFilter.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleWhackyColorFilter.java
@@ -28,7 +28,7 @@ public class SampleWhackyColorFilter extends BaseSampleFragment {
         //this.mMapView.getOverlayManager().getTilesOverlay().setColorFilter(adjustHue(160));
 
         ColorMatrix cm = new ColorMatrix();
-        float brightness =.5f;  // reduce color's by 50%
+        float brightness =.5f;  // reduce color's by 50%. i.e. just make it darker
         cm.set(new float[] {
                 brightness, 0, 0, 0, 0,    //red
                 0, brightness, 0, 0, 0,    //green

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleWithMinimapItemizedOverlayWithScale.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleWithMinimapItemizedOverlayWithScale.java
@@ -132,7 +132,7 @@ public class SampleWithMinimapItemizedOverlayWithScale extends BaseSampleFragmen
 	// Methods from SuperClass/Interfaces
 	// ===========================================================
 
-	/*@Override
+	@Override
 	public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
 		// Put overlay items first
 		mMapView.getOverlayManager().onCreateOptionsMenu(menu, MENU_LAST_ID, mMapView);
@@ -164,7 +164,7 @@ public class SampleWithMinimapItemizedOverlayWithScale extends BaseSampleFragmen
 			return true;
 		}
 		return false;
-	}*/
+	}
 
 	// ===========================================================
 	// Methods

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleWithMinimapItemizedOverlayWithScale.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleWithMinimapItemizedOverlayWithScale.java
@@ -39,7 +39,7 @@ public class SampleWithMinimapItemizedOverlayWithScale extends BaseSampleFragmen
 	// Fields
 	// ===========================================================
 
-	private ItemizedOverlayWithFocus<OverlayItem> mMyLocationOverlay;
+	private ItemizedOverlayWithFocus<OverlayItem> iconOverlay;
 	private RotationGestureOverlay mRotationGestureOverlay;
 
 	@Override
@@ -50,11 +50,8 @@ public class SampleWithMinimapItemizedOverlayWithScale extends BaseSampleFragmen
 	// ===========================================================
 	// Constructors
 	// ===========================================================
-	/** Called when the activity is first created. */
-	@Override
-	public void onActivityCreated(Bundle savedInstanceState) {
-		super.onActivityCreated(savedInstanceState);
-	}
+
+
 
 	@Override
 	protected void addOverlays() {
@@ -82,7 +79,7 @@ public class SampleWithMinimapItemizedOverlayWithScale extends BaseSampleFragmen
 					-122419200))); // San Francisco
 
 			/* OnTapListener for the Markers, shows a simple Toast. */
-			mMyLocationOverlay = new ItemizedOverlayWithFocus<>(items,
+			iconOverlay = new ItemizedOverlayWithFocus<>(items,
 					new ItemizedIconOverlay.OnItemGestureListener<OverlayItem>() {
 						@Override
 						public boolean onItemSingleTapUp(final int index, final OverlayItem item) {
@@ -102,10 +99,10 @@ public class SampleWithMinimapItemizedOverlayWithScale extends BaseSampleFragmen
 							return false;
 						}
 					}, context);
-			mMyLocationOverlay.setFocusItemsOnTap(true);
-			mMyLocationOverlay.setFocusedItem(0);
+			iconOverlay.setFocusItemsOnTap(true);
+			iconOverlay.setFocusedItem(0);
 
-			mMapView.getOverlays().add(mMyLocationOverlay);
+			mMapView.getOverlays().add(iconOverlay);
 
 			mRotationGestureOverlay = new RotationGestureOverlay(context, mMapView);
 			mRotationGestureOverlay.setEnabled(false);
@@ -114,17 +111,17 @@ public class SampleWithMinimapItemizedOverlayWithScale extends BaseSampleFragmen
 
 		/* MiniMap */
 		{
-			MinimapOverlay miniMapOverlay = new MinimapOverlay(context,
-					mMapView.getTileRequestCompleteHandler());
-			mMapView.getOverlays().add(miniMapOverlay);
+			//MinimapOverlay miniMapOverlay = new MinimapOverlay(context,
+			//		mMapView.getTileRequestCompleteHandler());
+			//mMapView.getOverlays().add(miniMapOverlay);
 		}
 
 		// Zoom and center on the focused item.
 		mMapView.getController().setZoom(5);
-        IGeoPoint geoPoint = mMyLocationOverlay.getFocusedItem().getPoint();
+        IGeoPoint geoPoint = iconOverlay.getFocusedItem().getPoint();
 		mMapView.getController().animateTo(geoPoint);
 
-		setHasOptionsMenu(true);
+		setHasOptionsMenu(false);
 	}
 
 	// ===========================================================
@@ -135,7 +132,7 @@ public class SampleWithMinimapItemizedOverlayWithScale extends BaseSampleFragmen
 	// Methods from SuperClass/Interfaces
 	// ===========================================================
 
-	@Override
+	/*@Override
 	public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
 		// Put overlay items first
 		mMapView.getOverlayManager().onCreateOptionsMenu(menu, MENU_LAST_ID, mMapView);
@@ -167,7 +164,7 @@ public class SampleWithMinimapItemizedOverlayWithScale extends BaseSampleFragmen
 			return true;
 		}
 		return false;
-	}
+	}*/
 
 	// ===========================================================
 	// Methods

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/USGSTileSource.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/USGSTileSource.java
@@ -1,0 +1,34 @@
+package org.osmdroid.samplefragments;
+
+import org.osmdroid.tileprovider.MapTile;
+import org.osmdroid.tileprovider.tilesource.OnlineTileSourceBase;
+
+/**
+ * Created by alex on 6/20/16.
+ */
+public class USGSTileSource extends OnlineTileSourceBase {
+
+    public USGSTileSource(){
+        this("USGS Topo", 0, 18, 256, "",
+                new String[] { "http://basemap.nationalmap.gov/ArcGIS/rest/services/USGSTopo/MapServer/tile/"});
+    }
+    /**
+     * Constructor
+     *
+     * @param aName                a human-friendly name for this tile source
+     * @param aZoomMinLevel        the minimum zoom level this tile source can provide
+     * @param aZoomMaxLevel        the maximum zoom level this tile source can provide
+     * @param aTileSizePixels      the tile size in pixels this tile source provides
+     * @param aImageFilenameEnding the file name extension used when constructing the filename
+     * @param aBaseUrl             the base url(s) of the tile server used when constructing the url to download the tiles
+     */
+    public USGSTileSource(String aName, int aZoomMinLevel, int aZoomMaxLevel, int aTileSizePixels, String aImageFilenameEnding, String[] aBaseUrl) {
+        super(aName, aZoomMinLevel, aZoomMaxLevel, aTileSizePixels, aImageFilenameEnding, aBaseUrl);
+    }
+
+    @Override
+    public String getTileURLString(MapTile aTile) {
+        return getBaseUrl() + aTile.getZoomLevel() + "/" + aTile.getY() + "/" + aTile.getX()
+                + mImageFilenameEnding;
+    }
+}

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/models/USGSTileSource.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/models/USGSTileSource.java
@@ -1,4 +1,4 @@
-package org.osmdroid.samplefragments;
+package org.osmdroid.samplefragments.models;
 
 import org.osmdroid.tileprovider.MapTile;
 import org.osmdroid.tileprovider.tilesource.OnlineTileSourceBase;

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/models/package-info.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/models/package-info.java
@@ -1,0 +1,3 @@
+/**
+ * This package's purpose is to contain any support classes, data models, and utilities for the sample fragments
+ */

--- a/osmdroid-android-it/pom.xml
+++ b/osmdroid-android-it/pom.xml
@@ -43,6 +43,10 @@
 	       <type>aar</type>
 	       <scope>provided</scope>
 	  </dependency>
+	 <dependency>
+		 <groupId>com.squareup.leakcanary</groupId>
+		 <artifactId>leakcanary-android</artifactId>
+	 </dependency>
 
      </dependencies>
 

--- a/osmdroid-android-it/src/main/java/org/osmdroid/test/ExtraSamplesTest.java
+++ b/osmdroid-android-it/src/main/java/org/osmdroid/test/ExtraSamplesTest.java
@@ -119,7 +119,7 @@ public class ExtraSamplesTest extends ActivityInstrumentationTestCase2<ExtraSamp
                             .addToBackStack(ExtraSamplesActivity.SAMPLES_FRAGMENT_TAG).commit();
                     //this sleep is here to give the fragment enough time to start up and do something
                     try {
-                        Thread.sleep(4000);
+                        Thread.sleep(1000);
                     } catch (InterruptedException e) {
                         e.printStackTrace();
                     }

--- a/osmdroid-android-it/src/main/java/org/osmdroid/test/ExtraSamplesTest.java
+++ b/osmdroid-android-it/src/main/java/org/osmdroid/test/ExtraSamplesTest.java
@@ -88,7 +88,7 @@ public class ExtraSamplesTest extends ActivityInstrumentationTestCase2<ExtraSamp
         final SampleFactory sampleFactory = SampleFactory.getInstance();
         Log.i(FragmentSamples.TAG, "Memory allocation: INIT Free: " + Runtime.getRuntime().freeMemory() + " Total:" + Runtime.getRuntime().totalMemory() + " Max:" + Runtime.getRuntime().maxMemory());
 
-        for (int i = 21; i < sampleFactory.count(); i++) {
+        for (int i = 0; i < sampleFactory.count(); i++) {
 
             for (int k = 0; k < 100; k++) {
                 Log.i(FragmentSamples.TAG, k + "Memory allocation: Before load: Free: " + Runtime.getRuntime().freeMemory() + " Total:" + Runtime.getRuntime().totalMemory() + " Max:" + Runtime.getRuntime().maxMemory());
@@ -123,7 +123,7 @@ public class ExtraSamplesTest extends ActivityInstrumentationTestCase2<ExtraSamp
                     } catch (InterruptedException e) {
                         e.printStackTrace();
                     }
-                } catch (java.lang.OutOfMemoryError oom) {
+                } catch (Exception oom) {
                     Assert.fail("Error popping fragment " + basefrag.getSampleTitle() + basefrag.getClass().getCanonicalName()+oom);
                 }
 

--- a/osmdroid-android-it/src/main/java/org/osmdroid/test/ExtraSamplesTest.java
+++ b/osmdroid-android-it/src/main/java/org/osmdroid/test/ExtraSamplesTest.java
@@ -90,14 +90,14 @@ public class ExtraSamplesTest extends ActivityInstrumentationTestCase2<ExtraSamp
 
         for (int i = 0; i < sampleFactory.count(); i++) {
 
-            for (int k = 0; k < 100; k++) {
+            for (int k = 0; k < 1; k++) {
                 Log.i(FragmentSamples.TAG, k + "Memory allocation: Before load: Free: " + Runtime.getRuntime().freeMemory() + " Total:" + Runtime.getRuntime().totalMemory() + " Max:" + Runtime.getRuntime().maxMemory());
                 final BaseSampleFragment basefrag = sampleFactory.getSample(i);
                 Log.i(FragmentSamples.TAG, "loading fragment " + basefrag.getSampleTitle() + ", " + frag.getClass().getCanonicalName());
 
                 Counters.printToLogcat();
-                if (Counters.countOOM > 0 || Counters.fileCacheOOM > 0){
-                    Assert.fail("OOM Detected, aborting! this test run was " +  basefrag.getSampleTitle() + ", " + basefrag.getClass().getCanonicalName());
+                if (Counters.countOOM > 0 || Counters.fileCacheOOM > 0) {
+                    Assert.fail("OOM Detected, aborting! this test run was " + basefrag.getSampleTitle() + ", " + basefrag.getClass().getCanonicalName());
                 }
 
 
@@ -111,33 +111,39 @@ public class ExtraSamplesTest extends ActivityInstrumentationTestCase2<ExtraSamp
                     continue;
                 }
                 //if (Build.VERSION.SDK_INT <= 10 && basefrag instanceof SampleGridlines) {
-                  //  continue;
+                //  continue;
                 //}
-
-                try {
-                    fm.beginTransaction().replace(org.osmdroid.R.id.samples_container, basefrag, ExtraSamplesActivity.SAMPLES_FRAGMENT_TAG)
-                            .addToBackStack(ExtraSamplesActivity.SAMPLES_FRAGMENT_TAG).commit();
-                    //this sleep is here to give the fragment enough time to start up and do something
-                    try {
-                        Thread.sleep(1000);
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
-                    }
-                } catch (Exception oom) {
-                    Assert.fail("Error popping fragment " + basefrag.getSampleTitle() + basefrag.getClass().getCanonicalName()+oom);
-                }
 
                 activity.runOnUiThread(new Runnable() {
                     @Override
                     public void run() {
                         try {
-                            fm.popBackStackImmediate();
-                        } catch (java.lang.Exception oom) {
-                //            Assert.fail("Error popping fragment " + basefrag.getSampleTitle() + basefrag.getClass().getCanonicalName()+oom);
+                            fm.beginTransaction().replace(org.osmdroid.R.id.samples_container, basefrag, ExtraSamplesActivity.SAMPLES_FRAGMENT_TAG)
+                                    .addToBackStack(ExtraSamplesActivity.SAMPLES_FRAGMENT_TAG).commit();
+                            fm.executePendingTransactions();
+                            //this sleep is here to give the fragment enough time to start up and do something
+
+                        } catch (Exception oom) {
+                            Assert.fail("Error popping fragment " + basefrag.getSampleTitle() + basefrag.getClass().getCanonicalName() + oom);
                         }
+
                     }
                 });
-
+                try {
+                    Thread.sleep(5000);
+                    activity.runOnUiThread(new Runnable() {
+                        @Override
+                        public void run() {
+                            try {
+                                fm.popBackStackImmediate();
+                            } catch (java.lang.Exception oom) {
+                                //            Assert.fail("Error popping fragment " + basefrag.getSampleTitle() + basefrag.getClass().getCanonicalName()+oom);
+                            }
+                        }
+                    });
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
 
 
                 System.gc();

--- a/osmdroid-android-it/src/main/java/org/osmdroid/test/ExtraSamplesTest.java
+++ b/osmdroid-android-it/src/main/java/org/osmdroid/test/ExtraSamplesTest.java
@@ -19,13 +19,14 @@ import junit.framework.Assert;
 
 import org.osmdroid.ExtraSamplesActivity;
 import org.osmdroid.samplefragments.*;
+import org.osmdroid.tileprovider.util.Counters;
 
 public class ExtraSamplesTest extends ActivityInstrumentationTestCase2<ExtraSamplesActivity> {
 
     public ExtraSamplesTest() {
         super("org.osmdroid", ExtraSamplesActivity.class);
     }
-
+/*
     public void testActivity() {
         //if (Build.VERSION.SDK_INT == 10)
         //    return; //FIXME dirty fix for travis ci
@@ -39,7 +40,10 @@ public class ExtraSamplesTest extends ActivityInstrumentationTestCase2<ExtraSamp
         //FragmentSamples samples = (FragmentSamples) frag;
 
         SampleFactory sampleFactory = SampleFactory.getInstance();
+        long startFree= Runtime.getRuntime().freeMemory();
+        Log.i(FragmentSamples.TAG, "Memory allocation: INIT Free: " + Runtime.getRuntime().freeMemory() +" Total:" + Runtime.getRuntime().totalMemory() +" Max:"+ Runtime.getRuntime().maxMemory());
         for (int i = 0; i < sampleFactory.count(); i++) {
+            Log.i(FragmentSamples.TAG, "Memory allocation: Before load: Free: " + Runtime.getRuntime().freeMemory() +" Total:" + Runtime.getRuntime().totalMemory() +" Max:"+ Runtime.getRuntime().maxMemory());
             BaseSampleFragment basefrag = sampleFactory.getSample(i);
             Log.i(FragmentSamples.TAG, "loading fragment " + basefrag.getSampleTitle() + ", " + frag.getClass().getCanonicalName());
             if (Build.VERSION.SDK_INT == 10 && basefrag instanceof SampleJumboCache)
@@ -63,6 +67,81 @@ public class ExtraSamplesTest extends ActivityInstrumentationTestCase2<ExtraSamp
                 }
             } catch (java.lang.OutOfMemoryError oom) {
                 Assert.fail("OOM error! " + sampleFactory.getSample(i).getSampleTitle() + sampleFactory.getSample(i).getClass().getCanonicalName());
+            }
+            System.gc();
+            Log.i(FragmentSamples.TAG, "Memory allocation: END Free: " + Runtime.getRuntime().freeMemory() +" Total:" + Runtime.getRuntime().totalMemory() +" Max:"+ Runtime.getRuntime().maxMemory());
+        }
+    }
+
+*/
+
+    public void testActivity() {
+        final ExtraSamplesActivity activity = getActivity();
+        assertNotNull(activity);
+        final FragmentManager fm = activity.getSupportFragmentManager();
+        Fragment frag = (fm.findFragmentByTag(ExtraSamplesActivity.SAMPLES_FRAGMENT_TAG));
+        assertNotNull(frag);
+
+        assertTrue(frag instanceof FragmentSamples);
+        //FragmentSamples samples = (FragmentSamples) frag;
+
+        final SampleFactory sampleFactory = SampleFactory.getInstance();
+        Log.i(FragmentSamples.TAG, "Memory allocation: INIT Free: " + Runtime.getRuntime().freeMemory() + " Total:" + Runtime.getRuntime().totalMemory() + " Max:" + Runtime.getRuntime().maxMemory());
+
+        for (int i = 21; i < sampleFactory.count(); i++) {
+
+            for (int k = 0; k < 100; k++) {
+                Log.i(FragmentSamples.TAG, k + "Memory allocation: Before load: Free: " + Runtime.getRuntime().freeMemory() + " Total:" + Runtime.getRuntime().totalMemory() + " Max:" + Runtime.getRuntime().maxMemory());
+                final BaseSampleFragment basefrag = sampleFactory.getSample(i);
+                Log.i(FragmentSamples.TAG, "loading fragment " + basefrag.getSampleTitle() + ", " + frag.getClass().getCanonicalName());
+
+                Counters.printToLogcat();
+                if (Counters.countOOM > 0 || Counters.fileCacheOOM > 0){
+                    Assert.fail("OOM Detected, aborting! this test run was " +  basefrag.getSampleTitle() + ", " + basefrag.getClass().getCanonicalName());
+                }
+
+
+                if (Build.VERSION.SDK_INT <= 10 && basefrag instanceof SampleJumboCache) {
+                    continue;
+                }
+                if (Build.VERSION.SDK_INT <= 10 && basefrag instanceof SampleOsmPath) {
+                    continue;
+                }
+                if (Build.VERSION.SDK_INT <= 10 && basefrag instanceof SampleMilitaryIcons) {
+                    continue;
+                }
+                //if (Build.VERSION.SDK_INT <= 10 && basefrag instanceof SampleGridlines) {
+                  //  continue;
+                //}
+
+                try {
+                    fm.beginTransaction().replace(org.osmdroid.R.id.samples_container, basefrag, ExtraSamplesActivity.SAMPLES_FRAGMENT_TAG)
+                            .addToBackStack(ExtraSamplesActivity.SAMPLES_FRAGMENT_TAG).commit();
+                    //this sleep is here to give the fragment enough time to start up and do something
+                    try {
+                        Thread.sleep(4000);
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                } catch (java.lang.OutOfMemoryError oom) {
+                    Assert.fail("Error popping fragment " + basefrag.getSampleTitle() + basefrag.getClass().getCanonicalName()+oom);
+                }
+
+                activity.runOnUiThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            fm.popBackStackImmediate();
+                        } catch (java.lang.Exception oom) {
+                //            Assert.fail("Error popping fragment " + basefrag.getSampleTitle() + basefrag.getClass().getCanonicalName()+oom);
+                        }
+                    }
+                });
+
+
+
+                System.gc();
+                Log.i(FragmentSamples.TAG, "Memory allocation: END Free: " + Runtime.getRuntime().freeMemory() + " Total:" + Runtime.getRuntime().totalMemory() + " Max:" + Runtime.getRuntime().maxMemory());
             }
         }
     }

--- a/osmdroid-android-it/src/main/java/org/osmdroid/test/MainActivityTest.java
+++ b/osmdroid-android-it/src/main/java/org/osmdroid/test/MainActivityTest.java
@@ -7,8 +7,9 @@
  */
 package org.osmdroid.test;
 
+import org.junit.Assert;
 import org.osmdroid.MainActivity;
-
+import org.osmdroid.tileprovider.util.Counters;
 import android.test.ActivityInstrumentationTestCase2;
 
 public class MainActivityTest extends ActivityInstrumentationTestCase2<MainActivity> {
@@ -18,8 +19,14 @@ public class MainActivityTest extends ActivityInstrumentationTestCase2<MainActiv
     }
 
     public void testActivity() {
+        Counters.reset();
         MainActivity activity = getActivity();
         assertNotNull(activity);
+        Counters.printToLogcat();
+        if (Counters.countOOM > 0 || Counters.fileCacheOOM > 0){
+            Assert.fail("OOM Detected, aborting!");
+        }
+        activity.finish();
     }
 }
 

--- a/osmdroid-android-it/src/main/java/org/osmdroid/test/MapActivityTest.java
+++ b/osmdroid-android-it/src/main/java/org/osmdroid/test/MapActivityTest.java
@@ -8,8 +8,11 @@
 package org.osmdroid.test;
 
 import org.osmdroid.StarterMapActivity;
+import org.osmdroid.tileprovider.util.Counters;
 
 import android.test.ActivityInstrumentationTestCase2;
+
+import junit.framework.Assert;
 
 public class MapActivityTest extends ActivityInstrumentationTestCase2<StarterMapActivity> {
 
@@ -20,6 +23,15 @@ public class MapActivityTest extends ActivityInstrumentationTestCase2<StarterMap
     public void testActivity() {
         StarterMapActivity activity = getActivity();
         assertNotNull(activity);
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException e) {
+        }
+        Counters.printToLogcat();
+        if (Counters.countOOM > 0 || Counters.fileCacheOOM > 0){
+            Assert.fail("OOM Detected, aborting!");
+        }
+        activity.finish();
     }
 }
 

--- a/osmdroid-android-it/src/main/java/org/osmdroid/test/MapActivityTest.java
+++ b/osmdroid-android-it/src/main/java/org/osmdroid/test/MapActivityTest.java
@@ -9,7 +9,6 @@ package org.osmdroid.test;
 
 import org.osmdroid.StarterMapActivity;
 import org.osmdroid.tileprovider.util.Counters;
-
 import android.test.ActivityInstrumentationTestCase2;
 
 import junit.framework.Assert;
@@ -21,6 +20,7 @@ public class MapActivityTest extends ActivityInstrumentationTestCase2<StarterMap
     }
 
     public void testActivity() {
+        Counters.reset();
         StarterMapActivity activity = getActivity();
         assertNotNull(activity);
         try {

--- a/osmdroid-android-it/src/main/java/org/osmdroid/tileprovider/modules/MapTileProviderTest.java
+++ b/osmdroid-android-it/src/main/java/org/osmdroid/tileprovider/modules/MapTileProviderTest.java
@@ -137,9 +137,13 @@ public class MapTileProviderTest extends AndroidTestCase {
 				new MapTileModuleProviderBase[] {}, mTileProviderCallback);
 		mTileProvider.loadMapTileAsync(state3);
 
-		// wait 4 seconds (because it takes 1 second for each tile + an extra
+		// wait up to 10 seconds (because it takes 1 second for each tile + an extra
 		// second)
-		Thread.sleep(4000);
+
+		long timeout=System.currentTimeMillis()+10000;
+		while (3 != mTiles.size() && System.currentTimeMillis() < timeout){
+			Thread.sleep(250);
+		}
 
 		// check that there are three tiles in the list (ie no duplicates)
 		assertEquals("Three tiles in the list", 3, mTiles.size());
@@ -179,9 +183,12 @@ public class MapTileProviderTest extends AndroidTestCase {
 				new MapTileModuleProviderBase[] {}, mTileProviderCallback);
 		mTileProvider.loadMapTileAsync(state4);
 
-		// wait 4 seconds (because it takes 1 second for each tile + an extra
+		// wait up to 10 seconds (because it takes 1 second for each tile + an extra
 		// second)
-		Thread.sleep(4000);
+		long timeout=System.currentTimeMillis()+10000;
+		while (3 != mTiles.size() && System.currentTimeMillis() < timeout){
+			Thread.sleep(250);
+		}
 
 		// check that there are three tiles in the list (ie no duplicates)
 		assertEquals("Three tiles in the list", 3, mTiles.size());

--- a/osmdroid-android-it/src/main/java/org/osmdroid/views/OpenStreetMapViewTest.java
+++ b/osmdroid-android-it/src/main/java/org/osmdroid/views/OpenStreetMapViewTest.java
@@ -12,7 +12,7 @@ import org.osmdroid.StarterMapFragment;
 import org.osmdroid.R;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.Projection;
-
+import org.osmdroid.tileprovider.util.Counters;
 import android.graphics.Point;
 import android.test.ActivityInstrumentationTestCase2;
 import android.test.UiThreadTest;
@@ -26,6 +26,7 @@ public class OpenStreetMapViewTest extends ActivityInstrumentationTestCase2<Star
 
 	public OpenStreetMapViewTest() {
         super(StarterMapActivity.class);
+		Counters.reset();
     }
 	
 	private MapView mOpenStreetMapView;

--- a/osmdroid-android-it/src/main/java/org/osmdroid/views/util/OpenStreetMapTileProviderDirectTest.java
+++ b/osmdroid-android-it/src/main/java/org/osmdroid/views/util/OpenStreetMapTileProviderDirectTest.java
@@ -33,9 +33,11 @@ import android.os.Environment;
 import android.os.RemoteException;
 import android.test.AndroidTestCase;
 
+import junit.framework.Assert;
+
 /**
  * @author Neil Boyd
- * 
+ *
  */
 public class OpenStreetMapTileProviderDirectTest extends AndroidTestCase {
 
@@ -68,11 +70,17 @@ public class OpenStreetMapTileProviderDirectTest extends AndroidTestCase {
 		final Bitmap bitmap1 = Bitmap.createBitmap(60, 30, Config.ARGB_8888);
 		bitmap1.eraseColor(Color.YELLOW);
 		final Canvas canvas = new Canvas(bitmap1);
-		canvas.drawText("test", 10, 20, new Paint());
-		final FileOutputStream fos = new FileOutputStream(path);
-		bitmap1.compress(CompressFormat.JPEG, 100, fos);
-		fos.close();
 
+		canvas.drawText("test", 10, 20, new Paint());
+		try {
+			f.createNewFile();
+			final FileOutputStream fos = new FileOutputStream(path);
+			bitmap1.compress(CompressFormat.JPEG, 100, fos);
+			fos.close();
+		}catch (Exception ex){
+			ex.printStackTrace();
+			Assert.fail("unable to write temp tile " + ex);
+		}
 		final MapTileRequestState state = new MapTileRequestState(tile,
 				new MapTileModuleProviderBase[] {}, mProvider);
 		mProvider.mapTileRequestCompleted(state, TileSourceFactory.MAPNIK.getDrawable(path));

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/IRegisterReceiver.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/IRegisterReceiver.java
@@ -9,4 +9,6 @@ public interface IRegisterReceiver {
 	Intent registerReceiver(BroadcastReceiver receiver, IntentFilter filter);
 
 	void unregisterReceiver(BroadcastReceiver receiver);
+
+	void destroy();
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderArray.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderArray.java
@@ -32,7 +32,7 @@ import org.osmdroid.tileprovider.constants.OpenStreetMapTileProviderConstants;
 public class MapTileProviderArray extends MapTileProviderBase {
 
 	protected final HashMap<MapTile, MapTileRequestState> mWorking;
-
+	protected IRegisterReceiver mRegisterReceiver=null;
 	protected final List<MapTileModuleProviderBase> mTileProviderList;
 
 	/**
@@ -60,7 +60,7 @@ public class MapTileProviderArray extends MapTileProviderBase {
 		super(pTileSource);
 
 		mWorking = new HashMap<MapTile, MapTileRequestState>();
-
+		mRegisterReceiver=aRegisterReceiver;
 		mTileProviderList = new ArrayList<MapTileModuleProviderBase>();
 		Collections.addAll(mTileProviderList, pTileProviderArray);
 	}
@@ -75,6 +75,11 @@ public class MapTileProviderArray extends MapTileProviderBase {
 
 		synchronized (mWorking) {
 			mWorking.clear();
+		}
+		clearTileCache();
+		if (mRegisterReceiver!=null) {
+			mRegisterReceiver.destroy();
+			mRegisterReceiver = null;
 		}
 
 	}

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderArray.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderArray.java
@@ -76,6 +76,7 @@ public class MapTileProviderArray extends MapTileProviderBase {
 		synchronized (mWorking) {
 			mWorking.clear();
 		}
+
 	}
 
 	@Override

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderBase.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderBase.java
@@ -196,6 +196,9 @@ public abstract class MapTileProviderBase implements IMapTileProviderCallback {
 		mTileCache.ensureCapacity(pCapacity);
 	}
 
+	/**
+	 * purges the cache of all tiles (default is the in memory cache)
+	 */
 	public void clearTileCache() {
 		mTileCache.clear();
 	}

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/ArchiveFileFactory.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/ArchiveFileFactory.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
+import android.os.Build;
 import android.util.Log;
 import org.osmdroid.api.IMapView;
 
@@ -12,9 +13,11 @@ public class ArchiveFileFactory {
 	static Map<String, Class<? extends IArchiveFile> > extensionMap = new HashMap<String,  Class<? extends IArchiveFile>>();
 	static {
 		extensionMap.put("zip", ZipFileArchive.class);
-		extensionMap.put("sqlite", DatabaseFileArchive.class);
-		extensionMap.put("mbtiles", MBTilesFileArchive.class);
-		extensionMap.put("gemf", GEMFFileArchive.class);
+		if (Build.VERSION.SDK_INT >= 10) {
+			extensionMap.put("sqlite", DatabaseFileArchive.class);
+			extensionMap.put("mbtiles", MBTilesFileArchive.class);
+			extensionMap.put("gemf", GEMFFileArchive.class);
+		}
 
 	}
 

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/IFilesystemCache.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/IFilesystemCache.java
@@ -26,4 +26,11 @@ public interface IFilesystemCache {
 	 */
 	boolean saveFile(final ITileSource pTileSourceInfo, MapTile pTile,
 			final InputStream pStream);
+
+	/**
+	 * Used when the map engine is shutdown, use it to perform any clean up activities and to terminate
+	 * any background threads
+	 * @since 5.3
+	 */
+	void onDetach();
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileFilesystemProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileFilesystemProvider.java
@@ -21,6 +21,7 @@ import android.graphics.drawable.Drawable;
 import android.util.Log;
 import org.osmdroid.api.IMapView;
 import org.osmdroid.tileprovider.constants.OpenStreetMapTileProviderConstants;
+import org.osmdroid.tileprovider.util.Counters;
 
 /**
  * Implements a file system cache and provides cached tiles. This functions as a tile provider by
@@ -41,7 +42,6 @@ public class MapTileFilesystemProvider extends MapTileFileStorageProviderBase {
 	// ===========================================================
 
 	private final long mMaximumCachedFileAge;
-	private DatabaseFileArchive databaseFileArchive;
 	private final AtomicReference<ITileSource> mTileSource = new AtomicReference<ITileSource>();
 
 	// ===========================================================
@@ -145,6 +145,7 @@ public class MapTileFilesystemProvider extends MapTileFileStorageProviderBase {
 				if (OpenStreetMapTileProviderConstants.DEBUGMODE) {
                          Log.d(IMapView.LOGTAG,"No sdcard - do nothing for tile: " + tile);
 				}
+				Counters.fileCacheMiss++;
 				return null;
 			}
 
@@ -169,14 +170,16 @@ public class MapTileFilesystemProvider extends MapTileFileStorageProviderBase {
 						ExpirableBitmapDrawable.setDrawableExpired(drawable);
 					}
 
+					Counters.fileCacheHit++;
 					return drawable;
 				} catch (final LowMemoryException e) {
 					// low memory so empty the queue
 					Log.w(IMapView.LOGTAG,"LowMemoryException downloading MapTile: " + tile + " : " + e);
+					Counters.fileCacheOOM++;
 					throw new CantContinueException(e);
 				}
 			}
-
+			Counters.fileCacheMiss++;
 			// If we get here then there is no file in the file cache
 			return null;
 		}

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileModuleProviderBase.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileModuleProviderBase.java
@@ -165,6 +165,7 @@ public abstract class MapTileModuleProviderBase {
 	public void detach() {
 		this.clearQueue();
 		this.mExecutor.shutdown();
+
 	}
 
 	void removeTileFromQueues(final MapTile mapTile) {

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/OfflineTileProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/OfflineTileProvider.java
@@ -49,4 +49,13 @@ public class OfflineTileProvider extends MapTileProviderArray implements IMapTil
 	public IArchiveFile[] getArchives(){
 		return archives;
 	}
+
+	public void detach() {
+		if (archives!=null){
+			for (int i=0; i < archives.length; i++){
+				archives[i].close();
+			}
+		}
+		super.detach();
+	}
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/SqlTileWriter.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/SqlTileWriter.java
@@ -13,7 +13,6 @@ import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 /**
@@ -28,8 +27,8 @@ import java.util.List;
  * @since 5.1
  */
 public class SqlTileWriter implements IFilesystemCache {
-    final File db_file;
-    final SQLiteDatabase db;
+    protected File db_file;
+    protected SQLiteDatabase db;
     final int questimate=8000;
 
     public SqlTileWriter() {
@@ -111,5 +110,17 @@ public class SqlTileWriter implements IFilesystemCache {
             Log.e(IMapView.LOGTAG, "Unable to store cached tile from " + pTileSourceInfo.name() + " " + pTile.toString(), ex);
         }
         return false;
+    }
+
+    @Override
+    public void onDetach() {
+        if (db != null && db.isOpen()) {
+            try {
+                db.close();
+            } catch (Exception ex) {
+            }
+        }
+        db = null;
+        db_file = null;
     }
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/BitmapTileSourceBase.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/BitmapTileSourceBase.java
@@ -10,6 +10,7 @@ import org.osmdroid.api.IMapView;
 import org.osmdroid.tileprovider.BitmapPool;
 import org.osmdroid.tileprovider.MapTile;
 import org.osmdroid.tileprovider.ReusableBitmapDrawable;
+import org.osmdroid.tileprovider.util.Counters;
 
 import java.io.File;
 import java.io.InputStream;
@@ -119,6 +120,7 @@ public abstract class BitmapTileSourceBase implements ITileSource {
 			throw new LowMemoryException(e);
 		} catch (final Exception e){
 			Log.e(IMapView.LOGTAG,"Unexpected error loading bitmap: " + aFilePath,e);
+			Counters.tileDownloadErrors++;
 			System.gc();
 		}
 		return null;
@@ -157,7 +159,7 @@ public abstract class BitmapTileSourceBase implements ITileSource {
 		return null;
 	}
 
-	public final class LowMemoryException extends Exception {
+	public static final class LowMemoryException extends Exception {
 		private static final long serialVersionUID = 146526524087765134L;
 
 		public LowMemoryException(final String pDetailMessage) {

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/Counters.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/Counters.java
@@ -1,0 +1,34 @@
+package org.osmdroid.tileprovider.util;
+
+import android.util.Log;
+
+/**
+ * The counters class is a simple container for tracking various internal statistics for osmdroid,
+ * useful for troubleshooting osmdroid, finding memory leaks and more
+ * Created by alex on 6/16/16.
+ */
+public class Counters {
+    static final String TAG="osmCounters";
+    /**
+     * out of memory errors
+     */
+    public static int countOOM =0;
+
+    public static int tileDownloadErrors=0;
+
+    public static int fileCacheSaveErrors=0;
+
+    public static int fileCacheMiss=0;
+
+    public static int fileCacheOOM=0;
+    public static int fileCacheHit=0;
+
+    public static void printToLogcat() {
+        Log.d(TAG, "countOOM " + countOOM);
+        Log.d(TAG, "tileDownloadErrors " + tileDownloadErrors);
+        Log.d(TAG, "fileCacheSaveErrors " + fileCacheSaveErrors);
+        Log.d(TAG, "fileCacheMiss " + fileCacheMiss);
+        Log.d(TAG, "fileCacheOOM " + fileCacheOOM);
+        Log.d(TAG, "fileCacheHit " + fileCacheHit);
+    }
+}

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/Counters.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/Counters.java
@@ -31,4 +31,12 @@ public class Counters {
         Log.d(TAG, "fileCacheOOM " + fileCacheOOM);
         Log.d(TAG, "fileCacheHit " + fileCacheHit);
     }
+    public static void reset(){
+        countOOM =0;
+        tileDownloadErrors=0;
+        fileCacheSaveErrors=0;
+        fileCacheMiss=0;
+        fileCacheOOM=0;
+        fileCacheHit=0;
+    }
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/SimpleRegisterReceiver.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/SimpleRegisterReceiver.java
@@ -9,7 +9,7 @@ import android.content.IntentFilter;
 
 public class SimpleRegisterReceiver implements IRegisterReceiver {
 
-	private final Context mContext;
+	private Context mContext;
 
 	public SimpleRegisterReceiver(final Context pContext) {
 		super();
@@ -24,5 +24,10 @@ public class SimpleRegisterReceiver implements IRegisterReceiver {
 	@Override
 	public void unregisterReceiver(final BroadcastReceiver aReceiver) {
 		mContext.unregisterReceiver(aReceiver);
+	}
+
+	@Override
+	public void destroy() {
+		mContext=null;
 	}
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
@@ -768,6 +768,7 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
 	public void onDetach() {
 		this.getOverlayManager().onDetach(this);
 		mTileProvider.detach();
+		mTileProvider.clearTileCache();
 		mZoomController.setVisible(false);
 	}
 

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/FolderOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/FolderOverlay.java
@@ -111,7 +111,8 @@ public class FolderOverlay extends Overlay {
 
 	@Override
 	public void onDetach(MapView mapView){
-		mOverlayManager.onDetach(mapView);
+		if (mOverlayManager!=null)
+			mOverlayManager.onDetach(mapView);
 		mOverlayManager=null;
 	}
 

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/FolderOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/FolderOverlay.java
@@ -109,4 +109,9 @@ public class FolderOverlay extends Overlay {
 		}
 	}
 
+	@Override
+	public void onDetach(MapView mapView){
+		mOverlayManager=null;
+	}
+
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/ItemizedIconOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/ItemizedIconOverlay.java
@@ -49,6 +49,8 @@ public class ItemizedIconOverlay<Item extends OverlayItem> extends ItemizedOverl
 
 	@Override
 	public void onDetach(MapView mapView){
+		if (mItemList!=null)
+			mItemList.clear();
 		mItemList=null;
 		mOnItemGestureListener=null;
 	}

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/ItemizedIconOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/ItemizedIconOverlay.java
@@ -14,7 +14,7 @@ import android.view.MotionEvent;
 
 public class ItemizedIconOverlay<Item extends OverlayItem> extends ItemizedOverlay<Item> {
 
-	protected final List<Item> mItemList;
+	protected List<Item> mItemList;
 	protected OnItemGestureListener<Item> mOnItemGestureListener;
 	private int mDrawnItemsLimit = Integer.MAX_VALUE;
 	private final Point mItemPoint = new Point();
@@ -45,6 +45,12 @@ public class ItemizedIconOverlay<Item extends OverlayItem> extends ItemizedOverl
 			final org.osmdroid.views.overlay.ItemizedIconOverlay.OnItemGestureListener<Item> pOnItemGestureListener) {
 		this(pList,  pContext.getResources().getDrawable(R.drawable.marker_default),
 				pOnItemGestureListener,pContext);
+	}
+
+	@Override
+	public void onDetach(MapView mapView){
+		mItemList=null;
+		mOnItemGestureListener=null;
 	}
 
 	@Override

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/ItemizedOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/ItemizedOverlay.java
@@ -86,6 +86,12 @@ public abstract class ItemizedOverlay<Item extends OverlayItem> extends Overlay 
 	// Methods from SuperClass/Interfaces (and supporting methods)
 	// ===========================================================
 
+	@Override
+	public void onDetach(MapView mapView){
+		if (mDefaultMarker!=null){
+			//release the bitmap
+		}
+	}
 	/**
 	 * Draw a marker on each of our items. populate() must have been called first.<br>
 	 * <br>

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/ItemizedOverlayWithFocus.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/ItemizedOverlayWithFocus.java
@@ -355,6 +355,12 @@ public class ItemizedOverlayWithFocus<Item extends OverlayItem> extends Itemized
 		Overlay.drawAt(c, markerFocusedBase, mFocusedScreenCoords.x, mFocusedScreenCoords.y, false, osmv.getMapOrientation());
 	}
 
+	@Override
+	public void onDetach(MapView mapView){
+		super.onDetach(mapView);
+		this.mContext=null;
+	}
+
 	// ===========================================================
 	// Methods
 	// ===========================================================

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/ItemizedOverlayWithFocus.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/ItemizedOverlayWithFocus.java
@@ -240,6 +240,9 @@ public class ItemizedOverlayWithFocus<Item extends OverlayItem> extends Itemized
 			return;
 		}
 
+		// this happens during shutdown
+		if (super.mItemList==null)
+			return;
 		// get focused item's preferred marker & hotspot
 		final Item focusedItem = super.mItemList.get(this.mFocusedItemIndex);
 		Drawable markerFocusedBase = focusedItem.getMarker(OverlayItem.ITEM_STATE_FOCUSED_MASK);

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Marker.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Marker.java
@@ -11,6 +11,7 @@ import android.graphics.Rect;
 import android.graphics.Typeface;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.view.MotionEvent;
 
 import org.osmdroid.library.R;
@@ -76,7 +77,7 @@ public class Marker extends OverlayWithIW {
 	protected Point mPositionPixels;
 	protected static MarkerInfoWindow mDefaultInfoWindow = null;
 	protected static Drawable mDefaultIcon = null; //cache for default icon (resourceProxy.getDrawable being slow)
-	final Resources resource;
+	protected Resources resource;
 
 	/** Usual values in the (U,V) coordinates system of the icon image */
 	public static final float ANCHOR_CENTER=0.5f, ANCHOR_LEFT=0.0f, ANCHOR_TOP=0.0f, ANCHOR_RIGHT=1.0f, ANCHOR_BOTTOM=1.0f;
@@ -292,9 +293,37 @@ public class Marker extends OverlayWithIW {
     /** Null out the static references when the MapView is detached to prevent memory leaks. */
 	@Override
 	public void onDetach(MapView mapView) {
+
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.GINGERBREAD) {
+			if (mIcon instanceof BitmapDrawable) {
+				final Bitmap bitmap = ((BitmapDrawable) mIcon).getBitmap();
+				if (bitmap != null) {
+					bitmap.recycle();
+				}
+			}
+		}
+		mIcon=null;
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.GINGERBREAD) {
+			if (mImage instanceof BitmapDrawable) {
+				final Bitmap bitmap = ((BitmapDrawable) mImage).getBitmap();
+				if (bitmap != null) {
+					bitmap.recycle();
+				}
+			}
+		}
 		cleanDefaults();
+		this.mOnMarkerClickListener=null;
+		this.mOnMarkerDragListener=null;
+		this.resource=null;
+		setRelatedObject(null);
+		closeInfoWindow();
+		onDestroy();
+
+
         super.onDetach(mapView);
     }
+
+
 
 	/**
 	 * reference https://github.com/MKergall/osmbonuspack/pull/210

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/OverlayWithIW.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/OverlayWithIW.java
@@ -81,6 +81,15 @@ public abstract class OverlayWithIW extends Overlay {
 			mInfoWindow.close();
 	}
 
+	public void onDestroy(){
+		if (mInfoWindow != null) {
+			mInfoWindow.close();
+			mInfoWindow.onDetach();
+			mInfoWindow=null;
+			mRelatedObject=null;
+		}
+	}
+
 	public boolean isInfoWindowOpen(){
 		return (mInfoWindow != null) && mInfoWindow.isOpen();
 	}

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polygon.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polygon.java
@@ -314,4 +314,11 @@ public class Polygon extends OverlayWithIW {
 		return tapped;
 	}
 
+	@Override
+	public void onDetach(MapView mapView) {
+		mOutline=null;
+		mHoles.clear();
+		onDestroy();
+	}
+
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polyline.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polyline.java
@@ -491,4 +491,10 @@ public class Polyline extends OverlayWithIW {
 		return true;
 	}
 
+	@Override
+	public void onDetach(MapView mapView) {
+		mOnClickListener=null;
+		onDestroy();
+	}
+
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/ScaleBarOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/ScaleBarOverlay.java
@@ -253,24 +253,24 @@ public class ScaleBarOverlay extends Overlay implements GeoConstants {
 	 * @param centred
 	 *            set true to centre the bar around the given screen coordinates
 	 */
-public void setCentred(final boolean centred) {
-    this.centred = centred;
-    alignBottom  = !centred;
-    alignRight   = !centred;
-    lastZoomLevel = -1; // Force redraw of scalebar
-}
+	public void setCentred(final boolean centred) {
+		this.centred = centred;
+		alignBottom  = !centred;
+		alignRight   = !centred;
+		lastZoomLevel = -1; // Force redraw of scalebar
+	}
 
-public void setAlignBottom(final boolean alignBottom) {
-    this.centred = false;
-    this.alignBottom  = alignBottom;
-    lastZoomLevel = -1; // Force redraw of scalebar
-}
+	public void setAlignBottom(final boolean alignBottom) {
+		this.centred = false;
+		this.alignBottom  = alignBottom;
+		lastZoomLevel = -1; // Force redraw of scalebar
+	}
 
-public void setAlignRight(final boolean alignRight) {
-    this.centred = false;
-    this.alignRight  = alignRight;
-    lastZoomLevel = -1; // Force redraw of scalebar
-}
+	public void setAlignRight(final boolean alignRight) {
+		this.centred = false;
+		this.alignRight  = alignRight;
+		lastZoomLevel = -1; // Force redraw of scalebar
+	}
 	/**
 	 * Return's the paint used to draw the bar
 	 * 
@@ -687,6 +687,9 @@ public void setAlignRight(final boolean alignRight) {
 	public void onDetach(MapView mapView){
 		this.context=null;
 		this.mMapView=null;
+		barPaint=null;
+		bgPaint=null;
+		textPaint=null;
 	}
 
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/ScaleBarOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/ScaleBarOverlay.java
@@ -31,6 +31,7 @@ package org.osmdroid.views.overlay;
  */
 
 import java.lang.reflect.Field;
+import java.util.Map;
 
 import org.osmdroid.api.IGeoPoint;
 import org.osmdroid.library.R;
@@ -77,8 +78,8 @@ public class ScaleBarOverlay extends Overlay implements GeoConstants {
 
 	// Internal
 
-	private final Context context;
-	private final MapView mMapView;
+	private Context context;
+	private MapView mMapView;
 
 	protected final Path barPath = new Path();
 	protected final Rect latitudeBarRect = new Rect();
@@ -680,6 +681,12 @@ public void setAlignRight(final boolean alignRight) {
 						((int) (meters * FEET_PER_METER)));
 			}
 		}
+	}
+
+	@Override
+	public void onDetach(MapView mapView){
+		this.context=null;
+		this.mMapView=null;
 	}
 
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/TilesOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/TilesOverlay.java
@@ -96,6 +96,7 @@ public class TilesOverlay extends Overlay implements IOverlayMenuProvider {
 	@Override
 	public void onDetach(final MapView pMapView) {
 		this.mTileProvider.detach();
+		ctx=null;
 	}
 
 	public int getMinimumZoomLevel() {

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/TilesOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/TilesOverlay.java
@@ -255,12 +255,13 @@ public class TilesOverlay extends Overlay implements IOverlayMenuProvider {
 		}
 		mapMenu.setGroupCheckable(MENU_MAP_MODE + pMenuIdOffset, true, true);
 
-		final String title = ctx.getString(
-				pMapView.useDataConnection() ? R.string.set_mode_offline
-						: R.string.set_mode_online);
-		final Drawable icon = ctx.getResources().getDrawable(R.drawable.ic_menu_offline);
-		pMenu.add(0, MENU_OFFLINE + pMenuIdOffset, Menu.NONE, title).setIcon(icon);
-
+		if (ctx!=null) {
+			final String title = ctx.getString(
+					pMapView.useDataConnection() ? R.string.set_mode_offline
+							: R.string.set_mode_online);
+			final Drawable icon = ctx.getResources().getDrawable(R.drawable.ic_menu_offline);
+			pMenu.add(0, MENU_OFFLINE + pMenuIdOffset, Menu.NONE, title).setIcon(icon);
+		}
 		return true;
 	}
 

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/compass/CompassOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/compass/CompassOverlay.java
@@ -31,8 +31,8 @@ import android.view.WindowManager;
  * 
  */
 public class CompassOverlay extends Overlay implements IOverlayMenuProvider, IOrientationConsumer {
-	private static final Paint sSmoothPaint = new Paint(Paint.FILTER_BITMAP_FLAG);
-	protected final MapView mMapView;
+	private Paint sSmoothPaint = new Paint(Paint.FILTER_BITMAP_FLAG);
+	protected MapView mMapView;
 	private final Display mDisplay;
 
 	public IOrientationProvider mOrientationProvider;
@@ -91,7 +91,11 @@ public class CompassOverlay extends Overlay implements IOverlayMenuProvider, IOr
 
 	@Override
 	public void onDetach(MapView mapView) {
+		this.mMapView=null;
+		sSmoothPaint=null;
 		this.disableCompass();
+		mCompassFrameBitmap.recycle();
+		mCompassRoseBitmap.recycle();
 		super.onDetach(mapView);
 	}
 
@@ -270,6 +274,7 @@ public class CompassOverlay extends Overlay implements IOverlayMenuProvider, IOr
 		if (mOrientationProvider != null) {
 			mOrientationProvider.stopOrientationProvider();
 		}
+		mOrientationProvider=null;
 
 		// Reset values
 		mAzimuth = Float.NaN;

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/compass/IOrientationProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/compass/IOrientationProvider.java
@@ -8,4 +8,6 @@ public interface IOrientationProvider
     void stopOrientationProvider();
 
     float getLastKnownOrientation();
+
+    void destroy();
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/compass/InternalCompassOrientationProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/compass/InternalCompassOrientationProvider.java
@@ -9,7 +9,7 @@ import android.hardware.SensorManager;
 public class InternalCompassOrientationProvider implements SensorEventListener, IOrientationProvider
 {
     private IOrientationConsumer mOrientationConsumer;
-    private final SensorManager mSensorManager;
+    private SensorManager mSensorManager;
     private float mAzimuth;
 
     public InternalCompassOrientationProvider(Context context)
@@ -48,6 +48,12 @@ public class InternalCompassOrientationProvider implements SensorEventListener, 
     public float getLastKnownOrientation()
     {
         return mAzimuth;
+    }
+
+    @Override
+    public void destroy() {
+        stopOrientationProvider();
+        mSensorManager=null;
     }
 
     //

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/gestures/RotationGestureOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/gestures/RotationGestureOverlay.java
@@ -21,7 +21,6 @@ public class RotationGestureOverlay extends Overlay implements
 
     private final RotationGestureDetector mRotationDetector;
     private MapView mMapView;
-    private float lastAngle=0f;
     private boolean mOptionsMenuEnabled = true;
 
     public RotationGestureOverlay(Context context, MapView mapView)
@@ -56,6 +55,11 @@ public class RotationGestureOverlay extends Overlay implements
             timeLastSet = System.currentTimeMillis();
             mMapView.setMapOrientation(mMapView.getMapOrientation() + currentAngle);
         }
+    }
+
+    @Override
+    public void onDetach(MapView map){
+        mMapView=null;
     }
 
     @Override

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/infowindow/InfoWindow.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/infowindow/InfoWindow.java
@@ -86,6 +86,17 @@ public abstract class InfoWindow {
 			onClose();
 		}
 	}
+
+	/**
+	 * this destroys the window and all references to views
+	 */
+	public void onDetach(){
+		close();
+		if (mView!=null)
+			mView.setTag(null);
+		mView=null;
+		mMapView=null;
+	}
 	
 	public boolean isOpen(){
 		return mIsVisible;

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/mylocation/DirectedLocationOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/mylocation/DirectedLocationOverlay.java
@@ -32,8 +32,8 @@ public class DirectedLocationOverlay extends Overlay {
 	// Fields
 	// ===========================================================
 
-	protected final Paint mPaint = new Paint();
-	protected final Paint mAccuracyPaint = new Paint();
+	protected Paint mPaint = new Paint();
+	protected Paint mAccuracyPaint = new Paint();
 
 	protected Bitmap DIRECTION_ARROW;
 
@@ -115,6 +115,12 @@ public class DirectedLocationOverlay extends Overlay {
 	// ===========================================================
 	// Methods from SuperClass/Interfaces
 	// ===========================================================
+
+	@Override
+	public void onDetach(MapView view){
+		mPaint=null;
+		mAccuracyPaint=null;
+	}
 
 	@Override
 	public void draw(final Canvas c, final MapView osmv, final boolean shadow) {

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/mylocation/GpsMyLocationProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/mylocation/GpsMyLocationProvider.java
@@ -15,13 +15,13 @@ import java.util.Set;
  * location provider, by default, uses {@link LocationManager#GPS_PROVIDER} and {@link LocationManager#NETWORK_PROVIDER}
  */
 public class GpsMyLocationProvider implements IMyLocationProvider, LocationListener {
-	private final LocationManager mLocationManager;
+	private LocationManager mLocationManager;
 	private Location mLocation;
 
 	private IMyLocationConsumer mMyLocationConsumer;
 	private long mLocationUpdateMinTime = 0;
 	private float mLocationUpdateMinDistance = 0.0f;
-	private final NetworkLocationIgnorer mIgnorer = new NetworkLocationIgnorer();
+	private NetworkLocationIgnorer mIgnorer = new NetworkLocationIgnorer();
 	private final Set<String> locationSources = new HashSet<>();
 
 	public GpsMyLocationProvider(Context context) {
@@ -120,6 +120,15 @@ public class GpsMyLocationProvider implements IMyLocationProvider, LocationListe
 	@Override
 	public Location getLastKnownLocation() {
 		return mLocation;
+	}
+
+	@Override
+	public void destroy() {
+		stopLocationProvider();
+		mLocation=null;
+		mLocationManager=null;
+		mMyLocationConsumer=null;
+		mIgnorer=null;
 	}
 
 	//

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/mylocation/IMyLocationProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/mylocation/IMyLocationProvider.java
@@ -8,4 +8,6 @@ public interface IMyLocationProvider {
 	void stopLocationProvider();
 
 	Location getLastKnownLocation();
+
+	void destroy();
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/mylocation/MyLocationNewOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/mylocation/MyLocationNewOverlay.java
@@ -54,15 +54,15 @@ public class MyLocationNewOverlay extends Overlay implements IMyLocationConsumer
 	protected Bitmap mPersonBitmap;
 	protected Bitmap mDirectionArrowBitmap;
 
-	protected final MapView mMapView;
+	protected MapView mMapView;
 
-	private final IMapController mMapController;
+	private IMapController mMapController;
 	public IMyLocationProvider mMyLocationProvider;
 
 	private final LinkedList<Runnable> mRunOnFirstFix = new LinkedList<Runnable>();
 	private final Point mMapCoordsProjected = new Point();
 	private final Point mMapCoordsTranslated = new Point();
-	private final Handler mHandler;
+	private Handler mHandler;
 	private final Object mHandlerToken = new Object();
 
 	/**
@@ -138,6 +138,11 @@ public class MyLocationNewOverlay extends Overlay implements IMyLocationConsumer
 	@Override
 	public void onDetach(MapView mapView) {
 		this.disableMyLocation();
+		mPersonBitmap.recycle();
+		mDirectionArrowBitmap.recycle();
+		this.mMapView=null;
+		this.mMapController=null;
+		mHandler=null;
 		super.onDetach(mapView);
 	}
 

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/mylocation/MyLocationNewOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/mylocation/MyLocationNewOverlay.java
@@ -1,19 +1,5 @@
 package org.osmdroid.views.overlay.mylocation;
 
-import java.util.LinkedList;
-
-import org.osmdroid.api.IMapController;
-import org.osmdroid.api.IMapView;
-import org.osmdroid.library.R;
-import org.osmdroid.util.GeoPoint;
-import org.osmdroid.util.TileSystem;
-import org.osmdroid.views.MapView;
-import org.osmdroid.views.Projection;
-import org.osmdroid.views.overlay.IOverlayMenuProvider;
-import org.osmdroid.views.overlay.Overlay;
-import org.osmdroid.views.overlay.Overlay.Snappable;
-
-import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Matrix;
@@ -30,6 +16,19 @@ import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.MotionEvent;
+
+import org.osmdroid.api.IMapController;
+import org.osmdroid.api.IMapView;
+import org.osmdroid.library.R;
+import org.osmdroid.util.GeoPoint;
+import org.osmdroid.util.TileSystem;
+import org.osmdroid.views.MapView;
+import org.osmdroid.views.Projection;
+import org.osmdroid.views.overlay.IOverlayMenuProvider;
+import org.osmdroid.views.overlay.Overlay;
+import org.osmdroid.views.overlay.Overlay.Snappable;
+
+import java.util.LinkedList;
 
 /**
  * 
@@ -48,8 +47,8 @@ public class MyLocationNewOverlay extends Overlay implements IMyLocationConsumer
 	// Fields
 	// ===========================================================
 
-	protected final Paint mPaint = new Paint();
-	protected final Paint mCirclePaint = new Paint();
+	protected Paint mPaint = new Paint();
+	protected Paint mCirclePaint = new Paint();
 
 	protected Bitmap mPersonBitmap;
 	protected Bitmap mDirectionArrowBitmap;
@@ -63,7 +62,7 @@ public class MyLocationNewOverlay extends Overlay implements IMyLocationConsumer
 	private final Point mMapCoordsProjected = new Point();
 	private final Point mMapCoordsTranslated = new Point();
 	private Handler mHandler;
-	private final Object mHandlerToken = new Object();
+	private Object mHandlerToken = new Object();
 
 	/**
 	 * if true, when the user pans the map, follow my location will automatically disable
@@ -88,9 +87,9 @@ public class MyLocationNewOverlay extends Overlay implements IMyLocationConsumer
 
 	// to avoid allocations during onDraw
 	private final float[] mMatrixValues = new float[9];
-	private final Matrix mMatrix = new Matrix();
-	private final Rect mMyLocationRect = new Rect();
-	private final Rect mMyLocationPreviousRect = new Rect();
+	private Matrix mMatrix = new Matrix();
+	private Rect mMyLocationRect = new Rect();
+	private Rect mMyLocationPreviousRect = new Rect();
 
 	// ===========================================================
 	// Constructors
@@ -138,11 +137,27 @@ public class MyLocationNewOverlay extends Overlay implements IMyLocationConsumer
 	@Override
 	public void onDetach(MapView mapView) {
 		this.disableMyLocation();
-		mPersonBitmap.recycle();
-		mDirectionArrowBitmap.recycle();
-		this.mMapView=null;
-		this.mMapController=null;
-		mHandler=null;
+		if (mPersonBitmap != null) {
+			mPersonBitmap.recycle();
+		}
+		if (mDirectionArrowBitmap != null) {
+			mDirectionArrowBitmap.recycle();
+		}
+		this.mMapView = null;
+		this.mMapController = null;
+		mHandler = null;
+		mMatrix = null;
+		mCirclePaint = null;
+		mPersonBitmap = null;
+		mDirectionArrowBitmap = null;
+		mHandlerToken = null;
+		mLocation = null;
+		mMapController = null;
+		mMyLocationPreviousRect = null;
+		if (mMyLocationProvider!=null)
+			mMyLocationProvider.destroy();
+
+		mMyLocationProvider = null;
 		super.onDetach(mapView);
 	}
 
@@ -563,7 +578,8 @@ public class MyLocationNewOverlay extends Overlay implements IMyLocationConsumer
 		if (mMyLocationProvider != null) {
 			mMyLocationProvider.stopLocationProvider();
 		}
-		mHandler.removeCallbacksAndMessages(mHandlerToken);
+		if (mHandler!=null && mHandlerToken!=null)
+			mHandler.removeCallbacksAndMessages(mHandlerToken);
 	}
 
 	/**

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/mylocation/SimpleLocationOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/mylocation/SimpleLocationOverlay.java
@@ -63,6 +63,10 @@ public class SimpleLocationOverlay extends Overlay {
 	// ===========================================================
 
 	@Override
+	public void onDetach(MapView mapView){
+		this.PERSON_ICON.recycle();
+	}
+	@Override
 	public void draw(final Canvas c, final MapView osmv, final boolean shadow) {
 		if (!shadow && this.mLocation != null) {
 			final Projection pj = osmv.getProjection();

--- a/osmdroid-forge-app/build.gradle
+++ b/osmdroid-forge-app/build.gradle
@@ -59,3 +59,54 @@ project.gradle.taskGraph.whenReady {
         }
     }
 }
+
+
+android.applicationVariants.all { variant ->
+    if (variant.getBuildType().name == "debug") {
+        task "configDevice${variant.name.capitalize()}" (type: Exec){
+            dependsOn variant.install
+
+            group = 'nameofyourtaskgroup'
+            description = 'Describe your task here.'
+
+            def adb = android.getAdbExe().toString()
+            def mypermission = 'android.permission.ACCESS_FINE_LOCATION'
+            commandLine "$adb shell pm grant ${variant.applicationId} $mypermission".split(' ')
+        }
+        variant.testVariant.connectedInstrumentTest.dependsOn "configDevice${variant.name.capitalize()}"
+    }
+}
+
+
+android.applicationVariants.all { variant ->
+    if (variant.getBuildType().name == "debug") {
+        task "configDevice2${variant.name.capitalize()}" (type: Exec){
+            dependsOn variant.install
+
+            group = 'nameofyourtaskgroup'
+            description = 'Describe your task here.'
+
+            def adb = android.getAdbExe().toString()
+            def mypermission = 'android.permission.WRITE_EXTERNAL_STORAGE '
+            commandLine "$adb shell pm grant ${variant.applicationId} $mypermission".split(' ')
+        }
+        variant.testVariant.connectedInstrumentTest.dependsOn "configDevice${variant.name.capitalize()}"
+    }
+}
+
+
+android.applicationVariants.all { variant ->
+    if (variant.getBuildType().name == "debug") {
+        task "configDevice3${variant.name.capitalize()}" (type: Exec){
+            dependsOn variant.install
+
+            group = 'nameofyourtaskgroup'
+            description = 'Describe your task here.'
+
+            def adb = android.getAdbExe().toString()
+            def mypermission = 'android.permission.READ_EXTERNAL_STORAGE '
+            commandLine "$adb shell pm grant ${variant.applicationId} $mypermission".split(' ')
+        }
+        variant.testVariant.connectedInstrumentTest.dependsOn "configDevice${variant.name.capitalize()}"
+    }
+}

--- a/osmdroid-forge-app/build.gradle
+++ b/osmdroid-forge-app/build.gradle
@@ -52,10 +52,9 @@ project.gradle.taskGraph.whenReady {
                 "14".equalsIgnoreCase(System.getenv("ANDROID_TARGET").trim()) ||
                 "1".equalsIgnoreCase(System.getenv("ANDROID_TARGET").trim()) ||
                 "2".equalsIgnoreCase(System.getenv("ANDROID_TARGET").trim())) {
-            connectedDebugAndroidTest {
-                ignoreFailures = true
-
-            }
+            println "Skipping osmdroid-forge-app instrumentation test since the API level doesn't match this project"
+            installDebug { actions = []; }
+            connectedDebugAndroidTest { actions = []; }
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,16 @@
                 <version>0.6</version>
                 <scope>provided</scope>
             </dependency>
+            <dependency>
+                <groupId>com.squareup.leakcanary</groupId>
+                <artifactId>leakcanary-android</artifactId>
+                <version>1.4-beta2</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.acra</groupId>
+                <artifactId>acra</artifactId>
+                <version>4.7.0</version>
+            </dependency>
 
             <!-- test dependencies -->
             <dependency>


### PR DESCRIPTION
This is a large commit (sorry!) that resolves a great deal of memory leaks. It's tested by running a slightly altered version of the instrumentation tests which loops for 100 iterations per sample fragment. If it doesnt crash on api 8 or api 10 devices (which has max heap of 25 MB) then we're in good shape. @MKergall may want to take a look at the changes for FolderOverlay and a few minor changes to Marker.