### PR TITLE
Handling tiles that failed due to max queue size being reached

### DIFF
--- a/osmdroid-android-it/src/main/java/org/osmdroid/tileprovider/modules/MapTileProviderTest.java
+++ b/osmdroid-android-it/src/main/java/org/osmdroid/tileprovider/modules/MapTileProviderTest.java
@@ -1,6 +1,6 @@
 /*
  * WARNING, All test cases exist in osmdroid-android-it/src/main/java (maven project)
- * 
+ *
  * During build time (with gradle), these tests are copied from osmdroid-android-it to OpenStreetMapViewer/src/androidTest/java
  * DO NOT Modify files in OpenSteetMapViewer/src/androidTest. You will loose your changes when building!
  *

--- a/osmdroid-android-it/src/main/java/org/osmdroid/tileprovider/modules/MapTileProviderTest.java
+++ b/osmdroid-android-it/src/main/java/org/osmdroid/tileprovider/modules/MapTileProviderTest.java
@@ -1,6 +1,6 @@
 /*
  * WARNING, All test cases exist in osmdroid-android-it/src/main/java (maven project)
- *
+ * 
  * During build time (with gradle), these tests are copied from osmdroid-android-it to OpenStreetMapViewer/src/androidTest/java
  * DO NOT Modify files in OpenSteetMapViewer/src/androidTest. You will loose your changes when building!
  *

--- a/osmdroid-android-it/src/main/java/org/osmdroid/tileprovider/modules/MapTileProviderTest.java
+++ b/osmdroid-android-it/src/main/java/org/osmdroid/tileprovider/modules/MapTileProviderTest.java
@@ -40,6 +40,10 @@ public class MapTileProviderTest extends AndroidTestCase {
 		}
 
 		@Override
+		public void mapTileRequestFailedExceedsMaxQueueSize(final MapTileRequestState aState) {
+		}
+
+		@Override
 		public void mapTileRequestExpiredTile(final MapTileRequestState aState, final Drawable aDrawable) {
 		}
 

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/IMapTileProviderCallback.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/IMapTileProviderCallback.java
@@ -21,6 +21,14 @@ public interface IMapTileProviderCallback {
 	 *            a state object
 	 */
 	void mapTileRequestFailed(MapTileRequestState aState);
+	
+	/**
+	* The map tile request has failed - exceeds MaxQueueSize.
+	*
+	* @param aState
+	*            a state object
+	*/
+	void mapTileRequestFailedExceedsMaxQueueSize(MapTileRequestState aState);
 
 	/**
 	 * The map tile request has produced an expired tile.

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderArray.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderArray.java
@@ -157,6 +157,14 @@ public class MapTileProviderArray extends MapTileProviderBase {
 			super.mapTileRequestFailed(aState);
 		}
 	}
+	
+	@Override
+	public void mapTileRequestFailedExceedsMaxQueueSize(final MapTileRequestState aState) {
+		synchronized (mWorking) {
+			mWorking.remove(aState.getMapTile());
+		}
+		super.mapTileRequestFailed(aState);
+	}
 
 	@Override
 	public void mapTileRequestExpiredTile(MapTileRequestState aState, Drawable aDrawable) {

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderBase.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderBase.java
@@ -194,6 +194,18 @@ public abstract class MapTileProviderBase implements IMapTileProviderCallback {
 	}
 
 	/**
+	 * Called by implementation class methods indicating that they have failed to retrieve the
+	 * requested map tile, because the max queue size has been reached
+	 *
+	 * @param pState
+	 *            the map tile request state object
+	 */
+	@Override
+	public void mapTileRequestFailedExceedsMaxQueueSize(final MapTileRequestState pState) {
+		mapTileRequestFailed(pState);
+	}
+
+	/**
 	 * Called by implementation class methods indicating that they have produced an expired result
 	 * that can be used but better results may be delivered later. The tile is added to the cache,
 	 * and a MAPTILE_SUCCESS_ID message is sent.

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileModuleProviderBase.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileModuleProviderBase.java
@@ -119,7 +119,7 @@ public abstract class MapTileModuleProviderBase {
 					if (result != null) {
 						MapTileRequestState state = mPending.get(result);
 						removeTileFromQueues(result);
-						state.getCallback().mapTileRequestFailed(state);
+						state.getCallback().mapTileRequestFailedExceedsMaxQueueSize(state);
 					}
 				}
 				return false;


### PR DESCRIPTION
Right now, when a tile can not be retrieved due to the max queue size being reached, the callback method `mapTileRequestFailed` is being called just like as if the corresponding provider doesn't have this tile. This is problematic, as `MapTileProviderArray` is then looking for the next appropriate provider for this tile, which we don't want in case the queue is full. This causes too much CPU and Memory load.
Related:  #757, probably also #801

This PR introduces a separation between `mapTileRequestFailed` and the new `mapTileRequestFailedExceedsMaxQueueSize` in:

- IMapTileProviderCallback.java
- MapTileModuleProviderBase.java
- MapTileProviderBase.java
- MapTileProviderArray.java
