### PR TITLE
#743: Fix double tab zoom animation around maximum zoom

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleFactory.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleFactory.java
@@ -8,6 +8,7 @@ import org.osmdroid.samplefragments.animations.AnimatedMarkerHandler;
 import org.osmdroid.samplefragments.animations.AnimatedMarkerTypeEvaluator;
 import org.osmdroid.samplefragments.animations.AnimatedMarkerValueAnimator;
 import org.osmdroid.samplefragments.animations.FastZoomSpeedAnimations;
+import org.osmdroid.samplefragments.animations.MaximumZoomLevel;
 import org.osmdroid.samplefragments.cache.CacheImport;
 import org.osmdroid.samplefragments.cache.CachePurge;
 import org.osmdroid.samplefragments.cache.SampleAlternateCacheDir;
@@ -246,6 +247,7 @@ public final class SampleFactory implements ISampleFactory {
         }
         // 60
         mSamples.add(SampleVeryHighZoomLevel.class);
+        mSamples.add(MaximumZoomLevel.class);
     }
 
     public void addSample(Class<? extends BaseSampleFragment> clz) {

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/animations/MaximumZoomLevel.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/animations/MaximumZoomLevel.java
@@ -1,0 +1,54 @@
+package org.osmdroid.samplefragments.animations;
+
+import android.app.Activity;
+import android.graphics.Color;
+import android.util.Log;
+import android.widget.Toast;
+import java.util.Locale;
+import java.util.Timer;
+import java.util.TimerTask;
+import org.osmdroid.events.MapListener;
+import org.osmdroid.events.ScrollEvent;
+import org.osmdroid.events.ZoomEvent;
+import org.osmdroid.samplefragments.BaseSampleFragment;
+import org.osmdroid.util.GeoPoint;
+import org.osmdroid.views.overlay.FolderOverlay;
+import org.osmdroid.views.overlay.Marker;
+import org.osmdroid.views.overlay.gridlines.LatLonGridlineOverlay;
+
+/**
+ * Demonstrates a one way to move an icon in an animation.
+ * It's dirty but it works
+ * created on 7/29/2017.
+ * https://github.com/osmdroid/osmdroid/issues/636
+ *
+ * @author Alex O'Ree
+ */
+
+public class MaximumZoomLevel extends BaseSampleFragment implements MapListener {
+
+    @Override
+    public String getSampleTitle() {
+        return "Maximum Zoom Level";
+    }
+
+    @Override
+    protected void addOverlays() {
+        super.addOverlays();
+        mMapView.setMaxZoomLevel(5);
+        mMapView.setMapListener(this);
+    }
+
+    @Override
+    public boolean onScroll(ScrollEvent scrollEvent) {
+        return false;
+    }
+
+    @Override
+    public boolean onZoom(ZoomEvent zoomEvent) {
+        String zoomLevel = String.format(Locale.getDefault(), "%.2f", zoomEvent.getZoomLevel());
+        Toast.makeText(getContext(), "Zoom to "+zoomLevel, Toast.LENGTH_SHORT).show();
+        return false;
+    }
+
+}

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/animations/MaximumZoomLevel.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/animations/MaximumZoomLevel.java
@@ -1,28 +1,18 @@
 package org.osmdroid.samplefragments.animations;
 
-import android.app.Activity;
-import android.graphics.Color;
-import android.util.Log;
 import android.widget.Toast;
 import java.util.Locale;
-import java.util.Timer;
-import java.util.TimerTask;
 import org.osmdroid.events.MapListener;
 import org.osmdroid.events.ScrollEvent;
 import org.osmdroid.events.ZoomEvent;
 import org.osmdroid.samplefragments.BaseSampleFragment;
-import org.osmdroid.util.GeoPoint;
-import org.osmdroid.views.overlay.FolderOverlay;
-import org.osmdroid.views.overlay.Marker;
-import org.osmdroid.views.overlay.gridlines.LatLonGridlineOverlay;
 
 /**
- * Demonstrates a one way to move an icon in an animation.
- * It's dirty but it works
- * created on 7/29/2017.
- * https://github.com/osmdroid/osmdroid/issues/636
+ * Demonstrates interaction of double tab zoom with maximum zoom level
+ * created on 10/18/2017.
+ * https://github.com/osmdroid/osmdroid/issues/743
  *
- * @author Alex O'Ree
+ * @author Maradox
  */
 
 public class MaximumZoomLevel extends BaseSampleFragment implements MapListener {


### PR DESCRIPTION
This PR fixes double tab zoom animation around maximum zoom for devices >= Honeycomb.
An example can be found in `Animations - Maximum Zoom Level`.

Issue: https://github.com/osmdroid/osmdroid/issues/743