### PR TITLE
Bug/#624

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/config/IConfigurationProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/config/IConfigurationProvider.java
@@ -160,7 +160,7 @@ public interface IConfigurationProvider {
     void setTileFileSystemCacheMaxBytes(long tileFileSystemCacheMaxBytes);
 
     /**
-     * When the cache size exceeds maxCacheSize, tiles will be automatically removed to reach this target. In Mb. Default is 500 Mb.
+     * When the cache size exceeds maxCacheSize, tiles will be automatically removed to reach this target. In bytes. Default is 500 Mb.
      * @return
      */
     long getTileFileSystemCacheTrimBytes();

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/SqlTileWriter.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/SqlTileWriter.java
@@ -486,4 +486,28 @@ public class SqlTileWriter implements IFilesystemCache {
         return 0;
     }
 
+
+    /**
+    * Returns the size of the database file in bytes.
+    */
+    public long getSize() {
+        return db_file.length();
+    }
+
+    /**
+    * Returns the expiry time of the tile that expires first.
+    */
+    public long getFirstExpiry() {
+        try {
+            Cursor cursor = db.rawQuery("select min(" + COLUMN_EXPIRES + ") from " + TABLE, null);
+            cursor.moveToFirst();
+            long time = cursor.getLong(0);
+            cursor.close();
+            return time;
+        } catch (Throwable ex) {
+            Log.e(IMapView.LOGTAG, "Unable to query for oldest tile", ex);
+        }
+        return 0;
+    }
+
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/SqlTileWriter.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/SqlTileWriter.java
@@ -118,7 +118,7 @@ public class SqlTileWriter implements IFilesystemCache {
                 //note, i considered adding a looping mechanism here but sqlite can behave differently
                 //i.e. there's no guarantee that the database file size shrinks immediately.
                 Log.i(IMapView.LOGTAG, "Local cache is now " + db_file.length() + " max size is " + Configuration.getInstance().getTileFileSystemCacheMaxBytes());
-                long diff = db_file.length() - Configuration.getInstance().getTileFileSystemCacheMaxBytes();
+                long diff = db_file.length() - Configuration.getInstance().getTileFileSystemCacheTrimBytes();
                 long tilesToKill = diff / questimate;
                 Log.d(IMapView.LOGTAG, "Local cache purging " + tilesToKill + " tiles.");
                 if (tilesToKill > 0)
@@ -178,7 +178,7 @@ public class SqlTileWriter implements IFilesystemCache {
                 Log.d(IMapView.LOGTAG, "tile inserted " + pTileSourceInfo.name() + pTile.toString());
             if (System.currentTimeMillis() > lastSizeCheck + 300000){
                 lastSizeCheck = System.currentTimeMillis();
-                if (db_file!=null && db_file.length() > Configuration.getInstance().getTileFileSystemCacheTrimBytes()) {
+                if (db_file!=null && db_file.length() > Configuration.getInstance().getTileFileSystemCacheMaxBytes()) {
                     runCleanupOperation();
                 }
             }

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/SqlTileWriter.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/SqlTileWriter.java
@@ -122,7 +122,7 @@ public class SqlTileWriter implements IFilesystemCache {
                 long diff = db_file.length() - Configuration.getInstance().getTileFileSystemCacheTrimBytes();
                 if (tileSize == 0l) {
                     long count = getRowCount(null);
-                    tileSize = db_file.length() / count;
+                    tileSize = count > 0l ? db_file.length() / count : 4000;
                     if (Configuration.getInstance().isDebugMode()) {
                         Log.d(IMapView.LOGTAG, "Number of cached tiles is " + count + ", mean size is " + tileSize);
                     }


### PR DESCRIPTION
Change SqlTileWriter's use of getTileFileSystemCacheTrimBytes() to hopefully what was intended.  Use average tile size rather than 4kB estimate to avoid purging too much of the cache.  See comments on #624.