### PR TITLE
feature/#646: MapTileApproximater with several sources

### DIFF
--- a/osmdroid-android-it/src/main/java/org/osmdroid/tileprovider/modules/MapTileProviderTest.java
+++ b/osmdroid-android-it/src/main/java/org/osmdroid/tileprovider/modules/MapTileProviderTest.java
@@ -57,10 +57,10 @@ public class MapTileProviderTest extends AndroidTestCase {
 		}
 
 		@Override
-		protected Runnable getTileLoader() {
+		public TileLoader getTileLoader() {
 			return new TileLoader() {
 				@Override
-				protected Drawable loadTile(final MapTileRequestState aState)
+				public Drawable loadTile(final MapTile pTile)
 						throws CantContinueException {
 					try {
 						Thread.sleep(1000);

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderBase.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderBase.java
@@ -406,7 +406,7 @@ public abstract class MapTileProviderBase implements IMapTileProviderCallback {
 
 			if (oldDrawable instanceof BitmapDrawable) {
 				final Bitmap bitmap = MapTileApproximater.approximateTileFromLowerZoom(
-						mTileSize, (BitmapDrawable)oldDrawable, pTile, mDiff);
+						(BitmapDrawable)oldDrawable, pTile, mDiff);
 				if (bitmap != null) {
 					mNewTiles.put(pTile, bitmap);
 				}

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderBasic.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderBasic.java
@@ -9,6 +9,7 @@ import org.osmdroid.tileprovider.modules.MapTileApproximater;
 import org.osmdroid.tileprovider.modules.MapTileAssetsProvider;
 import org.osmdroid.tileprovider.modules.MapTileDownloader;
 import org.osmdroid.tileprovider.modules.MapTileFileArchiveProvider;
+import org.osmdroid.tileprovider.modules.MapTileFileStorageProviderBase;
 import org.osmdroid.tileprovider.modules.MapTileFilesystemProvider;
 import org.osmdroid.tileprovider.modules.MapTileSqlCacheProvider;
 import org.osmdroid.tileprovider.modules.NetworkAvailabliltyCheck;
@@ -83,14 +84,14 @@ public class MapTileProviderBasic extends MapTileProviderArray implements IMapTi
 				pRegisterReceiver, pContext.getAssets(), pTileSource);
 		mTileProviderList.add(assetsProvider);
 
+		final MapTileFileStorageProviderBase cacheProvider;
 		if (Build.VERSION.SDK_INT < 10) {
-			final MapTileFilesystemProvider fileSystemProvider = new MapTileFilesystemProvider(
-					pRegisterReceiver, pTileSource);
-			mTileProviderList.add(fileSystemProvider);
+			cacheProvider = new MapTileFilesystemProvider(pRegisterReceiver, pTileSource);
 		} else {
-			final MapTileSqlCacheProvider cachedProvider = new MapTileSqlCacheProvider(pRegisterReceiver, pTileSource);
-			mTileProviderList.add(cachedProvider);
+			cacheProvider = new MapTileSqlCacheProvider(pRegisterReceiver, pTileSource);
 		}
+		mTileProviderList.add(cacheProvider);
+
 		final MapTileFileArchiveProvider archiveProvider = new MapTileFileArchiveProvider(
 				pRegisterReceiver, pTileSource);
 		mTileProviderList.add(archiveProvider);
@@ -99,8 +100,11 @@ public class MapTileProviderBasic extends MapTileProviderArray implements IMapTi
 				aNetworkAvailablityCheck);
 		mTileProviderList.add(downloaderProvider);
 
-		final MapTileApproximater approximationProvider = new MapTileApproximater(pTileSource, tileWriter);
+		final MapTileApproximater approximationProvider = new MapTileApproximater();
 		mTileProviderList.add(approximationProvider);
+		approximationProvider.addProvider(assetsProvider);
+		approximationProvider.addProvider(cacheProvider);
+		approximationProvider.addProvider(archiveProvider);
 	}
 
 	@Override

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileApproximater.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileApproximater.java
@@ -29,7 +29,6 @@ public class MapTileApproximater extends MapTileModuleProviderBase {
 
     private final List<MapTileModuleProviderBase> mProviders = new ArrayList<>();
     private int minZoomLevel;
-    private int maxZoomLevel;
 
     /**
      * @since 5.6.6
@@ -57,16 +56,14 @@ public class MapTileApproximater extends MapTileModuleProviderBase {
 
     private void computeZoomLevels() {
         boolean first = true;
+        minZoomLevel = OpenStreetMapTileProviderConstants.MINIMUM_ZOOMLEVEL;
         for (final MapTileModuleProviderBase provider : mProviders) {
             final int otherMin = provider.getMinimumZoomLevel();;
-            final int otherMax = provider.getMaximumZoomLevel();;
             if (first) {
                 first = false;
                 minZoomLevel = otherMin;
-                maxZoomLevel = otherMax;
             } else {
                 minZoomLevel = Math.min(minZoomLevel, otherMin);
-                maxZoomLevel = Math.max(maxZoomLevel, otherMax);
             }
         }
     }
@@ -98,7 +95,7 @@ public class MapTileApproximater extends MapTileModuleProviderBase {
 
     @Override
     public int getMaximumZoomLevel() {
-        return maxZoomLevel;
+        return microsoft.mappoint.TileSystem.getMaximumZoomLevel();
     }
 
     @Deprecated
@@ -218,12 +215,16 @@ public class MapTileApproximater extends MapTileModuleProviderBase {
         try {
             if (!isReusable || reusableBitmapDrawable.isBitmapValid()) {
                 final int srcSize = tileSizePixels >> pZoomDiff;
-                final int srcX = (pMapTile.getX() % (1 << pZoomDiff)) * srcSize;
-                final int srcY = (pMapTile.getY() % (1 << pZoomDiff)) * srcSize;
-                final Rect srcRect = new Rect(srcX, srcY, srcX + srcSize, srcY + srcSize);
-                final Rect dstRect = new Rect(0, 0, tileSizePixels, tileSizePixels);
-                canvas.drawBitmap(pSrcDrawable.getBitmap(), srcRect, dstRect, null);
-                success = true;
+                if (srcSize == 0) {
+                    success = false;
+                } else {
+                    final int srcX = (pMapTile.getX() % (1 << pZoomDiff)) * srcSize;
+                    final int srcY = (pMapTile.getY() % (1 << pZoomDiff)) * srcSize;
+                    final Rect srcRect = new Rect(srcX, srcY, srcX + srcSize, srcY + srcSize);
+                    final Rect dstRect = new Rect(0, 0, tileSizePixels, tileSizePixels);
+                    canvas.drawBitmap(pSrcDrawable.getBitmap(), srcRect, dstRect, null);
+                    success = true;
+                }
             }
         } finally {
             if (isReusable)

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileApproximater.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileApproximater.java
@@ -5,17 +5,17 @@ import android.graphics.Canvas;
 import android.graphics.Rect;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
-import android.util.Log;
 
 import org.osmdroid.config.Configuration;
 import org.osmdroid.tileprovider.BitmapPool;
 import org.osmdroid.tileprovider.ExpirableBitmapDrawable;
 import org.osmdroid.tileprovider.MapTile;
-import org.osmdroid.tileprovider.MapTileRequestState;
 import org.osmdroid.tileprovider.ReusableBitmapDrawable;
+import org.osmdroid.tileprovider.constants.OpenStreetMapTileProviderConstants;
 import org.osmdroid.tileprovider.tilesource.ITileSource;
 
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * The MapTileApproximater computes approximation of tiles.
@@ -27,20 +27,48 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class MapTileApproximater extends MapTileModuleProviderBase {
 
-    private final AtomicReference<ITileSource> mTileSource = new AtomicReference<>();
-    private final IFilesystemCache mReader;
+    private final List<MapTileModuleProviderBase> mProviders = new ArrayList<>();
+    private int minZoomLevel;
+    private int maxZoomLevel;
 
-    public MapTileApproximater(final ITileSource pTileSource, final IFilesystemCache pFilesystemCache) {
-        this(pTileSource, pFilesystemCache,
+    /**
+     * @since 5.6.6
+     */
+    public MapTileApproximater() {
+        this(
                 Configuration.getInstance().getTileFileSystemThreads(),
                 Configuration.getInstance().getTileFileSystemMaxQueueSize());
     }
 
-    public MapTileApproximater(final ITileSource pTileSource, final IFilesystemCache pFilesystemCache,
-                               final int pThreadPoolSize, final int pPendingQueueSize) {
+    /**
+     * @since 5.6.6
+     */
+    public MapTileApproximater(final int pThreadPoolSize, final int pPendingQueueSize) {
         super(pThreadPoolSize, pPendingQueueSize);
-        setTileSource(pTileSource);
-        mReader = pFilesystemCache;
+    }
+
+    /**
+     * @since 5.6.6
+     */
+    public void addProvider(final MapTileModuleProviderBase pProvider) {
+        mProviders.add(pProvider);
+        computeZoomLevels();
+    }
+
+    private void computeZoomLevels() {
+        boolean first = true;
+        for (final MapTileModuleProviderBase provider : mProviders) {
+            final int otherMin = provider.getMinimumZoomLevel();;
+            final int otherMax = provider.getMaximumZoomLevel();;
+            if (first) {
+                first = false;
+                minZoomLevel = otherMin;
+                maxZoomLevel = otherMax;
+            } else {
+                minZoomLevel = Math.min(minZoomLevel, otherMin);
+                maxZoomLevel = Math.max(maxZoomLevel, otherMax);
+            }
+        }
     }
 
     @Override
@@ -59,60 +87,52 @@ public class MapTileApproximater extends MapTileModuleProviderBase {
     }
 
     @Override
-    protected Runnable getTileLoader() {
+    public TileLoader getTileLoader() {
         return new TileLoader();
     }
 
     @Override
     public int getMinimumZoomLevel() {
-        final ITileSource tileSource = mTileSource.get();
-        return tileSource.getMinimumZoomLevel();
+        return minZoomLevel;
     }
 
     @Override
     public int getMaximumZoomLevel() {
-        final ITileSource tileSource = mTileSource.get();
-        return tileSource.getMaximumZoomLevel();
+        return maxZoomLevel;
     }
 
+    @Deprecated
     @Override
     public void setTileSource(final ITileSource pTileSource) {
-        mTileSource.set(pTileSource);
+        // not relevant
     }
 
     protected class TileLoader extends MapTileModuleProviderBase.TileLoader {
 
         @Override
-        public Drawable loadTile(final MapTileRequestState pState) {
-            final ITileSource tileSource = mTileSource.get();
-            if (tileSource == null) {
-                return null;
+        public Drawable loadTile(final MapTile pMapTile) {
+            final Bitmap bitmap = approximateTileFromLowerZoom(pMapTile);
+            if (bitmap != null) {
+                final BitmapDrawable drawable = new BitmapDrawable(bitmap);
+                ExpirableBitmapDrawable.setState(drawable, ExpirableBitmapDrawable.SCALED);
+                return drawable;
             }
-            final Bitmap bitmap = approximateTileFromLowerZoom(tileSource, mReader, pState.getMapTile());
-            if (bitmap == null) {
-                return null;
-            }
-            final BitmapDrawable drawable = new BitmapDrawable(bitmap);
-            ExpirableBitmapDrawable.setState(drawable, ExpirableBitmapDrawable.SCALED);
-            return drawable;
+            return null;
         }
     }
 
     /**
      * Approximate a tile from a lower zoom level
      *
-     * @param pTileSource Tile source to use in order to get the source tile
-     * @param pReader Cache where source tiles are stored
-     * @param pMapTile Destination tile
+     * @since 5.6.6
+     * @param pMapTile Destination tile, for the same place on the planet as the source, but on a higher zoom
      * @return
      */
-    public static Bitmap approximateTileFromLowerZoom(
-            final ITileSource pTileSource, final IFilesystemCache pReader,
-            final MapTile pMapTile) {
-        for (int zoomDiff = 1 ; pMapTile.getZoomLevel() - zoomDiff >= pTileSource.getMinimumZoomLevel() ; zoomDiff ++) {
-            final Bitmap result = approximateTileFromLowerZoom(pTileSource, pReader, pMapTile, zoomDiff);
-            if (result != null) {
-                return result;
+    public Bitmap approximateTileFromLowerZoom(final MapTile pMapTile) {
+        for (int zoomDiff = 1; pMapTile.getZoomLevel() - zoomDiff >= OpenStreetMapTileProviderConstants.MINIMUM_ZOOMLEVEL ; zoomDiff ++) {
+            final Bitmap bitmap = approximateTileFromLowerZoom(pMapTile, zoomDiff);
+            if (bitmap != null) {
+                return bitmap;
             }
         }
         return null;
@@ -121,32 +141,50 @@ public class MapTileApproximater extends MapTileModuleProviderBase {
     /**
      * Approximate a tile from a lower zoom level
      *
-     * @param pTileSource Tile source to use in order to get the source tile
-     * @param pReader Cache where source tiles are stored
-     * @param pMapTile Destination tile
+     * @since 5.6.6
+     * @param pMapTile Destination tile, for the same place on the planet as the source, but on a higher zoom
+     * @param pZoomDiff Zoom level difference between the destination and the source; strictly positive
+     * @return
+     */
+    public Bitmap approximateTileFromLowerZoom(final MapTile pMapTile, final int pZoomDiff) {
+        for (final MapTileModuleProviderBase provider : mProviders) {
+            final Bitmap bitmap = approximateTileFromLowerZoom(provider, pMapTile, pZoomDiff);
+            if (bitmap != null) {
+                return bitmap;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Approximate a tile from a lower zoom level
+     *
+     * @since 5.6.6
+     * @param pProvider Source tile provider
+     * @param pMapTile Destination tile, for the same place on the planet as the source, but on a higher zoom
      * @param pZoomDiff Zoom level difference between the destination and the source; strictly positive
      * @return
      */
     public static Bitmap approximateTileFromLowerZoom(
-            final ITileSource pTileSource, final IFilesystemCache pReader,
+            final MapTileModuleProviderBase pProvider,
             final MapTile pMapTile, final int pZoomDiff) {
         if (pZoomDiff <= 0) {
             return null;
         }
         final int srcZoomLevel = pMapTile.getZoomLevel() - pZoomDiff;
-        if (srcZoomLevel < pTileSource.getMinimumZoomLevel()) {
+        if (srcZoomLevel < pProvider.getMinimumZoomLevel()) {
             return null;
         }
-
+        if (srcZoomLevel > pProvider.getMaximumZoomLevel()) {
+            return null;
+        }
         final MapTile srcTile = new MapTile(srcZoomLevel, pMapTile.getX() >> pZoomDiff, pMapTile.getY() >> pZoomDiff);
         try {
-            final Drawable srcDrawable = pReader.loadTile(pTileSource, srcTile);
+            final Drawable srcDrawable = pProvider.getTileLoader().loadTile(srcTile);
             if (!(srcDrawable instanceof BitmapDrawable)) {
                 return null;
             }
-            return MapTileApproximater.approximateTileFromLowerZoom(
-                    pTileSource.getTileSizePixels(), (BitmapDrawable) srcDrawable,
-                    pMapTile, pZoomDiff);
+            return approximateTileFromLowerZoom((BitmapDrawable) srcDrawable, pMapTile, pZoomDiff);
         } catch (Exception e) {
             return null;
         }
@@ -156,19 +194,19 @@ public class MapTileApproximater extends MapTileModuleProviderBase {
      * Approximate a tile from a lower zoom level
      *
      * @since 5.6.5
-     * @param pTileSizePixels Pixel tile size, for source and destination
      * @param pSrcDrawable Source tile bitmap
      * @param pMapTile Destination tile, for the same place on the planet as the source, but on a higher zoom
      * @param pZoomDiff Zoom level difference between the destination and the source; strictly positive
      * @return
      */
     public static Bitmap approximateTileFromLowerZoom(
-            final int pTileSizePixels, final BitmapDrawable pSrcDrawable,
+            final BitmapDrawable pSrcDrawable,
             final MapTile pMapTile, final int pZoomDiff) {
         if (pZoomDiff <= 0) {
             return null;
         }
-        final Bitmap bitmap = getTileBitmap(pTileSizePixels);
+        final int tileSizePixels = pSrcDrawable.getBitmap().getWidth();
+        final Bitmap bitmap = getTileBitmap(tileSizePixels);
         final Canvas canvas = new Canvas(bitmap);
         final boolean isReusable = pSrcDrawable instanceof ReusableBitmapDrawable;
         final ReusableBitmapDrawable reusableBitmapDrawable = isReusable ?
@@ -179,11 +217,11 @@ public class MapTileApproximater extends MapTileModuleProviderBase {
         }
         try {
             if (!isReusable || reusableBitmapDrawable.isBitmapValid()) {
-                final int srcSize = pTileSizePixels >> pZoomDiff;
+                final int srcSize = tileSizePixels >> pZoomDiff;
                 final int srcX = (pMapTile.getX() % (1 << pZoomDiff)) * srcSize;
                 final int srcY = (pMapTile.getY() % (1 << pZoomDiff)) * srcSize;
                 final Rect srcRect = new Rect(srcX, srcY, srcX + srcSize, srcY + srcSize);
-                final Rect dstRect = new Rect(0, 0, pTileSizePixels, pTileSizePixels);
+                final Rect dstRect = new Rect(0, 0, tileSizePixels, tileSizePixels);
                 canvas.drawBitmap(pSrcDrawable.getBitmap(), srcRect, dstRect, null);
                 success = true;
             }

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileAssetsProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileAssetsProvider.java
@@ -95,7 +95,7 @@ public class MapTileAssetsProvider extends MapTileFileStorageProviderBase {
 	}
 
 	@Override
-	protected Runnable getTileLoader() {
+	public TileLoader getTileLoader() {
 		return new TileLoader(mAssets);
 	}
 
@@ -129,16 +129,14 @@ public class MapTileAssetsProvider extends MapTileFileStorageProviderBase {
 		}
 
 		@Override
-		public Drawable loadTile(final MapTileRequestState pState) throws CantContinueException {
+		public Drawable loadTile(final MapTile pTile) throws CantContinueException {
 			ITileSource tileSource = mTileSource.get();
 			if (tileSource == null) {
 				return null;
 			}
 
-			final MapTile tile = pState.getMapTile();
-
 			try {
-				InputStream is = mAssets.open(tileSource.getTileRelativeFilenameString(tile));
+				InputStream is = mAssets.open(tileSource.getTileRelativeFilenameString(pTile));
 				final Drawable drawable = tileSource.getDrawable(is);
 				if (drawable != null) {
 					//https://github.com/osmdroid/osmdroid/issues/272 why was this set to expired?

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileDownloader.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileDownloader.java
@@ -115,7 +115,7 @@ public class MapTileDownloader extends MapTileModuleProviderBase {
 	}
 
 	@Override
-	protected Runnable getTileLoader() {
+	public TileLoader getTileLoader() {
 		return new TileLoader();
 	}
 
@@ -157,7 +157,7 @@ public class MapTileDownloader extends MapTileModuleProviderBase {
 	protected class TileLoader extends MapTileModuleProviderBase.TileLoader {
 
 		@Override
-		public Drawable loadTile(final MapTileRequestState aState) throws CantContinueException {
+		public Drawable loadTile(final MapTile pTile) throws CantContinueException {
 
 			OnlineTileSourceBase tileSource = mTileSource.get();
 			if (tileSource == null) {
@@ -167,7 +167,6 @@ public class MapTileDownloader extends MapTileModuleProviderBase {
 			InputStream in = null;
 			OutputStream out = null;
 			HttpURLConnection c=null;
-			final MapTile tile = aState.getMapTile();
 
 			try {
 
@@ -179,7 +178,7 @@ public class MapTileDownloader extends MapTileModuleProviderBase {
 					return null;
 				}
 
-				final String tileURLString = tileSource.getTileURLString(tile);
+				final String tileURLString = tileSource.getTileURLString(pTile);
 
 				if (Configuration.getInstance().isDebugMode()) {
 					Log.d(IMapView.LOGTAG,"Downloading Maptile from url: " + tileURLString);
@@ -205,7 +204,7 @@ public class MapTileDownloader extends MapTileModuleProviderBase {
 				// Check to see if we got success
 				
 				if (c.getResponseCode() != 200) {
-					Log.w(IMapView.LOGTAG, "Problem downloading MapTile: " + tile + " HTTP response: " + c.getResponseMessage());
+					Log.w(IMapView.LOGTAG, "Problem downloading MapTile: " + pTile + " HTTP response: " + c.getResponseMessage());
 					if (Configuration.getInstance().isDebugMapTileDownloader()) {
 						Log.d(IMapView.LOGTAG, tileURLString);
 					}
@@ -238,7 +237,7 @@ public class MapTileDownloader extends MapTileModuleProviderBase {
 						}
 					}
 				}
-				tile.setExpires(dateExpires);
+				pTile.setExpires(dateExpires);
 				StreamUtils.copy(in, out);
 				out.flush();
 				final byte[] data = dataStream.toByteArray();
@@ -248,7 +247,7 @@ public class MapTileDownloader extends MapTileModuleProviderBase {
 				//this is the only point in which we insert tiles to the db or local file system.
 
 				if (mFilesystemCache != null) {
-					mFilesystemCache.saveFile(tileSource, tile, byteStream);
+					mFilesystemCache.saveFile(tileSource, pTile, byteStream);
 					byteStream.reset();
 				}
 				final Drawable result = tileSource.getDrawable(byteStream);
@@ -256,23 +255,23 @@ public class MapTileDownloader extends MapTileModuleProviderBase {
 				return result;
 			} catch (final UnknownHostException e) {
 				// no network connection so empty the queue
-				Log.w(IMapView.LOGTAG,"UnknownHostException downloading MapTile: " + tile + " : " + e);
+				Log.w(IMapView.LOGTAG,"UnknownHostException downloading MapTile: " + pTile + " : " + e);
 				Counters.tileDownloadErrors++;
 				throw new CantContinueException(e);
 			} catch (final LowMemoryException e) {
 				// low memory so empty the queue
 				Counters.countOOM++;
-				Log.w(IMapView.LOGTAG,"LowMemoryException downloading MapTile: " + tile + " : " + e);
+				Log.w(IMapView.LOGTAG,"LowMemoryException downloading MapTile: " + pTile + " : " + e);
 				throw new CantContinueException(e);
 			} catch (final FileNotFoundException e) {
 				Counters.tileDownloadErrors++;
-				Log.w(IMapView.LOGTAG,"Tile not found: " + tile + " : " + e);
+				Log.w(IMapView.LOGTAG,"Tile not found: " + pTile + " : " + e);
 			} catch (final IOException e) {
 				Counters.tileDownloadErrors++;
-				Log.w(IMapView.LOGTAG,"IOException downloading MapTile: " + tile + " : " + e);
+				Log.w(IMapView.LOGTAG,"IOException downloading MapTile: " + pTile + " : " + e);
 			} catch (final Throwable e) {
 				Counters.tileDownloadErrors++;
-				Log.e(IMapView.LOGTAG,"Error downloading MapTile: " + tile, e);
+				Log.e(IMapView.LOGTAG,"Error downloading MapTile: " + pTile, e);
 			} finally {
 				StreamUtils.closeStream(in);
 				StreamUtils.closeStream(out);

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileFileArchiveProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileFileArchiveProvider.java
@@ -102,7 +102,7 @@ public class MapTileFileArchiveProvider extends MapTileFileStorageProviderBase {
 	}
 
 	@Override
-	protected Runnable getTileLoader() {
+	public TileLoader getTileLoader() {
 		return new TileLoader();
 	}
 
@@ -198,14 +198,12 @@ public class MapTileFileArchiveProvider extends MapTileFileStorageProviderBase {
 	protected class TileLoader extends MapTileModuleProviderBase.TileLoader {
 
 		@Override
-		public Drawable loadTile(final MapTileRequestState pState) {
+		public Drawable loadTile(final MapTile pTile) {
 
 			ITileSource tileSource = mTileSource.get();
 			if (tileSource == null) {
 				return null;
 			}
-
-			final MapTile pTile = pState.getMapTile();
 
 			// if there's no sdcard then don't do anything
 			if (!isSdCardAvailable()) {

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileFilesystemProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileFilesystemProvider.java
@@ -95,7 +95,7 @@ public class MapTileFilesystemProvider extends MapTileFileStorageProviderBase {
 	}
 
 	@Override
-	protected Runnable getTileLoader() {
+	public TileLoader getTileLoader() {
 		return new TileLoader();
 	}
 
@@ -124,25 +124,23 @@ public class MapTileFilesystemProvider extends MapTileFileStorageProviderBase {
 	protected class TileLoader extends MapTileModuleProviderBase.TileLoader {
 
 		@Override
-		public Drawable loadTile(final MapTileRequestState pState) throws CantContinueException {
+		public Drawable loadTile(final MapTile pTile) throws CantContinueException {
 
 			ITileSource tileSource = mTileSource.get();
 			if (tileSource == null) {
 				return null;
 			}
 
-			final MapTile tile = pState.getMapTile();
-
 			// if there's no sdcard then don't do anything
 			if (!isSdCardAvailable()) {
 				if (Configuration.getInstance().isDebugMode()) {
-                         Log.d(IMapView.LOGTAG,"No sdcard - do nothing for tile: " + tile);
+                         Log.d(IMapView.LOGTAG,"No sdcard - do nothing for tile: " + pTile);
 				}
 				Counters.fileCacheMiss++;
 				return null;
 			}
 			try {
-				final Drawable result = mWriter.loadTile(tileSource, tile);
+				final Drawable result = mWriter.loadTile(tileSource, pTile);
 				if (result == null) {
 					Counters.fileCacheMiss++;
 				} else {
@@ -151,7 +149,7 @@ public class MapTileFilesystemProvider extends MapTileFileStorageProviderBase {
 				return result;
 			} catch (final BitmapTileSourceBase.LowMemoryException e) {
 				// low memory so empty the queue
-				Log.w(IMapView.LOGTAG, "LowMemoryException downloading MapTile: " + tile + " : " + e);
+				Log.w(IMapView.LOGTAG, "LowMemoryException downloading MapTile: " + pTile + " : " + e);
 				Counters.fileCacheOOM++;
 				throw new MapTileModuleProviderBase.CantContinueException(e);
 			} catch (final Throwable e) {

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileModuleProviderBase.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileModuleProviderBase.java
@@ -48,7 +48,7 @@ public abstract class MapTileModuleProviderBase {
 	 *
 	 * @return the internal member of this tile provider.
 	 */
-	protected abstract Runnable getTileLoader();
+	public abstract TileLoader getTileLoader();
 
 	/**
 	 * Returns true if implementation uses a data connection, false otherwise. This value is used to
@@ -185,18 +185,25 @@ public abstract class MapTileModuleProviderBase {
 	 * to acquire tiles from servers. It processes tiles from the 'pending' set to the 'working' set
 	 * as they become available. The key unimplemented method is 'loadTile'.
 	 */
-	protected abstract class TileLoader implements Runnable {
+	public abstract class TileLoader implements Runnable {
 
 		/**
 		 * Load the requested tile.
 		 *
+		 * @since 5.6.6
 		 * @return the tile if it was loaded successfully, or null if failed to
 		 *         load and other tile providers need to be called
-		 * @param pState
+		 * @param pTile
 		 * @throws CantContinueException
 		 */
-		protected abstract Drawable loadTile(MapTileRequestState pState)
+		public abstract Drawable loadTile(final MapTile pTile)
 				throws CantContinueException;
+
+		@Deprecated
+		protected Drawable loadTile(MapTileRequestState pState)
+				throws CantContinueException {
+			return loadTile(pState.getMapTile());
+		}
 
 		protected void onTileLoaderInit() {
 			// Do nothing by default
@@ -307,7 +314,7 @@ public abstract class MapTileModuleProviderBase {
 				}
 				try {
 					result = null;
-					result = loadTile(state);
+					result = loadTile(state.getMapTile());
 				} catch (final CantContinueException e) {
 					Log.i(IMapView.LOGTAG,"Tile loader can't continue: " + state.getMapTile(), e);
 					clearQueue();

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileSqlCacheProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileSqlCacheProvider.java
@@ -90,7 +90,7 @@ public class MapTileSqlCacheProvider  extends MapTileFileStorageProviderBase{
     }
 
     @Override
-    protected Runnable getTileLoader() {
+    public TileLoader getTileLoader() {
         return new TileLoader();
     }
 
@@ -159,14 +159,12 @@ public class MapTileSqlCacheProvider  extends MapTileFileStorageProviderBase{
     protected class TileLoader extends MapTileModuleProviderBase.TileLoader {
 
         @Override
-        public Drawable loadTile(final MapTileRequestState pState) throws CantContinueException{
+        public Drawable loadTile(final MapTile pTile) throws CantContinueException{
 
             ITileSource tileSource = mTileSource.get();
             if (tileSource == null) {
                 return null;
             }
-
-            final MapTile pTile = pState.getMapTile();
 
             // if there's no sdcard then don't do anything
             if (!isSdCardAvailable()) {

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
@@ -771,8 +771,18 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
 		super.onMeasure(widthMeasureSpec, heightMeasureSpec);
 	}
 
-	@Override
-	protected void onLayout(final boolean changed, final int l, final int t, final int r,
+    @Override
+    protected void onLayout(final boolean changed, final int l, final int t, final int r,
+                            final int b) {
+        myOnLayout(changed, l, t, r, b);
+    }
+
+    /**
+     * Code was moved from {@link #onLayout(boolean, int, int, int, int)}
+     * in order to avoid Android Studio warnings on direct calls
+     * @since 5.6.6
+     */
+	protected void myOnLayout(final boolean changed, final int l, final int t, final int r,
 			final int b) {
 		final int count = getChildCount();
 
@@ -1071,7 +1081,7 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
 
 		// Force a layout, so that children are correctly positioned according to map orientation
 		if (getMapOrientation() != 0f)
-			onLayout(true, getLeft(), getTop(), getRight(), getBottom());
+			myOnLayout(true, getLeft(), getTop(), getRight(), getBottom());
 
 		// do callback on listener
 		if (mListener != null) {

--- a/osmdroid-geopackage/src/main/java/org/osmdroid/gpkg/GeoPackageMapTileModuleProvider.java
+++ b/osmdroid-geopackage/src/main/java/org/osmdroid/gpkg/GeoPackageMapTileModuleProvider.java
@@ -182,10 +182,7 @@ public class GeoPackageMapTileModuleProvider extends MapTileModuleProviderBase {
     protected class TileLoader extends MapTileModuleProviderBase.TileLoader {
 
         @Override
-        public Drawable loadTile(final MapTileRequestState pState) {
-
-            final MapTile pTile = pState.getMapTile();
-
+        public Drawable loadTile(final MapTile pTile) {
             try {
                 Drawable mapTile = getMapTile(pTile);
                 return mapTile;
@@ -209,7 +206,7 @@ public class GeoPackageMapTileModuleProvider extends MapTileModuleProviderBase {
     }
 
     @Override
-    protected Runnable getTileLoader() {
+    public TileLoader getTileLoader() {
         return new TileLoader();
     }
 

--- a/osmdroid-mapsforge/src/main/java/org/osmdroid/mapsforge/MapsForgeTileModuleProvider.java
+++ b/osmdroid-mapsforge/src/main/java/org/osmdroid/mapsforge/MapsForgeTileModuleProvider.java
@@ -57,7 +57,7 @@ public class MapsForgeTileModuleProvider extends MapTileFileStorageProviderBase 
     }
 
     @Override
-    protected Runnable getTileLoader() {
+    public TileLoader getTileLoader() {
         return new TileLoader();
     }
 
@@ -87,15 +87,14 @@ public class MapsForgeTileModuleProvider extends MapTileFileStorageProviderBase 
     private class TileLoader extends MapTileModuleProviderBase.TileLoader {
 
         @Override
-        public Drawable loadTile(final MapTileRequestState pState) {
+        public Drawable loadTile(final MapTile pTile) {
             //TODO find a more efficient want to do this, seems overly complicated
-            MapTile mapTile = pState.getMapTile();
             String dbgPrefix = null;
             if (Configuration.getInstance().isDebugTileProviders()) {
-                dbgPrefix = "MapsForgeTileModuleProvider.TileLoader.loadTile(" + mapTile + "): ";
+                dbgPrefix = "MapsForgeTileModuleProvider.TileLoader.loadTile(" + pTile + "): ";
                 Log.d(IMapView.LOGTAG,dbgPrefix + "tileSource.renderTile");
             }
-            Drawable image= tileSource.renderTile(mapTile);
+            Drawable image= tileSource.renderTile(pTile);
             if (image!=null && image instanceof BitmapDrawable) {
                 ByteArrayOutputStream stream = new ByteArrayOutputStream();
                 ((BitmapDrawable)image).getBitmap().compress(Bitmap.CompressFormat.PNG, 100, stream);
@@ -104,10 +103,10 @@ public class MapsForgeTileModuleProvider extends MapTileFileStorageProviderBase 
                 if (Configuration.getInstance().isDebugTileProviders()) {
                     Log.d(IMapView.LOGTAG, dbgPrefix +
                             "save tile " + bitmapdata.length +
-                            " bytes to " + tileSource.getTileRelativeFilenameString(mapTile));
+                            " bytes to " + tileSource.getTileRelativeFilenameString(pTile));
                 }
 
-                tilewriter.saveFile(tileSource, mapTile, new ByteArrayInputStream(bitmapdata));
+                tilewriter.saveFile(tileSource, pTile, new ByteArrayInputStream(bitmapdata));
             }
             return image;
         }


### PR DESCRIPTION
`MapTileApproximater` now accepts not only one but several providers. They are added using new method `addProvider(final MapTileModuleProviderBase pProvider)`.
When `MapTileApproximater.getTileLoader().loadTile(MapTile mapTile)` is called, we return an approximation from the best possible bitmap, which comes from the best possible zoom level among all providers, and from the first provider on the ordered providers list for that best zoom level.

Files impacted:
* `MapTileApproximater`: changed the constructors, added method `addProvider(final MapTileModuleProviderBase pProvider)`, refactored `approximateTileFromLowerZoom`methods
* `MapTileModuleProviderBase`: `TileLoader` is more `public`, `getTileLoader()` is upgraded from `Runnable` to `TileLoader`, new method `loadTile(final MapTile pTile)` deprecates `loadTile(MapTileRequestState pState)`, with an obvious impact to the classes that extend `MapTileModuleProviderBase`
o `GeoPackageMapTileModuleProvider`
o `MapsForgeTileModuleProvider`
o `MapTileAssetsProvider`
o `MapTileDownloader`
o `MapTileFileArchiveProvider`
o `MapTileFilesystemProvider`
o `MapTileProviderTest`
o `MapTileSqlCacheProvider`
* `MapView`: unrelated Android Studio warning fix
* `MapTileProviderBase`: changed use of `MapTileApproximater.approximateTileFromLowerZoom`
* `MapTileProviderBasic`: changed use of `MapTileApproximater`