### PR TITLE
#779 Remove permissions from library

### DIFF
--- a/osmdroid-android/src/main/AndroidManifest.xml
+++ b/osmdroid-android/src/main/AndroidManifest.xml
@@ -6,14 +6,6 @@
 	<uses-sdk android:minSdkVersion="8" android:targetSdkVersion="23" />
 	<supports-screens android:largeScreens="true" android:normalScreens="true" android:anyDensity="true" />
 
-	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
-	<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
-	<uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-	<uses-permission android:name="android.permission.INTERNET" />
-	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-
 	<uses-feature android:name="android.hardware.location.network" android:required="false" />
 	<uses-feature android:name="android.hardware.location.gps" android:required="false" />
 	<uses-feature android:name="android.hardware.telephony" android:required="false" />


### PR DESCRIPTION
Removes the permissions from the library in order to not inflict them on developers.
Users of the library have to include them accordingly.

issue: https://github.com/osmdroid/osmdroid/issues/779