### PR TITLE
feature/#725 - computing the `LinearRing` clip area limits

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/LinearRing.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/LinearRing.java
@@ -69,7 +69,6 @@ class LinearRing implements SegmentClipper.SegmentClippable{
 				mPath.lineTo(pX, pY);
 				mLatestPathPoint.set(pX, pY);
 			}
-			mPath.lineTo(pX, pY);
 		}
 	}
 
@@ -230,7 +229,6 @@ class LinearRing implements SegmentClipper.SegmentClippable{
 		final double powerDifference = pProjection.getProjectedPowerDifference();
 		final PointL screenPoint0 = new PointL(); // points on screen
 		final PointL screenPoint1 = new PointL();
-		final RectL currentSegment = new RectL();
 		PointL firstPoint = null;
 		for (final PointL projectedPoint : pProjectedPoints) {
 			// compute next points
@@ -240,8 +238,7 @@ class LinearRing implements SegmentClipper.SegmentClippable{
 				firstPoint = new PointL(screenPoint1);
 			} else {
 				setCloserPoint(screenPoint0, screenPoint1, worldSize);
-				currentSegment.set(screenPoint0.x, screenPoint0.y, screenPoint1.x, screenPoint1.y);
-				pSegments.add(new RectL(currentSegment));
+				pSegments.add(new RectL(screenPoint0.x, screenPoint0.y, screenPoint1.x, screenPoint1.y));
 			}
 
 			// update starting point to next position
@@ -249,8 +246,7 @@ class LinearRing implements SegmentClipper.SegmentClippable{
 		}
 		if (pClosePath) {
 			if (firstPoint != null) {
-				currentSegment.set(screenPoint0.x, screenPoint0.y, firstPoint.x, firstPoint.y);
-				pSegments.add(new RectL(currentSegment));
+				pSegments.add(new RectL(screenPoint0.x, screenPoint0.y, firstPoint.x, firstPoint.y));
 			}
 		}
 	}

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/LinearRing.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/LinearRing.java
@@ -341,16 +341,16 @@ class LinearRing implements SegmentClipper.SegmentClippable{
 	 */
 	public void setClipArea(final MapView pMapView) {
 		final double border = .1;
-		final int width = pMapView.getWidth();
-		final int height = pMapView.getHeight();
+		final int halfWidth = pMapView.getWidth() / 2;
+		final int halfHeight = pMapView.getHeight() / 2;
 		// People less lazy than me would do more refined computations for width and height
 		// that include the map orientation: the covered area would be smaller but still big enough
-		final double maxSize = Math.max(width, height);
-		final double scaledSize = maxSize / pMapView.getMapScale();
-		final int half = (int) (scaledSize * (.5 + border));
+		// Now we use the circle which contains the `MapView`'s 4 corners
+		final double radius = Math.sqrt(halfWidth * halfWidth + halfHeight * halfHeight);
+		final int scaledRadius = (int) ((radius / pMapView.getMapScale()) * (1 + border));
 		setClipArea(
-				width / 2 - half, height / 2 - half,
-				width / 2 + half, height / 2 + half
+				halfWidth - scaledRadius, halfHeight - scaledRadius,
+				halfWidth + scaledRadius, halfHeight + scaledRadius
 		);
 	}
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polygon.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polygon.java
@@ -211,9 +211,11 @@ public class Polygon extends OverlayWithIW {
 		final Projection pj = mapView.getProjection();
 		mPath.rewind();
 
+		mOutline.setClipArea(mapView);
 		final PointL offset = mOutline.buildPathPortion(pj, true, null);
 		
 		for (LinearRing hole:mHoles){
+			hole.setClipArea(mapView);
 			hole.buildPathPortion(pj, true, offset);
 		}
 		mPath.setFillType(Path.FillType.EVEN_ODD); //for correct support of holes

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polyline.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polyline.java
@@ -198,6 +198,7 @@ public class Polyline extends OverlayWithIW {
         final Projection pj = mapView.getProjection();
         mPath.rewind();
 
+        mOutline.setClipArea(mapView);
         mOutline.buildPathPortion(pj, false, null);
 
         canvas.drawPath(mPath, mPaint);

--- a/osmdroid-android/src/test/java/org/osmdroid/util/SegmentClipperTest.java
+++ b/osmdroid-android/src/test/java/org/osmdroid/util/SegmentClipperTest.java
@@ -54,10 +54,29 @@ public class SegmentClipperTest {
 		Assert.assertEquals(new PointL(1361, 1400), points.get(2));
 		Assert.assertEquals(new PointL(-600, 1400), points.get(3));
 
+		// both segment points are inside the clip area
 		clippable.init();
 		segmentClipper.clip(new RectL(-30, 500, 700, 800));
 		Assert.assertEquals(2, points.size());
 		Assert.assertEquals(new PointL(-30, 500), points.get(0));
 		Assert.assertEquals(new PointL(700, 800), points.get(1));
+
+		// no intersection between clip area and segment
+		// computed corner: top right
+		clippable.init();
+		segmentClipper.clip(new RectL(-1000, -10000, 10000, 10000));
+		Assert.assertEquals(3, points.size());
+		Assert.assertEquals(new PointL(-600, -600), points.get(0));
+		Assert.assertEquals(new PointL(1400, -600), points.get(1));
+		Assert.assertEquals(new PointL(1400, 1400), points.get(2));
+
+		// no intersection between clip area and segment
+		// computed corner: bottom left
+		clippable.init();
+		segmentClipper.clip(new RectL(-10000, -1000, 10000, 10000));
+		Assert.assertEquals(3, points.size());
+		Assert.assertEquals(new PointL(-600, -600), points.get(0));
+		Assert.assertEquals(new PointL(-600, 1400), points.get(1));
+		Assert.assertEquals(new PointL(1400, 1400), points.get(2));
 	}
 }


### PR DESCRIPTION
Impacted classes:
* `LinearRing`: removed clip area limits constants; created methods `setClipArea` in order to set the most relevant clip area according to the current `MapView`
* `Polygon`: used new method `LinearRing.setClipArea(MapView)`
* `Polyline`: used new method `LinearRing.setClipArea(MapView)`