### PR TITLE
Check for real network availabilty (connectivity) in NetworkAvailabliltyCheck

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/NetworkAvailabliltyCheck.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/NetworkAvailabliltyCheck.java
@@ -39,7 +39,7 @@ public class NetworkAvailabliltyCheck implements INetworkAvailablityCheck {
 		if (networkInfo == null) {
 			return false;
 		}
-		if (networkInfo.isAvailable()) {
+		if (networkInfo.isConnected()) {
 			return true;
 		}
 		return mIsX86 && networkInfo.getType() == ConnectivityManager.TYPE_ETHERNET;
@@ -53,7 +53,7 @@ public class NetworkAvailabliltyCheck implements INetworkAvailablityCheck {
 		}
 		final NetworkInfo wifi = mConnectionManager
 				.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
-		return wifi != null && wifi.isAvailable();
+		return wifi != null && wifi.isConnected();
 	}
 
 	@Override
@@ -64,7 +64,7 @@ public class NetworkAvailabliltyCheck implements INetworkAvailablityCheck {
 		}
 		final NetworkInfo mobile = mConnectionManager
 				.getNetworkInfo(ConnectivityManager.TYPE_MOBILE);
-		return mobile != null && mobile.isAvailable();
+		return mobile != null && mobile.isConnected();
 	}
 
 	@Override


### PR DESCRIPTION
Having experienced a problem with unstable network conditions, where osmdroid tried to load tiles unavailingly instead of approximate them when there was no actual connectivity, I discovered that `NetworkAvailabliltyCheck` was checking for `NetworkInfo.isAvailable()` instead of `NetworkInfo.isConnected()` as advised here: https://developer.android.com/training/basics/network-ops/managing.html
> Note that you should not base decisions on whether a network is "available." You should always check isConnected() before performing network operations, since isConnected() handles cases like flaky mobile networks, airplane mode, and restricted background data.
  