### PR TITLE
Support implementation of own projection classes

### DIFF
--- a/GoogleWrapperSample/build.gradle
+++ b/GoogleWrapperSample/build.gradle
@@ -4,7 +4,7 @@ apply from: 'https://raw.githubusercontent.com/chrisdoyle/gradle-fury/master/gra
 
 android {
     compileSdkVersion 'Google Inc.:Google APIs:23'
-    buildToolsVersion "23.0.2"
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         applicationId "org.osmdroid.google.sample"

--- a/gradle.properties
+++ b/gradle.properties
@@ -59,7 +59,7 @@ compileJava.targetCompatibility=1.7
 
 # Android Configuration (used by gradle/android-support.gradle) ------------------------------------
 
-android.buildToolsVersion=23.0.2
+android.buildToolsVersion=23.0.3
 android.compileSdkVersion=23
 android.minSdkVersion=8
 android.targetSdkVersion=23

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
@@ -82,7 +82,7 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
 
 	private OverlayManager mOverlayManager;
 
-	private Projection mProjection;
+	protected Projection mProjection;
 
 	private TilesOverlay mMapOverlay;
 
@@ -293,6 +293,10 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
 		return mProjection;
 	}
 
+	protected void setProjection(Projection p){
+		mProjection = p;
+	}
+
 	void setMapCenter(final IGeoPoint aCenter) {
 		getController().animateTo(aCenter);
 	}
@@ -346,7 +350,7 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
 		final IGeoPoint centerGeoPoint = getMapCenter();
 
 		this.mZoomLevel = newZoomLevel;
-		mProjection = null;
+		setProjection(null);
 		this.checkZoomButtons();
 
 		if (isLayoutOccurred()) {
@@ -749,7 +753,7 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
 				listener.onFirstLayout(this, l, t, r, b);
 			mOnFirstLayoutListeners.clear();
 		}
-		mProjection = null;
+		setProjection(null);
 	}
 
 	public void addOnFirstLayoutListener(OnFirstLayoutListener listener) {
@@ -959,7 +963,7 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
 				y = maxY - (height);
 		}
 		super.scrollTo(x, y);
-		mProjection = null;
+		setProjection(null);
 
 		// Force a layout, so that children are correctly positioned according to map orientation
 		if (getMapOrientation() != 0f)
@@ -1002,8 +1006,8 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
 		// Apply the scale and rotate operations
 		c.concat(mRotateScaleMatrix);
 
-		// Make the projection
-		mProjection = new Projection(this);
+		// Reset the projection
+		setProjection(null);
 
 		/* Draw background */
 		// c.drawColor(mBackgroundColor);

--- a/osmdroid-third-party/build.gradle
+++ b/osmdroid-third-party/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 apply from: 'https://raw.githubusercontent.com/chrisdoyle/gradle-fury/master/gradle/android-support.gradle'
 android {
     compileSdkVersion "Google Inc.:Google APIs:23"
-    buildToolsVersion "23.0.2"
+    buildToolsVersion "23.0.3"
     defaultConfig {
         minSdkVersion 9
     }


### PR DESCRIPTION
Hi,

we needed for a project a custom projection class for our osmdroid mapview. This was currently not possible since the projection member of the map view was read only for derived classed and the reset of the projection was not done using a setter method (that could be overwritten).

So i did the following
* switched projection to be protected instead of private and added protected setter for projection in order to use own projection class

Also i updated the build tools to the current version of 23.0.3

I think there is no real reason for not providing write access to the projection member for derived classes. 

It would be nice if that could be merged into the main repo