### PR TITLE
Bug/#761 Respect minimum and maximum zoom during pinch-zoom

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleFactory.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleFactory.java
@@ -8,7 +8,7 @@ import org.osmdroid.samplefragments.animations.AnimatedMarkerHandler;
 import org.osmdroid.samplefragments.animations.AnimatedMarkerTypeEvaluator;
 import org.osmdroid.samplefragments.animations.AnimatedMarkerValueAnimator;
 import org.osmdroid.samplefragments.animations.FastZoomSpeedAnimations;
-import org.osmdroid.samplefragments.animations.MaximumZoomLevel;
+import org.osmdroid.samplefragments.animations.MinMaxZoomLevel;
 import org.osmdroid.samplefragments.cache.CacheImport;
 import org.osmdroid.samplefragments.cache.CachePurge;
 import org.osmdroid.samplefragments.cache.SampleAlternateCacheDir;
@@ -61,9 +61,6 @@ import org.osmdroid.samplefragments.tileproviders.OfflinePickerSample;
 import org.osmdroid.samplefragments.tileproviders.SampleAssetsOnly;
 import org.osmdroid.samplefragments.tileproviders.SampleOfflineGemfOnly;
 import org.osmdroid.samplefragments.tileproviders.SampleVeryHighZoomLevel;
-import org.osmdroid.samplefragments.tilesources.NasaWms111Source;
-import org.osmdroid.samplefragments.tilesources.NasaWms130Source;
-import org.osmdroid.samplefragments.tilesources.NasaWmsSrs;
 import org.osmdroid.samplefragments.tilesources.SampleBingHybrid;
 import org.osmdroid.samplefragments.tilesources.SampleBingRoad;
 import org.osmdroid.samplefragments.tilesources.SampleCopyrightOverlay;
@@ -247,7 +244,7 @@ public final class SampleFactory implements ISampleFactory {
         }
         // 60
         mSamples.add(SampleVeryHighZoomLevel.class);
-        mSamples.add(MaximumZoomLevel.class);
+        mSamples.add(MinMaxZoomLevel.class);
     }
 
     public void addSample(Class<? extends BaseSampleFragment> clz) {

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/animations/MinMaxZoomLevel.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/animations/MinMaxZoomLevel.java
@@ -16,18 +16,20 @@ import org.osmdroid.samplefragments.BaseSampleFragment;
  * @since 6.0.0
  */
 
-public class MaximumZoomLevel extends BaseSampleFragment implements MapListener {
+public class MinMaxZoomLevel extends BaseSampleFragment implements MapListener {
 
     @Override
     public String getSampleTitle() {
-        return "Maximum Zoom Level";
+        return "Minimum and Maximum Zoom Level";
     }
 
     @Override
     protected void addOverlays() {
         super.addOverlays();
+        mMapView.setMinZoomLevel(1.5);
         mMapView.setMaxZoomLevel(5.5);
         mMapView.setMapListener(this);
+        mMapView.getController().zoomTo(2.5);
     }
 
     @Override

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
@@ -1189,14 +1189,12 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
 	public boolean setPositionAndScale(final Object obj, final PositionAndScale aNewObjPosAndScale,
 			final PointInfo aTouchPoint) {
 		float multiTouchScale = aNewObjPosAndScale.getScale();
-		// If we are at the first or last zoom level, prevent pinching/expanding
-		if (multiTouchScale > 1 && !canZoomIn()) {
-			multiTouchScale = 1;
-		}
-		if (multiTouchScale < 1 && !canZoomOut()) {
-			multiTouchScale = 1;
-		}
-		mMultiTouchScale = multiTouchScale;
+
+		// If we are exceed the minimum or maximum zoom, prevent pinching/expanding
+		float minMultiTouchScale = (float) Math.exp((getMinZoomLevel() - mZoomLevel) / ZOOM_LOG_BASE_INV);
+		float maxMultiTouchScale = (float) Math.exp((getMaxZoomLevel() - mZoomLevel) / ZOOM_LOG_BASE_INV);
+		mMultiTouchScale = Math.max(Math.min(multiTouchScale, maxMultiTouchScale), minMultiTouchScale);
+
 		// Request a layout, so that children are correctly positioned according to scale
 		requestLayout();
 		invalidate(); // redraw


### PR DESCRIPTION
The pinch-zoom gesture now respects the minimum and maximum zoom. 

Previously it was possible to exceed the minimum and maximum zoom of the mapview  during a pinch-zoom. When the gesture was finished, the zoom snapped to the minimum and maximum zoom. Now the pinch-zoom respects the minimum and maximum zoom and does not allow to exceed these values even during the gesture.

The new behaviour can be tested via  the `MinMaxZoomLevel` sample.

Issue: https://github.com/osmdroid/osmdroid/issues/761