### PR TITLE
Fix Mapview zoomToBoundingBox 186 mistyping

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
@@ -422,7 +422,7 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
 
 	@Deprecated
 	public void zoomToBoundingBox(final BoundingBoxE6 boundingBox) {
-		BoundingBox box = new BoundingBox(boundingBox.getLatNorthE6()/1e6, boundingBox.getLonEastE6()/1e6, boundingBox.getLatSouthE6()/186, boundingBox.getLonWestE6()/1e6);
+		BoundingBox box = new BoundingBox(boundingBox.getLatNorthE6()/1e6, boundingBox.getLonEastE6()/1e6, boundingBox.getLatSouthE6()/1e6, boundingBox.getLonWestE6()/1e6);
 		zoomToBoundingBox(box, false);
 	}
 


### PR DESCRIPTION
zoomToBoundingBox  return corupted results cause of mistyping 186 instaed of 1e6