### PR TITLE
Mapsforge Adapter updates

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileModuleProviderBase.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileModuleProviderBase.java
@@ -285,7 +285,11 @@ public abstract class MapTileModuleProviderBase {
 			Drawable result = null;
 			while ((state = nextTile()) != null) {
 				if (OpenStreetMapTileProviderConstants.DEBUG_TILE_PROVIDERS) {
-					Log.d(IMapView.LOGTAG,"TileLoader.run() processing next tile: " + state.getMapTile());
+					Log.d(IMapView.LOGTAG,"TileLoader.run() processing next tile: "
+							+ state.getMapTile()
+							+ ", pending:" + mPending.size()
+							+ ", working:" + mWorking.size()
+					);
 				}
 				try {
 					result = null;

--- a/osmdroid-forge-app/build.gradle
+++ b/osmdroid-forge-app/build.gradle
@@ -31,10 +31,6 @@ dependencies {
     //crash logging
     compile 'ch.acra:acra:4.7.0'
 
-    //Mapsforge rendering and database support, which is LGPL
-    compile 'org.mapsforge:mapsforge-map-android:0.6.0'
-    compile 'org.mapsforge:mapsforge-map:0.6.0'
-
     //osmdroid map and mapsforge adapter
     compile project(':osmdroid-android')
     compile project(':osmdroid-mapsforge')

--- a/osmdroid-forge-app/src/main/java/org/osmdroid/forge/app/MainActivity.java
+++ b/osmdroid-forge-app/src/main/java/org/osmdroid/forge/app/MainActivity.java
@@ -14,7 +14,6 @@ import android.view.MenuItem;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import org.mapsforge.map.android.graphics.AndroidGraphicFactory;
 import org.mapsforge.map.android.rendertheme.AssetsRenderTheme;
 import org.mapsforge.map.rendertheme.XmlRenderTheme;
 import org.osmdroid.api.IGeoPoint;
@@ -56,7 +55,7 @@ public class MainActivity extends AppCompatActivity {
         /**
          * super important to configure some of the mapsforge settings first
          */
-        AndroidGraphicFactory.createInstance(this.getApplication());
+        MapsForgeTileSource.createInstance(this.getApplication());
         /*
         not sure how important these are....
         MapFile.wayFilterEnabled = true;

--- a/osmdroid-mapsforge/build.gradle
+++ b/osmdroid-mapsforge/build.gradle
@@ -18,8 +18,8 @@ dependencies {
     testCompile 'junit:junit:4.12'
 
     //Mapsforge rendering and database support, which is LGPL
-    compile 'org.mapsforge:mapsforge-map-android:0.6.0'
-    compile 'org.mapsforge:mapsforge-map:0.6.0'
+    compile 'org.mapsforge:mapsforge-map-android:0.6.1'
+    compile 'org.mapsforge:mapsforge-map:0.6.1'
 
     //osmdroid which is ASF licensed
     compile project(':osmdroid-android')

--- a/osmdroid-mapsforge/src/main/java/org/osmdroid/mapsforge/MapsForgeTileModuleProvider.java
+++ b/osmdroid-mapsforge/src/main/java/org/osmdroid/mapsforge/MapsForgeTileModuleProvider.java
@@ -3,8 +3,11 @@ package org.osmdroid.mapsforge;
 import android.graphics.Bitmap;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
+import android.util.Log;
 
+import org.osmdroid.api.IMapView;
 import org.osmdroid.tileprovider.IRegisterReceiver;
+import org.osmdroid.tileprovider.MapTile;
 import org.osmdroid.tileprovider.MapTileRequestState;
 import org.osmdroid.tileprovider.constants.OpenStreetMapTileProviderConstants;
 import org.osmdroid.tileprovider.modules.IFilesystemCache;
@@ -84,12 +87,25 @@ public class MapsForgeTileModuleProvider extends MapTileFileStorageProviderBase 
         @Override
         public Drawable loadTile(final MapTileRequestState pState) {
             //TODO find a more efficient want to do this, seems overlay complicated
-            Drawable image= tileSource.renderTile(pState.getMapTile());
+            MapTile mapTile = pState.getMapTile();
+            String dbgPrefix = null;
+            if (OpenStreetMapTileProviderConstants.DEBUG_TILE_PROVIDERS) {
+                dbgPrefix = "MapsForgeTileModuleProvider.TileLoader.loadTile(" + mapTile + "): ";
+                Log.d(IMapView.LOGTAG,dbgPrefix + "tileSource.renderTile");
+            }
+            Drawable image= tileSource.renderTile(mapTile);
             if (image!=null && image instanceof BitmapDrawable) {
                 ByteArrayOutputStream stream = new ByteArrayOutputStream();
                 ((BitmapDrawable)image).getBitmap().compress(Bitmap.CompressFormat.PNG, 100, stream);
                 byte[] bitmapdata = stream.toByteArray();
-                tilewriter.saveFile(tileSource, pState.getMapTile(), new ByteArrayInputStream(bitmapdata));
+
+                if (OpenStreetMapTileProviderConstants.DEBUG_TILE_PROVIDERS) {
+                    Log.d(IMapView.LOGTAG, dbgPrefix +
+                            "save tile " + bitmapdata.length +
+                            " bytes to " + tileSource.getTileRelativeFilenameString(mapTile));
+                }
+
+                tilewriter.saveFile(tileSource, mapTile, new ByteArrayInputStream(bitmapdata));
             }
             return image;
         }

--- a/osmdroid-mapsforge/src/main/java/org/osmdroid/mapsforge/MapsForgeTileSource.java
+++ b/osmdroid-mapsforge/src/main/java/org/osmdroid/mapsforge/MapsForgeTileSource.java
@@ -1,20 +1,26 @@
 package org.osmdroid.mapsforge;
 
+import android.app.Application;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.util.Log;
 
+import org.mapsforge.core.graphics.GraphicFactory;
 import org.mapsforge.core.model.Tile;
 import org.mapsforge.map.android.graphics.AndroidGraphicFactory;
 import org.mapsforge.map.android.graphics.AndroidTileBitmap;
+import org.mapsforge.map.datastore.MapDataStore;
 import org.mapsforge.map.datastore.MultiMapDataStore;
 import org.mapsforge.map.layer.cache.InMemoryTileCache;
+import org.mapsforge.map.layer.cache.TileCache;
+import org.mapsforge.map.layer.labels.TileBasedLabelStore;
 import org.mapsforge.map.layer.renderer.DatabaseRenderer;
 import org.mapsforge.map.layer.renderer.RendererJob;
 import org.mapsforge.map.model.DisplayModel;
 import org.mapsforge.map.reader.MapFile;
+import org.mapsforge.map.reader.ReadBuffer;
 import org.mapsforge.map.rendertheme.InternalRenderTheme;
 import org.mapsforge.map.rendertheme.XmlRenderTheme;
 import org.mapsforge.map.rendertheme.rule.RenderThemeFuture;
@@ -63,10 +69,16 @@ public class MapsForgeTileSource extends BitmapTileSourceBase {
         for (int i = 0; i < file.length; i++)
             mapDatabase.addMapDataStore(new MapFile(file[i]), false, false);
 
-        if (AndroidGraphicFactory.INSTANCE==null)
-            throw new RuntimeException("Need to initialize the AndroidGraphicFactory.INSTANCE via AndroidGraphicFactory.createInstance(context);");
+        if (AndroidGraphicFactory.INSTANCE==null) {
+            throw new RuntimeException("Must call MapsForgeTileSource.createInstance(context.getApplication()); once before MapsForgeTileSource.createFromFiles().");
+        }
 
-        renderer = new DatabaseRenderer(mapDatabase, AndroidGraphicFactory.INSTANCE, new InMemoryTileCache(2));
+        // mapsforge0.6
+        // renderer = new DatabaseRenderer(mapDatabase, AndroidGraphicFactory.INSTANCE, new InMemoryTileCache(2));
+        // mapsforge0.6.1
+        InMemoryTileCache tileCache = new InMemoryTileCache(2);
+        renderer = new DatabaseRenderer(mapDatabase, AndroidGraphicFactory.INSTANCE, tileCache,
+                new TileBasedLabelStore(tileCache.getCapacityFirstLevel()), true, true);
 
         minZoom = MIN_ZOOM;
         maxZoom = renderer.getZoomLevelMax();
@@ -174,5 +186,13 @@ public class MapsForgeTileSource extends BitmapTileSourceBase {
         bitmap.eraseColor(Color.YELLOW);
         return new BitmapDrawable(bitmap);
     }
+
+    public static void createInstance(Application app) {
+        AndroidGraphicFactory.createInstance(app);
+
+        // see https://github.com/mapsforge/mapsforge/issues/868
+        ReadBuffer.setMaximumBufferSize(6500000);
+    }
+
 
 }


### PR DESCRIPTION
Changes:

* Fix: Added more temporary memory for rendering. See https://github.com/mapsforge/mapsforge/issues/868 for details
*  Added debuglogging to osmdroid-mapsforge code via OpenStreetMapTileProviderConstants.DEBUG_TILE_PROVIDERS==true
* Update to mapsforge-0.6.1
* Example app: Hide dependencies to mapsforge-version

Note i kept dependcy to kxml2
