### PR TITLE
Optimized the display for `Polyline`

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/drawing/CustomPaintingSurface.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/drawing/CustomPaintingSurface.java
@@ -115,8 +115,10 @@ public class CustomPaintingSurface extends View {
         if (map!=null){
             Projection projection = map.getProjection();
             List<GeoPoint> geoPoints = new ArrayList<>();
+            final Point unrotatedPoint = new Point();
             for (int i=0; i < pts.size(); i++) {
-                GeoPoint iGeoPoint = (GeoPoint) projection.fromPixels(pts.get(i).x, pts.get(i).y);
+                projection.unrotateAndScalePoint(pts.get(i).x, pts.get(i).y, unrotatedPoint);
+                GeoPoint iGeoPoint = (GeoPoint) projection.fromPixels(unrotatedPoint.x, unrotatedPoint.y);
                 geoPoints.add(iGeoPoint);
             }
             //TODO run the douglas pucker algorithm to reduce the points for performance reasons

--- a/osmdroid-android/src/main/java/org/osmdroid/util/LineBuilder.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/LineBuilder.java
@@ -1,0 +1,48 @@
+package org.osmdroid.util;
+
+/**
+ * Created by Fabrice on 03/01/2018.
+ * @since 6.0.0
+ */
+
+public class LineBuilder implements PointAccepter {
+
+    private final ListPointL mPoints = new ListPointL();
+    private float[] mLines;
+    private int mSize;
+
+    @Override
+    public void init() {
+        mPoints.clear();
+        mSize = 0;
+    }
+
+    @Override
+    public void add(final long pX, final long pY) {
+        mPoints.add(pX, pY);
+    }
+
+    @Override
+    public void end() {
+        mSize = mPoints.size() * 2;
+        if (mSize < 4) {
+            return;
+        }
+        if (mLines == null || mLines.length < mSize) {
+            mLines = new float[mSize];
+        }
+        int index = 0;
+        for (final PointL point : mPoints) {
+            mLines[index ++] = point.x;
+            mLines[index ++] = point.y;
+        }
+    }
+
+    public float[] getLines() {
+        return mLines;
+    }
+
+    public int getSize() {
+        return mSize;
+    }
+}

--- a/osmdroid-android/src/main/java/org/osmdroid/util/LineBuilder.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/LineBuilder.java
@@ -5,37 +5,32 @@ package org.osmdroid.util;
  * @since 6.0.0
  */
 
-public class LineBuilder implements PointAccepter {
+public abstract class LineBuilder implements PointAccepter {
 
-    private final ListPointL mPoints = new ListPointL();
-    private float[] mLines;
-    private int mSize;
+    private final float[] mLines;
+    private int mIndex;
+
+    public LineBuilder(final int pMaxSize) {
+        mLines = new float[pMaxSize];
+    }
 
     @Override
     public void init() {
-        mPoints.clear();
-        mSize = 0;
+        mIndex = 0;
     }
 
     @Override
     public void add(final long pX, final long pY) {
-        mPoints.add(pX, pY);
+        mLines[mIndex ++] = pX;
+        mLines[mIndex ++] = pY;
+        if (mIndex >= mLines.length) {
+            innerFlush();
+        }
     }
 
     @Override
     public void end() {
-        mSize = mPoints.size() * 2;
-        if (mSize < 4) {
-            return;
-        }
-        if (mLines == null || mLines.length < mSize) {
-            mLines = new float[mSize];
-        }
-        int index = 0;
-        for (final PointL point : mPoints) {
-            mLines[index ++] = point.x;
-            mLines[index ++] = point.y;
-        }
+        innerFlush();
     }
 
     public float[] getLines() {
@@ -43,6 +38,15 @@ public class LineBuilder implements PointAccepter {
     }
 
     public int getSize() {
-        return mSize;
+        return mIndex;
     }
+
+    private void innerFlush() {
+        if (mIndex > 0) {
+            flush();
+        }
+        mIndex = 0;
+    }
+
+    public abstract void flush();
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/util/ListPointL.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/ListPointL.java
@@ -1,0 +1,64 @@
+package org.osmdroid.util;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Optimized version of List&lt;PointL&gt;
+ * Created by Fabrice on 31/12/2017.
+ * @since 6.0.0
+ */
+
+public class ListPointL implements Iterable<PointL>{
+
+    private final List<PointL> mList = new ArrayList<>();
+    private int mSize;
+
+    public void clear() {
+        mSize = 0;
+    }
+
+    public int size() {
+        return mSize;
+    }
+
+    public PointL get(final int pIndex) {
+        return mList.get(pIndex);
+    }
+
+    public void add(final long pX, final long pY) {
+        final PointL point;
+        if (mSize >= mList.size()) {
+            point = new PointL();
+            mList.add(point);
+        } else {
+            point = mList.get(mSize);
+        }
+        mSize ++;
+        point.set(pX, pY);
+    }
+
+    @Override
+    public Iterator<PointL> iterator() {
+        return new Iterator<PointL>() {
+
+            private int mIndex;
+
+            @Override
+            public boolean hasNext() {
+                return mIndex < mSize;
+            }
+
+            @Override
+            public PointL next() {
+                return get(mIndex ++);
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+}

--- a/osmdroid-android/src/main/java/org/osmdroid/util/PathBuilder.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/PathBuilder.java
@@ -11,6 +11,7 @@ public class PathBuilder implements PointAccepter{
 
     private final Path mPath;
     private final PointL mLatestPoint = new PointL();
+    private final ListPointL mPoints = new ListPointL();
     private boolean mFirst;
 
     public PathBuilder(final Path pPath) {
@@ -20,17 +21,26 @@ public class PathBuilder implements PointAccepter{
     @Override
     public void init() {
         mFirst = true;
+        mPoints.clear();
     }
 
     @Override
     public void add(final long pX, final long pY) {
         if (mFirst) {
             mFirst = false;
-            mPath.moveTo(pX, pY);
+            if (mPath != null) {
+                mPath.moveTo(pX, pY);
+            } else {
+                mPoints.add(pX, pY);
+            }
             mLatestPoint.set(pX, pY);
         } else {
             if (mLatestPoint.x != pX || mLatestPoint.y != pY) {
-                mPath.lineTo(pX, pY);
+                if (mPath != null) {
+                    mPath.lineTo(pX, pY);
+                } else {
+                    mPoints.add(pX, pY);
+                }
                 mLatestPoint.set(pX, pY);
             }
         }
@@ -38,4 +48,11 @@ public class PathBuilder implements PointAccepter{
 
     @Override
     public void end() {}
+
+    /**
+     * @since 6.0.0
+     */
+    public ListPointL getPoints() {
+        return mPoints;
+    }
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/util/PathBuilder.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/PathBuilder.java
@@ -11,7 +11,6 @@ public class PathBuilder implements PointAccepter{
 
     private final Path mPath;
     private final PointL mLatestPoint = new PointL();
-    private final ListPointL mPoints = new ListPointL();
     private boolean mFirst;
 
     public PathBuilder(final Path pPath) {
@@ -21,38 +20,20 @@ public class PathBuilder implements PointAccepter{
     @Override
     public void init() {
         mFirst = true;
-        mPoints.clear();
     }
 
     @Override
     public void add(final long pX, final long pY) {
         if (mFirst) {
             mFirst = false;
-            if (mPath != null) {
-                mPath.moveTo(pX, pY);
-            } else {
-                mPoints.add(pX, pY);
-            }
+            mPath.moveTo(pX, pY);
             mLatestPoint.set(pX, pY);
-        } else {
-            if (mLatestPoint.x != pX || mLatestPoint.y != pY) {
-                if (mPath != null) {
-                    mPath.lineTo(pX, pY);
-                } else {
-                    mPoints.add(pX, pY);
-                }
-                mLatestPoint.set(pX, pY);
-            }
+        } else if (mLatestPoint.x != pX || mLatestPoint.y != pY) {
+            mPath.lineTo(pX, pY);
+            mLatestPoint.set(pX, pY);
         }
     }
 
     @Override
     public void end() {}
-
-    /**
-     * @since 6.0.0
-     */
-    public ListPointL getPoints() {
-        return mPoints;
-    }
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/util/SegmentClipper.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/SegmentClipper.java
@@ -68,6 +68,11 @@ public class SegmentClipper implements PointAccepter{
      * Clip a segment into the clip area
      */
     public void clip(final long pX0, final long pY0, final long pX1, final long pY1) {
+        if (!mPathMode) {
+            if (isOnTheSameSideOut(pX0, pY0, pX1, pY1)) {
+                return;
+            }
+        }
         if (isInClipArea(pX0, pY0)) {
             if (isInClipArea(pX1, pY1)) {
                 nextVertex(pX0, pY0);
@@ -226,4 +231,18 @@ public class SegmentClipper implements PointAccepter{
         }
         return corner;
     }
+
+    /**
+     * Optimization for lines (as opposed to Path)
+     * If both points are outside of the clip area and "on the same side of the outside" (sic)
+     * we don't need to compute anything anymore as it won't draw a line in the end
+     * @since 6.0.0
+     */
+    private boolean isOnTheSameSideOut(final long pX0, final long pY0, final long pX1, final long pY1) {
+        return (pX0 < mXMin && pX1 < mXMin)
+                || (pX0 > mXMax && pX1 > mXMax)
+                || (pY0 < mYMin && pY1 < mYMin)
+                || (pY0 > mYMax && pY1 > mYMax);
+    }
+
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/util/SegmentClipper.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/SegmentClipper.java
@@ -45,6 +45,7 @@ public class SegmentClipper implements PointAccepter{
     @Override
     public void init() {
         mFirstPoint = true;
+        mPointAccepter.init();
     }
 
     @Override
@@ -59,7 +60,9 @@ public class SegmentClipper implements PointAccepter{
     }
 
     @Override
-    public void end() {}
+    public void end() {
+        mPointAccepter.end();
+    }
 
     /**
      * Clip a segment into the clip area

--- a/osmdroid-android/src/main/java/org/osmdroid/util/SegmentClipper.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/SegmentClipper.java
@@ -23,9 +23,13 @@ public class SegmentClipper implements PointAccepter{
     private final PointL mPoint0 = new PointL();
     private final PointL mPoint1 = new PointL();
     private boolean mFirstPoint;
+    /**
+     * If true we keep the invisible segments: they have an impact on Path inner area
+     */
+    private boolean mPathMode;
 
     public void set(final long pXMin, final long pYMin, final long pXMax, final long pYMax,
-                    final PointAccepter pPointAccepter) {
+                    final PointAccepter pPointAccepter, final boolean pPathMode) {
         mXMin = pXMin;
         mYMin = pYMin;
         mXMax = pXMax;
@@ -35,6 +39,7 @@ public class SegmentClipper implements PointAccepter{
         cornerY[0] = cornerY[2] = mYMin;
         cornerY[1] = cornerY[3] = mYMax;
         mPointAccepter = pPointAccepter;
+        mPathMode = pPathMode;
     }
 
     @Override
@@ -69,14 +74,18 @@ public class SegmentClipper implements PointAccepter{
             if (intersection(pX0, pY0, pX1, pY1)) {
                 nextVertex(pX0, pY0);
                 nextVertex(mOptimIntersection.x, mOptimIntersection.y);
-                nextVertex(clipX(pX1), clipY(pY1));
+                if (mPathMode) {
+                    nextVertex(clipX(pX1), clipY(pY1));
+                }
                 return;
             }
             throw new RuntimeException("Cannot find expected mOptimIntersection for " + new RectL(pX0, pY0, pX1, pY1));
         }
         if (isInClipArea(pX1, pY1)) {
             if (intersection(pX0, pY0, pX1, pY1)) {
-                nextVertex(clipX(pX0), clipY(pY0));
+                if (mPathMode) {
+                    nextVertex(clipX(pX0), clipY(pY0));
+                }
                 nextVertex(mOptimIntersection.x, mOptimIntersection.y);
                 nextVertex(pX1, pY1);
                 return;
@@ -108,23 +117,31 @@ public class SegmentClipper implements PointAccepter{
                     mOptimIntersection2.x, mOptimIntersection2.y, pX0, pY0);
             final PointL start = distance1 < distance2 ? mOptimIntersection1 : mOptimIntersection2;
             final PointL end =  distance1 < distance2 ? mOptimIntersection2 : mOptimIntersection1;
-            nextVertex(clipX(pX0), clipY(pY0));
+            if (mPathMode) {
+                nextVertex(clipX(pX0), clipY(pY0));
+            }
             nextVertex(start.x, start.y);
             nextVertex(end.x, end.y);
-            nextVertex(clipX(pX1), clipY(pY1));
+            if (mPathMode) {
+                nextVertex(clipX(pX1), clipY(pY1));
+            }
             return;
         }
         if (count == 1) {
-            nextVertex(clipX(pX0), clipY(pY0));
-            nextVertex(mOptimIntersection1.x, mOptimIntersection1.y);
-            nextVertex(clipX(pX1), clipY(pY1));
+            if (mPathMode) {
+                nextVertex(clipX(pX0), clipY(pY0));
+                nextVertex(mOptimIntersection1.x, mOptimIntersection1.y);
+                nextVertex(clipX(pX1), clipY(pY1));
+            }
             return;
         }
         if (count == 0) {
-            nextVertex(clipX(pX0), clipY(pY0));
-            final int corner = getClosestCorner(pX0, pY0, pX1, pY1);
-            nextVertex(cornerX[corner], cornerY[corner]);
-            nextVertex(clipX(pX1), clipY(pY1));
+            if (mPathMode) {
+                nextVertex(clipX(pX0), clipY(pY0));
+                final int corner = getClosestCorner(pX0, pY0, pX1, pY1);
+                nextVertex(cornerX[corner], cornerY[corner]);
+                nextVertex(clipX(pX1), clipY(pY1));
+            }
             return;
         }
         throw new RuntimeException("Impossible mOptimIntersection count (" + count + ")");

--- a/osmdroid-android/src/main/java/org/osmdroid/views/Projection.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/Projection.java
@@ -32,7 +32,11 @@ import android.graphics.Canvas;
  */
 public class Projection implements IProjection {
 
-	private final double mProjectedMapSize = TileSystem.MapSize((double)microsoft.mappoint.TileSystem.projectionZoomLevel);
+	/**
+	 * WARNING: `mProjectedMapSize` MUST NOT be a static member,
+	 * as it depends on {@link TileSystem#getTileSize()}
+	 */
+	public final double mProjectedMapSize = TileSystem.MapSize((double)microsoft.mappoint.TileSystem.projectionZoomLevel);
 	private long mOffsetX;
 	private long mOffsetY;
 

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/LineDrawer.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/LineDrawer.java
@@ -1,0 +1,36 @@
+package org.osmdroid.views.overlay;
+
+import android.graphics.Canvas;
+import android.graphics.Paint;
+
+import org.osmdroid.util.LineBuilder;
+
+/**
+ * Created by Fabrice on 04/01/2018.
+ * @since 6.0.0
+ */
+
+public class LineDrawer extends LineBuilder{
+
+    private Canvas mCanvas;
+    private Paint mPaint;
+
+    public LineDrawer(int pMaxSize) {
+        super(pMaxSize);
+    }
+
+    public void setCanvas(final Canvas pCanvas) {
+        mCanvas = pCanvas;
+    }
+
+    public void setPaint(final Paint pPaint) {
+        mPaint = pPaint;
+    }
+
+    @Override
+    public void flush() {
+        if (getSize() >= 4) {
+            mCanvas.drawLines(getLines(), 0, getSize(), mPaint);
+        }
+    }
+}

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/LinearRing.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/LinearRing.java
@@ -6,10 +6,11 @@ import android.graphics.Rect;
 
 import org.osmdroid.util.Distance;
 import org.osmdroid.util.GeoPoint;
+import org.osmdroid.util.LineBuilder;
 import org.osmdroid.util.ListPointL;
 import org.osmdroid.util.PathBuilder;
+import org.osmdroid.util.PointAccepter;
 import org.osmdroid.util.PointL;
-import org.osmdroid.util.RectL;
 import org.osmdroid.util.SegmentClipper;
 import org.osmdroid.util.TileSystem;
 import org.osmdroid.views.MapView;
@@ -44,35 +45,43 @@ class LinearRing{
 	 */
 
 	private final ArrayList<GeoPoint> mOriginalPoints = new ArrayList<>();
-	private final ArrayList<Double> mDistances = new ArrayList<>();
-	private final ArrayList<PointL> mProjectedPoints = new ArrayList<>();
+	private double[] mDistances;
+	private long[] mProjectedPoints;
+	private final PointL mProjectedCenter = new PointL();
 	private final SegmentClipper mSegmentClipper = new SegmentClipper();
 	private final Path mPath;
 	private boolean mPrecomputed;
 	private boolean isHorizontalRepeating = true;
 	private boolean isVerticalRepeating  = true;
-	private final ListPointL mGatheredPoints = new ListPointL();
-	private final PathBuilder mPathBuilder;
+	private final ListPointL mPointsForMilestones = new ListPointL();
+	private final PointAccepter mPointAccepter;
 
+	/**
+	 * Dedicated to `Path`
+	 */
 	public LinearRing(final Path pPath) {
 		mPath = pPath;
-		mPathBuilder = new PathBuilder(pPath);
+		mPointAccepter = new PathBuilder(pPath);
+	}
+
+	/**
+	 * Dedicated to lines
+	 * @since 6.0.0
+	 */
+	public LinearRing(final LineBuilder pLineBuilder) {
+		mPath = null;
+		mPointAccepter = pLineBuilder;
 	}
 
 	void clearPath() {
 		mOriginalPoints.clear();
-		mDistances.clear();
+		mProjectedPoints = null;
+		mDistances = null;
 		mPrecomputed = false;
+		mPointAccepter.init();
 	}
 
 	void addPoint(final GeoPoint pGeoPoint) {
-		final int size = mOriginalPoints.size();
-		if (size == 0) {
-			mDistances.add(0d);
-		} else {
-			final GeoPoint previous = mOriginalPoints.get(size - 1);
-			mDistances.add(previous.distanceToAsDouble(pGeoPoint));
-		}
 		mOriginalPoints.add(pGeoPoint);
 		mPrecomputed = false;
 	}
@@ -81,7 +90,7 @@ class LinearRing{
 		return mOriginalPoints;
 	}
 
-	ArrayList<Double> getDistances(){
+	double[] getDistances(){
 		return mDistances;
 	}
 
@@ -98,24 +107,23 @@ class LinearRing{
 	 * In most cases (Polygon without holes, Polyline) the offset parameter will be null.
 	 * In the case of a Polygon with holes, the first path will use a null offset.
 	 * Then this method will return the pixel offset computed for this path so that
-	 * the path is in the best possible place on the map (maximum area on the map + top left).
+	 * the path is in the best possible place on the map:
+	 * the center of all pixels is as close to the screen center as possible
 	 * Then, this computed offset must be injected into the buildPathPortion for each hole,
 	 * in order to have the main polygon and its holes at the same place on the map.
 	 * @return the initial offset if not null, or the computed offset
 	 */
 	PointL buildPathPortion(final Projection pProjection,
-							final boolean pClosePath, final PointL pOffset){
+							final PointL pOffset,
+							final boolean pStorePoints){
 		final int size = mOriginalPoints.size();
 		if (size < 2) { // nothing to paint
 			return pOffset;
 		}
-
 		if (!mPrecomputed){
-			getProjectedFromGeo(mOriginalPoints, mProjectedPoints, pProjection);
+			computeProjectedAndDistances(pProjection);
 			mPrecomputed = true;
 		}
-
-		getGatheredPointsFromProjected(pProjection, mProjectedPoints);
 		final PointL offset;
 		if (pOffset != null) {
 			offset = pOffset;
@@ -123,82 +131,103 @@ class LinearRing{
 			offset = new PointL();
 			getBestOffset(pProjection, offset);
 		}
-		applyOffset(offset);
-		if (pClosePath) {
-			if (mGatheredPoints.size() > 0) {
-				final PointL first = mGatheredPoints.get(0);
-				mGatheredPoints.add(first.x, first.y);
-			}
-		}
-		mPathBuilder.init();
 		mSegmentClipper.init();
-		for (final PointL point : mGatheredPoints) {
-			mSegmentClipper.add(point.x, point.y);
-		}
+		clipAndStore(pProjection, offset, true, pStorePoints);
 		mSegmentClipper.end();
-		mPathBuilder.end();
-		if (pClosePath) {
-			if (mPath != null) {
-				mPath.close();
-			}
-		}
+		mPath.close();
 		return offset;
+	}
+
+	/**
+	 * Dedicated to Polyline, as they can run much faster with drawLine than through a Path
+	 * @since 6.0.0
+	 */
+	void buildLinePortion(final Projection pProjection,
+						  final boolean pStorePoints){
+		final int size = mOriginalPoints.size();
+		if (size < 2) { // nothing to paint
+			return;
+		}
+		if (!mPrecomputed){
+			computeProjectedAndDistances(pProjection);
+			mPrecomputed = true;
+		}
+		final PointL offset = new PointL();
+		getBestOffset(pProjection, offset);
+		mSegmentClipper.init();
+		clipAndStore(pProjection, offset, false, pStorePoints);
+		mSegmentClipper.end();
 	}
 
 	/**
 	 * @since 6.0.0
 	 */
-	public ListPointL getGatheredPoints() {
-		return mGatheredPoints;
+	public ListPointL getPointsForMilestones() {
+		return mPointsForMilestones;
 	}
 
 	/**
 	 * Compute the pixel offset so that a list of pixel segments display in the best possible way:
-	 * the biggest possible covered area, and top left.
+	 * the center of all pixels is as close to the screen center as possible
 	 * This notion of pixel offset only has a meaning on very low zoom level,
 	 * when a GeoPoint can be projected on different places on the screen.
 	 */
 	private void getBestOffset(final Projection pProjection, final PointL pOffset) {
+		final double powerDifference = pProjection.getProjectedPowerDifference();
+		final PointL center = pProjection.getLongPixelsFromProjected(
+				mProjectedCenter, powerDifference, false, null);
 		final Rect screenRect = pProjection.getIntrinsicScreenRect();
+		final double screenCenterX = (screenRect.left + screenRect.right) / 2.;
+		final double screenCenterY = (screenRect.top + screenRect.bottom) / 2.;
 		final double worldSize = TileSystem.MapSize(pProjection.getZoomLevel());
-		final RectL boundingBox = getBoundingBox(mGatheredPoints);
-		getBestOffset(boundingBox, screenRect, worldSize, pOffset);
+		getBestOffset(center.x, center.y, screenCenterX, screenCenterY, worldSize, pOffset);
 	}
 
-	private void getBestOffset(final RectL pBoundingBox, final Rect pScreenRect,
+	/**
+	 * @since 6.0.0
+	 */
+	private void getBestOffset(final double pPolyCenterX, final double pPolyCenterY,
+							   final double pScreenCenterX, final double pScreenCenterY,
 							   final double pWorldSize, final PointL pOffset) {
 		final long worldSize = Math.round(pWorldSize);
-		int deltaXPositive = getBestOffset(pBoundingBox, pScreenRect, worldSize, 0);
-		int deltaXNegative = getBestOffset(pBoundingBox, pScreenRect, -worldSize, 0);
-		int deltaYPositive = getBestOffset(pBoundingBox, pScreenRect, 0, worldSize);
-		int deltaYNegative = getBestOffset(pBoundingBox, pScreenRect, 0, -worldSize);
+		int deltaPositive;
+		int deltaNegative;
 		if (!isVerticalRepeating) {
-			deltaYPositive=0;
-			deltaYNegative=0;
+			deltaPositive = 0;
+			deltaNegative = 0;
+		} else {
+			deltaPositive = getBestOffset(
+					pPolyCenterX, pPolyCenterY, pScreenCenterX, pScreenCenterY, 0, worldSize);
+			deltaNegative = getBestOffset(
+					pPolyCenterX, pPolyCenterY, pScreenCenterX, pScreenCenterY, 0, -worldSize);
+
 		}
+		pOffset.y = worldSize * (deltaPositive > deltaNegative ? deltaPositive:-deltaNegative);
 		if (!isHorizontalRepeating) {
-			deltaXPositive=0;
-			deltaXNegative=0;
+			deltaPositive = 0;
+			deltaNegative = 0;
+		} else {
+			deltaPositive = getBestOffset(
+					pPolyCenterX, pPolyCenterY, pScreenCenterX, pScreenCenterY, worldSize, 0);
+			deltaNegative = getBestOffset(
+					pPolyCenterX, pPolyCenterY, pScreenCenterX, pScreenCenterY, -worldSize, 0);
+
 		}
-		pOffset.x = worldSize * (deltaXPositive > deltaXNegative ? deltaXPositive:-deltaXNegative);
-		pOffset.y = worldSize * (deltaYPositive > deltaYNegative ? deltaYPositive:-deltaYNegative);
+		pOffset.x = worldSize * (deltaPositive > deltaNegative ? deltaPositive:-deltaNegative);
 	}
 
-	private int getBestOffset(final RectL pBoundingBox, final Rect pScreenRect,
+	/**
+	 * @since 6.0.0
+	 */
+	private int getBestOffset(final double pPolyCenterX, final double pPolyCenterY,
+							  final double pScreenCenterX, final double pScreenCenterY,
 							  final long pDeltaX, final long pDeltaY) {
-		if (!isHorizontalRepeating && !isVerticalRepeating ) {
-			return 0;
-		}
-		final double boundingBoxCenterX = (pBoundingBox.left + pBoundingBox.right) / 2.;
-		final double boundingBoxCenterY = (pBoundingBox.top + pBoundingBox.bottom) / 2.;
-		final double screenRectCenterX = (pScreenRect.left + pScreenRect.right) / 2.;
-		final double screenRectCenterY = (pScreenRect.top + pScreenRect.bottom) / 2.;
 		double squaredDistance = 0;
 		int i = 0;
 		while(true) {
 			final double tmpSquaredDistance = Distance.getSquaredDistanceToPoint(
-					boundingBoxCenterX + i * pDeltaX, boundingBoxCenterY + i * pDeltaY,
-					screenRectCenterX, screenRectCenterY);
+					pPolyCenterX + i * pDeltaX, pPolyCenterY + i * pDeltaY,
+					pScreenCenterX, pScreenCenterY);
 			if (i == 0 || squaredDistance > tmpSquaredDistance) {
 				squaredDistance = tmpSquaredDistance;
 				i ++;
@@ -209,66 +238,80 @@ class LinearRing{
 		return i - 1;
 	}
 
-	private RectL getBoundingBox(final ListPointL pPoints) {
-		final RectL out = new RectL();
-		boolean first = true;
-		for (final PointL point : pPoints) {
-			if (first) {
-				first = false;
-				out.left = out.right = point.x;
-				out.top = out.bottom = point.y;
+	private void computeProjectedAndDistances(final Projection pProjection) {
+		if (mProjectedPoints == null || mProjectedPoints.length != mOriginalPoints.size() * 2) {
+			mProjectedPoints = new long[mOriginalPoints.size() * 2];
+		}
+		if (mDistances == null || mDistances.length != mOriginalPoints.size()) {
+			mDistances = new double[mOriginalPoints.size()];
+		}
+		long minX = 0;
+		long maxX = 0;
+		long minY = 0;
+		long maxY = 0;
+		int index = 0;
+		final PointL previous = new PointL();
+		final PointL current = new PointL();
+		final GeoPoint previousGeo = new GeoPoint(0., 0);
+		for (final GeoPoint currentGeo : mOriginalPoints) {
+			pProjection.toProjectedPixels(currentGeo.getLatitude(), currentGeo.getLongitude(), current);
+			if (index == 0) {
+				mDistances[index] = 0;
+				minX = maxX = current.x;
+				minY = maxY = current.y;
 			} else {
-				if (out.left > point.x) {
-					out.left = point.x;
+				mDistances[index] = currentGeo.distanceToAsDouble(previousGeo);
+				setCloserPoint(previous, current, pProjection.mProjectedMapSize);
+				if (minX > current.x) {
+					minX = current.x;
 				}
-				if (out.top > point.y) {
-					out.top = point.y;
+				if (maxX < current.x) {
+					maxX = current.x;
 				}
-				if (out.right < point.x) {
-					out.right = point.x;
+				if (minY > current.y) {
+					minY = current.y;
 				}
-				if (out.bottom < point.y) {
-					out.bottom = point.y;
+				if (maxY < current.y) {
+					maxY = current.y;
 				}
 			}
+			mProjectedPoints[2 * index] = current.x;
+			mProjectedPoints[2 * index + 1] = current.y;
+			previousGeo.setCoords(currentGeo.getLatitude(), currentGeo.getLongitude());
+			previous.set(current.x, current.y);
+			index ++;
 		}
-		return out;
-	}
-
-	private void getProjectedFromGeo(final List<GeoPoint> pGeo, final ArrayList<PointL> pProjected,
-									final Projection pProjection) {
-		pProjected.clear();
-		pProjected.ensureCapacity(pGeo.size());
-		for (final GeoPoint geoPoint : pGeo) {
-			pProjected.add(pProjection.toProjectedPixels(
-					geoPoint.getLatitude(), geoPoint.getLongitude(), null));
-		}
+		mProjectedCenter.set((minX + maxX) / 2, (minY + maxY) / 2);
 	}
 
 	/**
 	 * @since 6.0.0
 	 */
-	private void getGatheredPointsFromProjected(final Projection pProjection,
-												final List<PointL> pProjectedPoints) {
-		mGatheredPoints.clear();
-		final double worldSize = TileSystem.MapSize(pProjection.getZoomLevel());
+	private void clipAndStore(final Projection pProjection, final PointL pOffset,
+							  final boolean pClosePath, final boolean pStorePoints) {
+		mPointsForMilestones.clear();
 		final double powerDifference = pProjection.getProjectedPowerDifference();
-		final PointL screenPoint0 = new PointL(); // points on screen
-		final PointL screenPoint1 = new PointL();
-		PointL firstPoint = null;
-		for (final PointL projectedPoint : pProjectedPoints) {
-			// compute next points
-			pProjection.getLongPixelsFromProjected(
-					projectedPoint, powerDifference, false, screenPoint1);
-			if (firstPoint == null) {
-				firstPoint = new PointL(screenPoint1);
-			} else {
-				setCloserPoint(screenPoint0, screenPoint1, worldSize);
+		final PointL projected = new PointL();
+		final PointL point = new PointL();
+		final PointL first = new PointL();
+		for (int i = 0 ; i < mProjectedPoints.length ; i += 2) {
+			projected.set(mProjectedPoints[i], mProjectedPoints[i + 1]);
+			pProjection.getLongPixelsFromProjected(projected, powerDifference, false, point);
+			final long x = point.x + pOffset.x;
+			final long y = point.y + pOffset.y;
+			if (pStorePoints) {
+				mPointsForMilestones.add(x, y);
 			}
-			mGatheredPoints.add(screenPoint1.x, screenPoint1.y);
-
-			// update starting point to next position
-			screenPoint0.set(screenPoint1);
+			mSegmentClipper.add(x, y);
+			if (i == 0) {
+				first.set(x, y);
+			}
+		}
+		if (pClosePath) {
+			mSegmentClipper.add(first.x, first.y);
+			if (pStorePoints) {
+				mPointsForMilestones.add(first.x, first.y);
+			}
 		}
 	}
 
@@ -298,21 +341,20 @@ class LinearRing{
 	 * @return true if the Polyline is close enough to the point.
 	 */
 	boolean isCloseTo(final GeoPoint pPoint, final double tolerance,
-							 final Projection pProjection) {
+					  final Projection pProjection, final boolean pClosePath) {
 		if (!mPrecomputed){
-			getProjectedFromGeo(mOriginalPoints, mProjectedPoints, pProjection);
+			computeProjectedAndDistances(pProjection);
 			mPrecomputed = true;
 		}
 		final Point pixel = pProjection.toPixels(pPoint, null);
-		getGatheredPointsFromProjected(pProjection, mProjectedPoints);
 		final PointL offset = new PointL();
 		getBestOffset(pProjection, offset);
-		applyOffset(offset);
+		clipAndStore(pProjection, offset, pClosePath, true);
 		final double squaredTolerance = tolerance * tolerance;
 		final PointL point0 = new PointL();
 		final PointL point1 = new PointL();
 		boolean first = true;
-		for (final PointL point : mGatheredPoints) {
+		for (final PointL point : mPointsForMilestones) {
 			point1.set(point);
 			if (first) {
 				first = false;
@@ -325,26 +367,12 @@ class LinearRing{
 		return false;
 	}
 
-	private void applyOffset(final PointL pOffset) {
-		if (pOffset.x == 0 && pOffset.y == 0) {
-			return;
-		}
-		for (final PointL point : mGatheredPoints) {
-			if (pOffset.x != 0) {
-				pOffset.x += pOffset.x;
-			}
-			if (pOffset.y != 0) {
-				point.y += pOffset.y;
-			}
-		}
-	}
-
 	/**
 	 * @since 6.0.0
 	 * Mandatory use before clipping.
 	 */
 	public void setClipArea(final long pXMin, final long pYMin, final long pXMax, final long pYMax) {
-		mSegmentClipper.set(pXMin, pYMin, pXMax, pYMax, mPathBuilder, mPath != null);
+		mSegmentClipper.set(pXMin, pYMin, pXMax, pYMax, mPointAccepter, mPath != null);
 	}
 
 	/**
@@ -367,12 +395,5 @@ class LinearRing{
 		// TODO: Not sure if this is the correct approach 
 		this.isHorizontalRepeating = pMapView.isHorizontalMapRepetitionEnabled();
 		this.isVerticalRepeating = pMapView.isVerticalMapRepetitionEnabled();
-	}
-
-	/**
-	 * @since 6.0.0
-	 */
-	public ListPointL getSegmentPoints() {
-		return mPathBuilder.getPoints();
 	}
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polygon.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polygon.java
@@ -213,11 +213,11 @@ public class Polygon extends OverlayWithIW {
 		mPath.rewind();
 
 		mOutline.setClipArea(mapView);
-		final PointL offset = mOutline.buildPathPortion(pj, true, null);
+		final PointL offset = mOutline.buildPathPortion(pj, null, mMilestoneManagers.size() > 0);
 		for (final MilestoneManager milestoneManager : mMilestoneManagers) {
 			milestoneManager.init();
 			milestoneManager.setDistances(mOutline.getDistances());
-			for (final PointL point : mOutline.getGatheredPoints()) {
+			for (final PointL point : mOutline.getPointsForMilestones()) {
 				milestoneManager.add(point.x, point.y);
 			}
 			milestoneManager.end();
@@ -225,7 +225,7 @@ public class Polygon extends OverlayWithIW {
 
 		for (LinearRing hole:mHoles){
 			hole.setClipArea(mapView);
-			hole.buildPathPortion(pj, true, offset);
+			hole.buildPathPortion(pj, offset, mMilestoneManagers.size() > 0);
 		}
 		mPath.setFillType(Path.FillType.EVEN_ODD); //for correct support of holes
 

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polyline.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polyline.java
@@ -7,7 +7,6 @@ import android.graphics.Paint;
 import android.view.MotionEvent;
 
 import org.osmdroid.util.GeoPoint;
-import org.osmdroid.util.LineBuilder;
 import org.osmdroid.util.PointL;
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.Projection;
@@ -36,8 +35,8 @@ public class Polyline extends OverlayWithIW {
 
 	private boolean mGeodesic;
 	private final Paint mPaint = new Paint();
-	private final LineBuilder mLineBuilder = new LineBuilder();
-    private LinearRing mOutline = new LinearRing(mLineBuilder);
+	private final LineDrawer mLineDrawer = new LineDrawer(256);
+    private LinearRing mOutline = new LinearRing(mLineDrawer);
 	private String id=null;
 	private List<MilestoneManager> mMilestoneManagers = new ArrayList<>();
 
@@ -58,6 +57,7 @@ public class Polyline extends OverlayWithIW {
 		mPaint.setAntiAlias(true);
 		this.clearPath();
 		mGeodesic = false;
+		mLineDrawer.setPaint(mPaint);
 	}
 
 	protected void clearPath() {
@@ -190,6 +190,7 @@ public class Polyline extends OverlayWithIW {
 
         final Projection pj = mapView.getProjection();
 
+		mLineDrawer.setCanvas(canvas);
         mOutline.setClipArea(mapView);
         mOutline.buildLinePortion(pj, mMilestoneManagers.size() > 0);
         for (final MilestoneManager milestoneManager : mMilestoneManagers) {
@@ -199,11 +200,6 @@ public class Polyline extends OverlayWithIW {
        			milestoneManager.add(point.x, point.y);
 			}
 			milestoneManager.end();
-		}
-
-		final int size = mLineBuilder.getSize();
-        if (size >= 4) {
-			canvas.drawLines(mLineBuilder.getLines(), 0, size, mPaint);
 		}
 
 		for (final MilestoneManager milestoneManager : mMilestoneManagers) {

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polyline.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polyline.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
-import android.graphics.Path;
 import android.view.MotionEvent;
 
 import org.osmdroid.util.GeoPoint;
@@ -35,10 +34,9 @@ import java.util.List;
 public class Polyline extends OverlayWithIW {
 
 	private boolean mGeodesic;
-	private final Path mPath = new Path();
 	private final Paint mPaint = new Paint();
 	/** Bounding rectangle for view */
-    private LinearRing mOutline = new LinearRing(mPath);
+    private LinearRing mOutline = new LinearRing(null);
 	private String id=null;
 	private List<MilestoneManager> mMilestoneManagers = new ArrayList<>();
 
@@ -190,7 +188,6 @@ public class Polyline extends OverlayWithIW {
 		}
 
         final Projection pj = mapView.getProjection();
-        mPath.rewind();
 
         mOutline.setClipArea(mapView);
         mOutline.buildPathPortion(pj, false, null);
@@ -203,7 +200,7 @@ public class Polyline extends OverlayWithIW {
 			milestoneManager.end();
 		}
 
-        canvas.drawPath(mPath, mPaint);
+		drawLines(canvas);
 
 		for (final MilestoneManager milestoneManager : mMilestoneManagers) {
         	milestoneManager.draw(canvas);
@@ -286,5 +283,25 @@ public class Polyline extends OverlayWithIW {
 		} else {
 			mMilestoneManagers = pMilestoneManagers;
 		}
+	}
+
+	/**
+	 * @since 6.0.0
+	 */
+	private void drawLines(final Canvas pCanvas) {
+		boolean first = true;
+		final PointL startPoint = new PointL();
+		final PointL endPoint = new PointL();
+		for (final PointL pointL : mOutline.getSegmentPoints()) {
+			if (first) {
+				first = false;
+				startPoint.set(pointL);
+			} else {
+				endPoint.set(pointL);
+				pCanvas.drawLine(startPoint.x, startPoint.y, endPoint.x, endPoint.y, mPaint);
+				startPoint.set(endPoint);
+			}
+		}
+		pCanvas.drawLine(startPoint.x, startPoint.y, endPoint.x, endPoint.y, mPaint);
 	}
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/milestones/MilestoneLister.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/milestones/MilestoneLister.java
@@ -18,18 +18,18 @@ public abstract class MilestoneLister implements PointAccepter{
     private final List<MilestoneStep> mMilestones = new ArrayList<>();
     private final PointL mLatestPoint = new PointL();
     private boolean mFirst;
-    private List<Double> mDistances;
+    private double[] mDistances;
 
     public List<MilestoneStep> getMilestones() {
         return mMilestones;
     }
 
-    public void setDistances(final List<Double> pDistances) {
+    public void setDistances(final double[] pDistances) {
         mDistances = pDistances;
     }
 
     protected double getDistance(final int pIndex) {
-        return mDistances.get(pIndex);
+        return mDistances[pIndex];
     }
 
     @Override

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/milestones/MilestoneManager.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/milestones/MilestoneManager.java
@@ -4,8 +4,6 @@ import android.graphics.Canvas;
 
 import org.osmdroid.util.PointAccepter;
 
-import java.util.List;
-
 /**
  * Created by Fabrice on 24/12/2017.
  * @since 6.0.0
@@ -42,7 +40,7 @@ public class MilestoneManager implements PointAccepter{
         mLister.end();
     }
 
-    public void setDistances(final List<Double> pDistances) {
+    public void setDistances(final double[] pDistances) {
         mLister.setDistances(pDistances);
     }
 }

--- a/osmdroid-android/src/test/java/org/osmdroid/util/ListPointLTest.java
+++ b/osmdroid-android/src/test/java/org/osmdroid/util/ListPointLTest.java
@@ -1,0 +1,52 @@
+package org.osmdroid.util;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+import java.util.Random;
+
+/**
+ * Created by Fabrice on 31/12/2017.
+ * @since 6.0.0
+ */
+
+public class ListPointLTest {
+
+    private static final Random random = new Random();
+
+    @Test
+    public void test() throws Exception{
+        final int size = 100;
+        final long[] values = new long[2 * size];
+        final ListPointL list = new ListPointL();
+        Assert.assertEquals(0, list.size());
+        reload(values);
+        check(values, list);
+        list.clear();
+        reload(values);
+        check(values, list);
+        list.clear();
+        Assert.assertEquals(0, list.size());
+    }
+
+    private void reload(final long[] pValues) {
+        for (int i = 0 ; i < pValues.length ; i ++) {
+            pValues[i] = random.nextInt();
+        }
+    }
+
+    private void check(final long[] pValues, final ListPointL pList) {
+        int i;
+        for (i = 0 ; i < pValues.length ; i += 2) {
+            pList.add(pValues[i], pValues[i + 1]);
+        }
+        i = 0;
+        for (final PointL point : pList) {
+            Assert.assertEquals(pValues[i], point.x);
+            Assert.assertEquals(pValues[i+1], point.y);
+            i += 2;
+        }
+        Assert.assertEquals(pValues.length / 2, pList.size());
+    }
+}

--- a/osmdroid-android/src/test/java/org/osmdroid/util/SegmentClipperTest.java
+++ b/osmdroid-android/src/test/java/org/osmdroid/util/SegmentClipperTest.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class SegmentClipperTest {
 
 	@Test
-	public void test_clip() {
+	public void test_clip_with_path() {
 		final List<PointL> points = new ArrayList<>();
 
 		final PointAccepter clippable = new PointAccepter() {
@@ -34,7 +34,7 @@ public class SegmentClipperTest {
 			public void end() {}
 		};
 		final SegmentClipper segmentClipper = new SegmentClipper();
-		segmentClipper.set(-600, -600, 1400, 1400, clippable);
+		segmentClipper.set(-600, -600, 1400, 1400, clippable, true);
 
 		clippable.init();
 		segmentClipper.clip(-2146, -2152, -145, -141);
@@ -82,5 +82,65 @@ public class SegmentClipperTest {
 		Assert.assertEquals(new PointL(-600, -600), points.get(0));
 		Assert.assertEquals(new PointL(-600, 1400), points.get(1));
 		Assert.assertEquals(new PointL(1400, 1400), points.get(2));
+	}
+
+	@Test
+	public void test_clip_without_path() {
+		final List<PointL> points = new ArrayList<>();
+
+		final PointAccepter clippable = new PointAccepter() {
+
+			@Override
+			public void init() {
+				points.clear();
+			}
+
+			@Override
+			public void add(long pX, long pY) {
+				points.add(new PointL(pX, pY));
+			}
+
+			@Override
+			public void end() {}
+		};
+		final SegmentClipper segmentClipper = new SegmentClipper();
+		segmentClipper.set(-600, -600, 1400, 1400, clippable, false);
+
+		clippable.init();
+		segmentClipper.clip(-2146, -2152, -145, -141);
+		Assert.assertEquals(2, points.size());
+		Assert.assertEquals(new PointL(-600, -598), points.get(0));
+		Assert.assertEquals(new PointL(-145, -141), points.get(1));
+
+		clippable.init();
+		segmentClipper.clip(-145, -141, 855, -1150);
+		Assert.assertEquals(2, points.size());
+		Assert.assertEquals(new PointL(-145, -141), points.get(0));
+		Assert.assertEquals(new PointL(310, -600), points.get(1));
+
+		clippable.init();
+		segmentClipper.clip(1856, 267, -2146, 9434);
+		Assert.assertEquals(2, points.size());
+		Assert.assertEquals(new PointL(1400, 1312), points.get(0));
+		Assert.assertEquals(new PointL(1361, 1400), points.get(1));
+
+		// both segment points are inside the clip area
+		clippable.init();
+		segmentClipper.clip(-30, 500, 700, 800);
+		Assert.assertEquals(2, points.size());
+		Assert.assertEquals(new PointL(-30, 500), points.get(0));
+		Assert.assertEquals(new PointL(700, 800), points.get(1));
+
+		// no intersection between clip area and segment
+		// computed corner: top right
+		clippable.init();
+		segmentClipper.clip(-1000, -10000, 10000, 10000);
+		Assert.assertEquals(0, points.size());
+
+		// no intersection between clip area and segment
+		// computed corner: bottom left
+		clippable.init();
+		segmentClipper.clip(-10000, -1000, 10000, 10000);
+		Assert.assertEquals(0, points.size());
 	}
 }


### PR DESCRIPTION
Here are the improvements:
* for `Polyline` we now use `Canvas.drawLine` and we don't care about invisible segments: they may have an impact on visible Path but never on visible segments
* introduction of `ListPointL` as an optimization of `List<PointL>`, which is supposed to benefit both `Polyline` and `Polygon` display

New classes:
* `ListPointL`: an optimized version of `List<PointL>`
* `ListPointLTest`: a unit test class for `ListPointL`

Impacted classes:
* `LinearRing`: used new class `ListPointL` for constantly refreshed `List<PointL>`; handled the case where `mPath` is `null`; refactored a little
* `PathBuilder`: handled the case where `mPath` is `null`
* `Polyline`: removed the `Path` and handled the display with `Canvas.drawLine`
* `SegmentClipper`: added `boolean mPathMode`, to be set to `true` when dealing with a `Path` (if so we keep the invisible segments: they have an impact on Path inner area)