### PR TITLE
bug/#762: taking the current scale into account

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
@@ -1032,24 +1032,27 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
 		if (mScrollableAreaBoundingBox == null) {
 			return false;
 		}
-		final double worldSize = TileSystem.MapSize(getZoomLevelDouble());
-		final long offsetX = checkScrollableOffset(
-				getProjection().getLongPixelXFromLongitude(mScrollableAreaBoundingBox.getLonWest(), true),
-				getProjection().getLongPixelXFromLongitude(mScrollableAreaBoundingBox.getLonEast(), true),
-				worldSize,
-				getWidth());
-		final long offsetY = checkScrollableOffset(
-				getProjection().getLongPixelYFromLatitude(mScrollableAreaBoundingBox.getActualNorth(), true),
-				getProjection().getLongPixelYFromLatitude(mScrollableAreaBoundingBox.getActualSouth(), true),
-				worldSize,
-				getHeight());
+		final long west = getProjection().getLongPixelXFromLongitude(mScrollableAreaBoundingBox.getLonWest(), true);
+		final long east = getProjection().getLongPixelXFromLongitude(mScrollableAreaBoundingBox.getLonEast(), true);
+		final long north = getProjection().getLongPixelYFromLatitude(mScrollableAreaBoundingBox.getActualNorth(), true);
+		final long south = getProjection().getLongPixelYFromLatitude(mScrollableAreaBoundingBox.getActualSouth(), true);
+		final Point topRight = getProjection().scalePoint((int)east, (int)north, null);
+		final Point bottomLeft = getProjection().scalePoint((int)west, (int)south, null);
+		final Point bottomRight = getProjection().scalePoint((int)east, (int)south, null);
+		final int left = bottomLeft.x;
+		final int right = bottomRight.x;
+		final int top = topRight.y;
+		final int bottom = bottomRight.y;
+		final double worldSize = TileSystem.MapSize(getZoomLevelDouble()) * mMultiTouchScale;
+		final long offsetX = Math.round(checkScrollableOffset(left, right, worldSize, getWidth()) / mMultiTouchScale);
+		final long offsetY = Math.round(checkScrollableOffset(top, bottom, worldSize, getHeight()) / mMultiTouchScale);
 		if (offsetX == 0 && offsetY == 0) {
 			return false;
 		}
-		setMapScroll(mMapScrollX + offsetX, mMapScrollY + offsetY);
 		resetProjection();
-		mScroller.setFinalX((int)getMapScrollX());
-		mScroller.setFinalY((int)getMapScrollY());
+		mScroller.setFinalX((int)(mMapScrollX + offsetX));
+		mScroller.setFinalY((int)(mMapScrollY + offsetY));
+		setMapScroll(Math.round(mMapScrollX + offsetX), Math.round(mMapScrollY + offsetY));
 		return true;
 	}
 

--- a/osmdroid-android/src/main/java/org/osmdroid/views/Projection.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/Projection.java
@@ -40,6 +40,7 @@ public class Projection implements IProjection {
 
 	private final Matrix mRotateAndScaleMatrix = new Matrix();
 	private final Matrix mUnrotateAndScaleMatrix = new Matrix();
+	private final Matrix mScaleMatrix = new Matrix();
 	private final float[] mRotateScalePoints = new float[2];
 
 	private final BoundingBox mBoundingBoxProjection;
@@ -90,6 +91,8 @@ public class Projection implements IProjection {
 		mRotateAndScaleMatrix.preScale(mMultiTouchScale, mMultiTouchScale, mMultiTouchScalePoint.x, mMultiTouchScalePoint.y);
 		mRotateAndScaleMatrix.preRotate(mOrientation, getScreenCenterX(), getScreenCenterY());
 		mRotateAndScaleMatrix.invert(mUnrotateAndScaleMatrix);
+		mScaleMatrix.preScale(mMultiTouchScale, mMultiTouchScale, mMultiTouchScalePoint.x, mMultiTouchScalePoint.y);
+		mScaleMatrix.preRotate(0, getScreenCenterX(), getScreenCenterY());
 		mScreenRectProjection = new Rect();
 		mScreenRectProjection.left = mIntrinsicScreenRectProjection.left;
 		mScreenRectProjection.top = mIntrinsicScreenRectProjection.top;
@@ -322,20 +325,8 @@ public class Projection implements IProjection {
 	 * drawing to a fixed location on the screen.
 	 */
 	public Point unrotateAndScalePoint(int x, int y, Point reuse) {
-		if (reuse == null)
-			reuse = new Point();
-
-		if (mOrientation != 0 || mMultiTouchScale != 1.0f) {
-			mRotateScalePoints[0] = x;
-			mRotateScalePoints[1] = y;
-			mUnrotateAndScaleMatrix.mapPoints(mRotateScalePoints);
-			reuse.x = (int) mRotateScalePoints[0];
-			reuse.y = (int) mRotateScalePoints[1];
-		} else {
-			reuse.x = x;
-			reuse.y = y;
-		}
-		return reuse;
+		return applyMatrixToPoint(x, y, reuse,
+				mUnrotateAndScaleMatrix, mOrientation != 0 || mMultiTouchScale != 1.0f);
 	}
 
 	/**
@@ -343,20 +334,34 @@ public class Projection implements IProjection {
 	 * converting MotionEvents to a screen point.
 	 */
 	public Point rotateAndScalePoint(int x, int y, Point reuse) {
-		if (reuse == null)
-			reuse = new Point();
+		return applyMatrixToPoint(x, y, reuse,
+				mRotateAndScaleMatrix, mOrientation != 0 || mMultiTouchScale != 1.0f);
+	}
 
-		if (mOrientation != 0 || mMultiTouchScale != 1.0f) {
-			mRotateScalePoints[0] = x;
-			mRotateScalePoints[1] = y;
-			mRotateAndScaleMatrix.mapPoints(mRotateScalePoints);
-			reuse.x = (int) mRotateScalePoints[0];
-			reuse.y = (int) mRotateScalePoints[1];
+	/**
+	 * @since 6.0.0
+	 */
+	public Point scalePoint(int x, int y, Point reuse) {
+		return applyMatrixToPoint(x, y, reuse,
+				mScaleMatrix, mMultiTouchScale != 1.0f);
+	}
+
+	/**
+	 * @since 6.0.0
+	 */
+	private Point applyMatrixToPoint(final int pX, final int pY, final Point reuse, final Matrix pMatrix, final boolean pCondition) {
+		final Point out = reuse != null ? reuse : new Point();
+		if (pCondition) {
+			mRotateScalePoints[0] = pX;
+			mRotateScalePoints[1] = pY;
+			pMatrix.mapPoints(mRotateScalePoints);
+			out.x = (int) mRotateScalePoints[0];
+			out.y = (int) mRotateScalePoints[1];
 		} else {
-			reuse.x = x;
-			reuse.y = y;
+			out.x = pX;
+			out.y = pY;
 		}
-		return reuse;
+		return out;
 	}
 
 	/**


### PR DESCRIPTION
Impacted classes:
* `MapView`: modified method `checkScrollableAreaBoundingBox` in order to take into account the current scale
* `Projection`: added member `Matrix mScaleMatrix` in order to deal with the scale factor without the rotation; added method `scalePoint` in order to apply `mScaleMatrix` to a point; added helper method `applyMatrixToPoint`

Bad news: the map angle isn't taken into account. The results with an angle do not look like a big bug but are not perfect.
I think that in general many things should be fixed regarding the map angle, including the MiniMap behavior. In another issue I guess...