### PR TITLE
Feature/#855: added ability to individually style points and labels in SimpleFastPointOverlay, fixes #855

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleSimpleFastPointOverlay.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleSimpleFastPointOverlay.java
@@ -31,18 +31,18 @@ public class SampleSimpleFastPointOverlay extends BaseSampleFragment {
 
     @Override
     public String getSampleTitle() {
-        return "Simple Fast Point Overlay with 20k points";
+        return "Simple Fast Point Overlay with 60k points";
     }
 
     @Override
     protected void addOverlays() {
         super.addOverlays();
         // **********************************************
-        // Create 10k labelled points sharing same style
+        // Create 30k labelled points sharing same style
         // **********************************************
         // in most cases, there will be no problems of displaying >100k points, feel free to try
         List<IGeoPoint> points = new ArrayList<>();
-        for (int i = 0; i < 10000; i++) {
+        for (int i = 0; i < 30000; i++) {
             points.add(new LabelledGeoPoint(37 + Math.random() * 5, -8 + Math.random() * 5
                     , "Point #" + i));
         }
@@ -60,9 +60,10 @@ public class SampleSimpleFastPointOverlay extends BaseSampleFragment {
         // set some visual options for the overlay
         // we use here MAXIMUM_OPTIMIZATION algorithm, which works well with >100k points
         SimpleFastPointOverlayOptions opt = SimpleFastPointOverlayOptions.getDefaultStyle()
+                .setSymbol(SimpleFastPointOverlayOptions.Shape.SQUARE)
                 .setAlgorithm(SimpleFastPointOverlayOptions.RenderingAlgorithm.MAXIMUM_OPTIMIZATION)
                 .setRadius(7).setIsClickable(true).setCellSize(12).setTextStyle(textStyle)
-                .setMinZoomShowLabels(9);
+                .setMinZoomShowLabels(10);
 
         // create the overlay with the theme
         final SimpleFastPointOverlay sfpo = new SimpleFastPointOverlay(pointTheme, opt);
@@ -83,11 +84,11 @@ public class SampleSimpleFastPointOverlay extends BaseSampleFragment {
         // *****************************************************
         // Now add another layer with points individually styled
         // *****************************************************
-        // create 10k labelled points
+        // create 30k labelled points
         List<IGeoPoint> individualStyledPoints = new ArrayList<>();
         Paint indPointStyle, indTextStyle;
 
-        for (int i = 0; i < 10000; i++) {
+        for (int i = 0; i < 30000; i++) {
             // create random colored style for each point
             indPointStyle = new Paint();
             indPointStyle.setStyle(Paint.Style.FILL);
@@ -96,7 +97,7 @@ public class SampleSimpleFastPointOverlay extends BaseSampleFragment {
 
             // create style with random color and text size for each point label
             indTextStyle = new Paint();
-            indTextStyle.setTextSize((int) (10 + Math.random() * 40));
+            indTextStyle.setTextSize((int) (10 + Math.random() * 30));
             indTextStyle.setTextAlign(Paint.Align.CENTER);
             indTextStyle.setColor(Color.rgb((int) Math.floor(Math.random() * 255)
                     , (int) Math.floor(Math.random() * 255), (int) Math.floor(Math.random() * 255)));
@@ -114,7 +115,7 @@ public class SampleSimpleFastPointOverlay extends BaseSampleFragment {
         opt = SimpleFastPointOverlayOptions.getDefaultStyle()
                 .setSymbol(SimpleFastPointOverlayOptions.Shape.SQUARE)
                 .setAlgorithm(SimpleFastPointOverlayOptions.RenderingAlgorithm.MAXIMUM_OPTIMIZATION)
-                .setRadius(7).setCellSize(12).setMinZoomShowLabels(9);
+                .setRadius(7).setCellSize(12).setMinZoomShowLabels(10);
 
         // create the overlay with the theme
         final SimpleFastPointOverlay sfpo1 = new SimpleFastPointOverlay(individualStyledPointTheme, opt);

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/simplefastpoint/LabelledGeoPoint.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/simplefastpoint/LabelledGeoPoint.java
@@ -12,15 +12,7 @@ import org.osmdroid.util.GeoPoint;
  */
 
 public class LabelledGeoPoint extends GeoPoint {
-    private String mLabel;
-
-    public LabelledGeoPoint(int aLatitudeE6, int aLongitudeE6) {
-        super(aLatitudeE6, aLongitudeE6);
-    }
-
-    public LabelledGeoPoint(int aLatitudeE6, int aLongitudeE6, int aAltitude) {
-        super(aLatitudeE6, aLongitudeE6, aAltitude);
-    }
+    String mLabel;
 
     public LabelledGeoPoint(double aLatitude, double aLongitude) {
         super(aLatitude, aLongitude);

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/simplefastpoint/SimpleFastPointOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/simplefastpoint/SimpleFastPointOverlay.java
@@ -112,13 +112,7 @@ public class SimpleFastPointOverlay extends Overlay {
         viewHei = mapView.getHeight();
         gridWid = (int) Math.floor((float) viewWid / mStyle.mCellSize) + 1;
         gridHei = (int) Math.floor((float) viewHei / mStyle.mCellSize) + 1;
-/*
-        if(mStyle.mAlgorithm ==
-                SimpleFastPointOverlayOptions.RenderingAlgorithm.MAXIMUM_OPTIMIZATION)
-            grid = new StyledLabelledPoint[gridWid][gridHei];
-        else
-*/
-            gridBool = new boolean[gridWid][gridHei];
+        gridBool = new boolean[gridWid][gridHei];
 
         // TODO the measures on first draw are not the final values.
         // MapView should propagate onLayout to overlays

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/simplefastpoint/SimpleFastPointOverlayOptions.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/simplefastpoint/SimpleFastPointOverlayOptions.java
@@ -52,6 +52,7 @@ public class SimpleFastPointOverlayOptions {
 
     /**
      * Sets the style for the point overlay, which is applied to all circles.
+     * If the layer is individually styled, the individual style overrides this.
      * @param style A Paint object.
      * @return The updated {@link SimpleFastPointOverlayOptions}
      */
@@ -139,6 +140,7 @@ public class SimpleFastPointOverlayOptions {
 
     /**
      * Sets the style for the labels.
+     * If the layer is individually styled, the individual style overrides this.
      * @param textStyle The style.
      * @return The updated {@link SimpleFastPointOverlayOptions}
      */

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/simplefastpoint/SimpleFastPointOverlayOptions.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/simplefastpoint/SimpleFastPointOverlayOptions.java
@@ -20,7 +20,7 @@ public class SimpleFastPointOverlayOptions {
     protected boolean mClickable = true;
     protected int mCellSize = 10;   // the size of the grid cells in pixels.
     protected RenderingAlgorithm mAlgorithm = RenderingAlgorithm.MAXIMUM_OPTIMIZATION;
-    protected Shape mSymbol = Shape.CIRCLE;
+    protected Shape mSymbol = Shape.SQUARE;     // default is square, cause circle is a slow renderer
     protected LabelPolicy mLabelPolicy = LabelPolicy.ZOOM_THRESHOLD;
     protected int mMaxNShownLabels = 250;
     protected int mMinZoomShowLabels = 11;
@@ -129,8 +129,8 @@ public class SimpleFastPointOverlayOptions {
     }
 
     /**
-     * Sets the symbol shape for this layer.
-     * @param symbol The symbol.
+     * Sets the symbol shape for this layer. Hint: circle shape is less performant, avoid for large N.
+     * @param symbol The symbol, currently CIRCLE or SQUARE.
      * @return The updated {@link SimpleFastPointOverlayOptions}
      */
     public SimpleFastPointOverlayOptions setSymbol(Shape symbol) {

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/simplefastpoint/SimplePointTheme.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/simplefastpoint/SimplePointTheme.java
@@ -16,11 +16,21 @@ import java.util.List;
 
 public final class SimplePointTheme implements SimpleFastPointOverlay.PointAdapter {
     private final List<IGeoPoint> mPoints;
-    private boolean mLabelled;
+    private boolean mLabelled, mStyled;
+
+    public SimplePointTheme(List<IGeoPoint> pPoints) {
+        this(pPoints, pPoints.size() != 0 && pPoints.get(0) instanceof LabelledGeoPoint
+                , pPoints.size() != 0 && pPoints.get(0) instanceof StyledLabelledGeoPoint);
+    }
 
     public SimplePointTheme(List<IGeoPoint> pPoints, boolean labelled) {
+        this(pPoints, labelled, false);
+    }
+
+    public SimplePointTheme(List<IGeoPoint> pPoints, boolean labelled, boolean styled) {
         mPoints = pPoints;
         mLabelled = labelled;
+        mStyled = styled;
     }
 
     @Override
@@ -36,6 +46,11 @@ public final class SimplePointTheme implements SimpleFastPointOverlay.PointAdapt
     @Override
     public boolean isLabelled() {
         return mLabelled;
+    }
+
+    @Override
+    public boolean isStyled() {
+        return mStyled;
     }
 
     /**

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/simplefastpoint/SimplePointTheme.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/simplefastpoint/SimplePointTheme.java
@@ -7,10 +7,11 @@ import java.util.List;
 
 /**
  * This class is just a simple wrapper for a List of {@link IGeoPoint}s to be used in
- * {@link SimpleFastPointOverlay}. Can be used for unlabelled or labelled GeoPoints. Be sure to set
- * the labelled parameter of the constructor to match the kind of points.
+ * {@link SimpleFastPointOverlay}. Can be used for unlabelled or labelled GeoPoints.
+ * Use the simple constructor, or otherwise be sure to set the labelled and styled parameters of the
+ * constructor to match the kind of points.
  * More complex cases should implement {@link SimpleFastPointOverlay.PointAdapter}, not extend this
- * one.
+ * one. This is a simple example on how to implement an adapter for any case.
  * Created by Miguel Porto on 26-10-2016.
  */
 

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/simplefastpoint/StyledLabelledGeoPoint.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/simplefastpoint/StyledLabelledGeoPoint.java
@@ -1,0 +1,77 @@
+package org.osmdroid.views.overlay.simplefastpoint;
+
+import android.graphics.Paint;
+import android.location.Location;
+
+import org.osmdroid.util.GeoPoint;
+
+/**
+ * Created by miguel on 07-01-2018.
+ */
+
+public class StyledLabelledGeoPoint extends LabelledGeoPoint {
+    Paint mPointStyle, mTextStyle;
+
+    public StyledLabelledGeoPoint(double aLatitude, double aLongitude) {
+        super(aLatitude, aLongitude);
+    }
+
+    public StyledLabelledGeoPoint(double aLatitude, double aLongitude, double aAltitude) {
+        super(aLatitude, aLongitude, aAltitude);
+    }
+
+    public StyledLabelledGeoPoint(double aLatitude, double aLongitude, double aAltitude, String aLabel) {
+        super(aLatitude, aLongitude, aAltitude, aLabel);
+    }
+
+    public StyledLabelledGeoPoint(Location aLocation) {
+        super(aLocation);
+    }
+
+    public StyledLabelledGeoPoint(GeoPoint aGeopoint) {
+        super(aGeopoint);
+    }
+
+    public StyledLabelledGeoPoint(double aLatitude, double aLongitude, String aLabel) {
+        super(aLatitude, aLongitude, aLabel);
+    }
+
+    public StyledLabelledGeoPoint(double aLatitude, double aLongitude, String aLabel, Paint pointStyle, Paint textStyle) {
+        super(aLatitude, aLongitude, aLabel);
+        this.mPointStyle = pointStyle;
+        this.mTextStyle = textStyle;
+    }
+
+    public StyledLabelledGeoPoint(double aLatitude, double aLongitude, double aAltitude, String aLabel, Paint pointStyle, Paint textStyle) {
+        super(aLatitude, aLongitude, aAltitude, aLabel);
+        this.mPointStyle = pointStyle;
+        this.mTextStyle = textStyle;
+    }
+
+    public StyledLabelledGeoPoint(LabelledGeoPoint aLabelledGeopoint) {
+        super(aLabelledGeopoint);
+    }
+
+    public Paint getPointStyle() {
+        return mPointStyle;
+    }
+
+    public void setPointStyle(Paint mPointStyle) {
+        this.mPointStyle = mPointStyle;
+    }
+
+    public Paint getTextStyle() {
+        return mTextStyle;
+    }
+
+    public void setTextStyle(Paint mTextStyle) {
+        this.mTextStyle = mTextStyle;
+    }
+
+    @Override
+    public StyledLabelledGeoPoint clone() {
+        return new StyledLabelledGeoPoint(this.getLatitude(), this.getLongitude(), this.getAltitude()
+                , this.mLabel, this.mPointStyle, this.mTextStyle);
+    }
+
+}


### PR DESCRIPTION
Added class `StyledLabelledGeoPoint`, which allows to provide a style for each point and respective label individually. See `SampleSimpleFastPointOverlay` for a sample.
