### PR TITLE
# Use double for maximum and minimum zoom level

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/bugtestfragments/Bug419Zoom.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/bugtestfragments/Bug419Zoom.java
@@ -51,8 +51,8 @@ public class Bug419Zoom extends BaseSampleFragment implements View.OnClickListen
         }
     }
 
-    int i = 0;
-    int x = 0;
+    double i = 0;
+    double x = 0;
 
     //call this from off the UI thread
     public void startTest() {

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/animations/MaximumZoomLevel.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/animations/MaximumZoomLevel.java
@@ -26,7 +26,7 @@ public class MaximumZoomLevel extends BaseSampleFragment implements MapListener 
     @Override
     protected void addOverlays() {
         super.addOverlays();
-        mMapView.setMaxZoomLevel(5);
+        mMapView.setMaxZoomLevel(5.5);
         mMapView.setMapListener(this);
     }
 

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/cache/SampleCacheDownloader.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/cache/SampleCacheDownloader.java
@@ -125,13 +125,13 @@ public class SampleCacheDownloader extends BaseSampleFragment implements View.On
 
         BoundingBox boundingBox = mMapView.getBoundingBox();
         zoom_max=(SeekBar) view.findViewById(R.id.slider_zoom_max);
-        zoom_max.setMax(mMapView.getMaxZoomLevel());
+        zoom_max.setMax((int) mMapView.getMaxZoomLevel());
         zoom_max.setOnSeekBarChangeListener(SampleCacheDownloader.this);
 
 
         zoom_min=(SeekBar) view.findViewById(R.id.slider_zoom_min);
-        zoom_min.setMax(mMapView.getMaxZoomLevel());
-        zoom_min.setProgress(mMapView.getMinZoomLevel());
+        zoom_min.setMax((int) mMapView.getMaxZoomLevel());
+        zoom_min.setProgress((int) mMapView.getMinZoomLevel());
         zoom_min.setOnSeekBarChangeListener(SampleCacheDownloader.this);
         cache_east= (EditText) view.findViewById(R.id.cache_east);
         cache_east.setText(boundingBox.getLonEast() +"");

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/cache/SampleCacheDownloaderArchive.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/cache/SampleCacheDownloaderArchive.java
@@ -132,13 +132,13 @@ public class SampleCacheDownloaderArchive  extends BaseSampleFragment implements
 
         BoundingBox boundingBox = mMapView.getBoundingBox();
         zoom_max=(SeekBar) view.findViewById(R.id.slider_zoom_max);
-        zoom_max.setMax(mMapView.getMaxZoomLevel());
+        zoom_max.setMax((int) mMapView.getMaxZoomLevel());
         zoom_max.setOnSeekBarChangeListener(SampleCacheDownloaderArchive.this);
 
 
         zoom_min=(SeekBar) view.findViewById(R.id.slider_zoom_min);
-        zoom_min.setMax(mMapView.getMaxZoomLevel());
-        zoom_min.setProgress(mMapView.getMinZoomLevel());
+        zoom_min.setMax((int) mMapView.getMaxZoomLevel());
+        zoom_min.setProgress((int) mMapView.getMinZoomLevel());
         zoom_min.setOnSeekBarChangeListener(SampleCacheDownloaderArchive.this);
         cache_east= (EditText) view.findViewById(R.id.cache_east);
         cache_east.setText(boundingBox.getLonEast() +"");

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/cache/SampleCacheDownloaderCustomUI.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/cache/SampleCacheDownloaderCustomUI.java
@@ -132,13 +132,13 @@ public class SampleCacheDownloaderCustomUI extends BaseSampleFragment implements
 
         BoundingBox boundingBox = mMapView.getBoundingBox();
         zoom_max = (SeekBar) view.findViewById(R.id.slider_zoom_max);
-        zoom_max.setMax(mMapView.getMaxZoomLevel());
+        zoom_max.setMax((int) mMapView.getMaxZoomLevel());
         zoom_max.setOnSeekBarChangeListener(SampleCacheDownloaderCustomUI.this);
 
 
         zoom_min = (SeekBar) view.findViewById(R.id.slider_zoom_min);
-        zoom_min.setMax(mMapView.getMaxZoomLevel());
-        zoom_min.setProgress(mMapView.getMinZoomLevel());
+        zoom_min.setMax((int) mMapView.getMaxZoomLevel());
+        zoom_min.setProgress((int) mMapView.getMinZoomLevel());
         zoom_min.setOnSeekBarChangeListener(SampleCacheDownloaderCustomUI.this);
         cache_east = (EditText) view.findViewById(R.id.cache_east);
         cache_east.setText(boundingBox.getLonEast() + "");

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleOsmPath.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleOsmPath.java
@@ -107,7 +107,7 @@ public class SampleOsmPath extends BaseSampleFragment implements MapListener {
 			}
 		});*/
 		mMapView.getOverlayManager().add(line);
