### PR TITLE
#781 Add zoom and scale parameters in onDrawItem of ItemizedOverlay

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/ItemizedOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/ItemizedOverlay.java
@@ -157,7 +157,7 @@ public abstract class ItemizedOverlay<Item extends OverlayItem> extends Overlay 
 
             pj.toPixels(item.getPoint(), mCurScreenCoords);
 
-			mInternalItemDisplayedList[i] = onDrawItem(canvas,item, mCurScreenCoords, mapView.getMapOrientation());
+			mInternalItemDisplayedList[i] = onDrawItem(canvas,item, mCurScreenCoords, mapView.getMapOrientation(), mapView.getZoomLevel(false), mapView.getMapScale());
         }
     }
 
@@ -207,7 +207,7 @@ public abstract class ItemizedOverlay<Item extends OverlayItem> extends Overlay 
 	 * @return true if the item was actually drawn
 	 */
 	protected boolean onDrawItem(final Canvas canvas, final Item item, final Point curScreenCoords,
-			final float aMapOrientation) {
+			final float aMapOrientation, final double zoomLevel, final float mapScale) {
 
 		
 

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/ItemizedOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/ItemizedOverlay.java
@@ -157,7 +157,7 @@ public abstract class ItemizedOverlay<Item extends OverlayItem> extends Overlay 
 
             pj.toPixels(item.getPoint(), mCurScreenCoords);
 
-			mInternalItemDisplayedList[i] = onDrawItem(canvas,item, mCurScreenCoords, mapView.getMapOrientation(), mapView.getZoomLevel(false), mapView.getMapScale());
+			mInternalItemDisplayedList[i] = onDrawItem(canvas,item, mCurScreenCoords, mapView);
         }
     }
 
@@ -203,11 +203,11 @@ public abstract class ItemizedOverlay<Item extends OverlayItem> extends Overlay 
 	 * @param item
 	 *            the item to be drawn
 	 * @param curScreenCoords
-	 * @param aMapOrientation
+	 * @param mapView
 	 * @return true if the item was actually drawn
 	 */
 	protected boolean onDrawItem(final Canvas canvas, final Item item, final Point curScreenCoords,
-			final float aMapOrientation, final double zoomLevel, final float mapScale) {
+			final MapView mapView) {
 
 		
 
@@ -223,7 +223,7 @@ public abstract class ItemizedOverlay<Item extends OverlayItem> extends Overlay 
 		int y = mCurScreenCoords.y;
 
 		canvas.save();
-		canvas.rotate(-aMapOrientation, x, y);
+		canvas.rotate(-mapView.getMapOrientation(), x, y);
 		marker.copyBounds(mRect);
 		marker.setBounds(mRect.left + x, mRect.top + y, mRect.right + x, mRect.bottom + y);
 		canvas.scale(1 / scaleX, 1 / scaleY, x, y);


### PR DESCRIPTION
This PR adds the zoom and scale of the map to the parameters of `ItemizedOverlay.onDrawItem(...)`. This allows subclasses to use this parameters for custom logic regarding drawing the icons.

issue: https://github.com/osmdroid/osmdroid/issues/781