### PR TITLE
PointL and RectL method extensions

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/util/PointL.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/PointL.java
@@ -41,6 +41,14 @@ public class PointL {
     /**
      * @since 6.0.0
      */
+    public final void offset(long dx, long dy) {
+        x += dx;
+        y += dy;
+    }
+
+    /**
+     * @since 6.0.0
+     */
     @Override
     public String toString() {
         return "PointL(" + x + ", " + y + ")";

--- a/osmdroid-android/src/main/java/org/osmdroid/util/RectL.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/RectL.java
@@ -54,6 +54,26 @@ public class RectL {
         return a.left < b.right && b.left < a.right && a.top < b.bottom && b.top < a.bottom;
     }
 
+    /**
+     * Returns true if (x,y) is inside the rectangle. Left and top coordinates are considered
+     * inside the bounds, while right and bottom are not.
+     *
+     * @since 6.0.0
+     */
+    public boolean contains(long x, long y) {
+        return left < right && top < bottom && x >= left && x < right && y >= top && y < bottom;
+    }
+
+    /**
+     * @since 6.0.0
+     */
+    public void inset(long dx, long dy) {
+        left += dx;
+        top += dy;
+        right -= dx;
+        bottom -= dy;
+    }
+
     public final long width() {
         return right - left;
     }


### PR DESCRIPTION
New methods for `PointL` and `RectL` classes. These methods are currently not used by osmdroid itself, but may be utilized by users of the library.

`PointL`:
* `offset(dx,dy)`

`RectL`:
* `contains(x,y)`
* `inset(dx,dy)`