-		mMapView.setMaxZoomLevel(22);
+		mMapView.setMaxZoomLevel(22.0);
 
 
 		Marker marker = new Marker(mMapView);

--- a/osmdroid-android/src/main/java/org/osmdroid/api/IMapView.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/api/IMapView.java
@@ -18,7 +18,7 @@ public interface IMapView {
 	 * @since 6.0
 	 */
 	double getZoomLevelDouble();
-	int getMaxZoomLevel();
+	double getMaxZoomLevel();
      @Deprecated
 	int getLatitudeSpan();
      @Deprecated

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/cachemanager/CacheManager.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/cachemanager/CacheManager.java
@@ -81,7 +81,7 @@ public class CacheManager {
     }
 
     public CacheManager(final MapView mapView, IFilesystemCache writer) {
-        this(mapView.getTileProvider(), writer, mapView.getMinZoomLevel(), mapView.getMaxZoomLevel());
+        this(mapView.getTileProvider(), writer, (int) mapView.getMinZoomLevel(), (int) mapView.getMaxZoomLevel());
     }
 
     /**

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
@@ -97,8 +97,8 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
 	protected final AtomicReference<Double> mTargetZoomLevel = new AtomicReference<>();
 	protected final AtomicBoolean mIsAnimating = new AtomicBoolean(false);
 
-	protected Integer mMinimumZoomLevel;
-	protected Integer mMaximumZoomLevel;
+	protected Double mMinimumZoomLevel;
+	protected Double mMaximumZoomLevel;
 
 	private final MapController mController;
 
@@ -394,8 +394,8 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
 	 * Used to be an int - is a double since 6.0
 	 */
 	double setZoomLevel(final double aZoomLevel) {
-		final int minZoomLevel = getMinZoomLevel();
-		final int maxZoomLevel = getMaxZoomLevel();
+		final double minZoomLevel = getMinZoomLevel();
+		final double maxZoomLevel = getMaxZoomLevel();
 
 		final double newZoomLevel = Math.max(minZoomLevel, Math.min(maxZoomLevel, aZoomLevel));
 		final double curZoomLevel = this.mZoomLevel;
@@ -515,7 +515,7 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
 	/**
 	 * Get the minimum allowed zoom level for the maps.
 	 */
-	public int getMinZoomLevel() {
+	public double getMinZoomLevel() {
 		return mMinimumZoomLevel == null ? mMapOverlay.getMinimumZoomLevel() : mMinimumZoomLevel;
 	}
 
@@ -523,7 +523,7 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
 	 * Get the maximum allowed zoom level for the maps.
 	 */
 	@Override
-	public int getMaxZoomLevel() {
+	public double getMaxZoomLevel() {
 		return mMaximumZoomLevel == null ? mMapOverlay.getMaximumZoomLevel() : mMaximumZoomLevel;
 	}
 
@@ -531,7 +531,7 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
 	 * Set the minimum allowed zoom level, or pass null to use the minimum zoom level from the tile
 	 * provider.
 	 */
-	public void setMinZoomLevel(Integer zoomLevel) {
+	public void setMinZoomLevel(Double zoomLevel) {
 		mMinimumZoomLevel = zoomLevel;
 	}
 
@@ -539,12 +539,12 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
 	 * Set the maximum allowed zoom level, or pass null to use the maximum zoom level from the tile
 	 * provider.
 	 */
-	public void setMaxZoomLevel(Integer zoomLevel) {
+	public void setMaxZoomLevel(Double zoomLevel) {
 		mMaximumZoomLevel = zoomLevel;
 	}
 
 	public boolean canZoomIn() {
-		final int maxZoomLevel = getMaxZoomLevel();
+		final double maxZoomLevel = getMaxZoomLevel();
 		if ((isAnimating() ? mTargetZoomLevel.get() : mZoomLevel) >= maxZoomLevel) {
 			return false;
 		}
@@ -552,7 +552,7 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
 	}
 
 	public boolean canZoomOut() {
-		final int minZoomLevel = getMinZoomLevel();
+		final double minZoomLevel = getMinZoomLevel();
 		if ((isAnimating() ? mTargetZoomLevel.get() : mZoomLevel) <= minZoomLevel) {
 			return false;
 		}

--- a/osmdroid-third-party/src/main/java/org/osmdroid/google/wrapper/MapView.java
+++ b/osmdroid-third-party/src/main/java/org/osmdroid/google/wrapper/MapView.java
@@ -75,7 +75,7 @@ public class MapView implements IMapView {
 	}
 
 	@Override
-	public int getMaxZoomLevel() {
+	public double getMaxZoomLevel() {
 		return mMapView.getMaxZoomLevel();
 	}
 


### PR DESCRIPTION
`setMaxZoomLevel` and `setMinZoomLevel` now use `Double` instead of `Integer`.

Inside `CacheManager` the `double` are casted to `int`. I'm not sure this is the correct way to go though.

issue: https://github.com/osmdroid/osmdroid/issues/734