### PR TITLE
Fixed possible crash if mLocationManager for GpsMyLocationProvider is…

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/mylocation/GpsMyLocationProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/mylocation/GpsMyLocationProvider.java
@@ -114,7 +114,9 @@ public class GpsMyLocationProvider implements IMyLocationProvider, LocationListe
 	@Override
 	public void stopLocationProvider() {
 		mMyLocationConsumer = null;
-		mLocationManager.removeUpdates(this);
+		if(mLocationManager != null){
+			mLocationManager.removeUpdates(this);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
… null

This fixes a crash that appeared on devices with deactivated location services causing a null pointer exception to be thrown. I don't know exactly how this could happen, but this will fix it and does not demage anything ;-)

The following backtrace was reported:

`java.lang.NullPointerException
	at org.osmdroid.views.overlay.mylocation.GpsMyLocationProvider.stopLocationProvider(GpsMyLocationProvider.java:117)
	at org.osmdroid.views.overlay.mylocation.MyLocationNewOverlay.stopLocationProvider(MyLocationNewOverlay.java:579)
	at org.osmdroid.views.overlay.mylocation.MyLocationNewOverlay.disableMyLocation(MyLocationNewOverlay.java:569)
	at org.osmdroid.views.overlay.mylocation.MyLocationNewOverlay.onDetach(MyLocationNewOverlay.java:139)
	at org.osmdroid.views.overlay.DefaultOverlayManager.onDetach(DefaultOverlayManager.java:132)
	at org.osmdroid.views.MapView.onDetach(MapView.java:774)
	at org.osmdroid.views.MapView.onDetachedFromWindow(MapView.java:1032)
	at android.view.View.dispatchDetachedFromWindow(View.java:12107)
	at android.view.ViewGroup.dispatchDetachedFromWindow(ViewGroup.java:2776)
	at android.view.ViewGroup.dispatchDetachedFromWindow(ViewGroup.java:2774)
	at android.view.ViewGroup.dispatchDetachedFromWindow(ViewGroup.java:2774)
	at android.view.ViewGroup.dispatchDetachedFromWindow(ViewGroup.java:2774)
	at android.view.ViewGroup.dispatchDetachedFromWindow(ViewGroup.java:2774)
	at android.view.ViewGroup.dispatchDetachedFromWindow(ViewGroup.java:2774)
	at android.view.ViewGroup.dispatchDetachedFromWindow(ViewGroup.java:2774)
	at android.view.ViewGroup.dispatchDetachedFromWindow(ViewGroup.java:2774)
	at android.view.ViewRootImpl.dispatchDetachedFromWindow(ViewRootImpl.java:2752)
	at android.view.ViewRootImpl.doDie(ViewRootImpl.java:4214)
	at android.view.ViewRootImpl.die(ViewRootImpl.java:4197)
	at android.view.WindowManagerImpl.removeViewImmediate(WindowManagerImpl.java:394)
	at android.view.WindowManagerImpl$CompatModeWrapper.removeViewImmediate(WindowManagerImpl.java:170)
	at android.app.ActivityThread.handleDestroyActivity(ActivityThread.java:3370)
	at android.app.ActivityThread.access$1300(ActivityThread.java:140)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1291)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loop(Looper.java:137)
	at android.app.ActivityThread.main(ActivityThread.java:4918)
	at java.lang.reflect.Method.invokeNative(Native Method)
	at java.lang.reflect.Method.invoke(Method.java:511)
	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:994)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:761)
	at dalvik.system.NativeStart.main(Native Method)`