### PR TITLE
setCenter now able to work for every GeoPoint within the scroll limits

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/events/SampleLimitedScrollArea.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/events/SampleLimitedScrollArea.java
@@ -81,9 +81,15 @@ public class SampleLimitedScrollArea extends BaseSampleFragment {
 
 		mMapView.getController().setZoom(13.);
 
-		setLimitScrollingLatitude(true);
-		setLimitScrollingLongitude(true);
 		setHasOptionsMenu(true);
+
+		mMapView.post(new Runnable() { // "post" because we need View.getWidth() to be set
+			@Override
+			public void run() {
+				setLimitScrollingLatitude(true);
+				setLimitScrollingLongitude(true);
+			}
+		});
 	}
 
 	/**
@@ -93,7 +99,7 @@ public class SampleLimitedScrollArea extends BaseSampleFragment {
 		mMapView.getOverlays().remove(mNorthPolyline);
 		mMapView.getOverlays().remove(mSouthPolyline);
 		if (pLimitScrolling) {
-			mMapView.setScrollableAreaLimitLatitude(sCentralParkBoundingBox.getActualNorth(), sCentralParkBoundingBox.getActualSouth());
+			mMapView.setScrollableAreaLimitLatitude(sCentralParkBoundingBox.getActualNorth(), sCentralParkBoundingBox.getActualSouth(), mMapView.getHeight() / 2);
 			mMapView.setCenter(sCentralParkBoundingBox.getCenterWithDateLine());
 			mMapView.getOverlays().add(mNorthPolyline);
 			mMapView.getOverlays().add(mSouthPolyline);
@@ -110,7 +116,7 @@ public class SampleLimitedScrollArea extends BaseSampleFragment {
 		mMapView.getOverlays().remove(mWestPolyline);
 		mMapView.getOverlays().remove(mEastPolyline);
 		if (pLimitScrolling) {
-			mMapView.setScrollableAreaLimitLongitude(sCentralParkBoundingBox.getLonWest(), sCentralParkBoundingBox.getLonEast());
+			mMapView.setScrollableAreaLimitLongitude(sCentralParkBoundingBox.getLonWest(), sCentralParkBoundingBox.getLonEast(), mMapView.getWidth() / 2);
 			mMapView.setCenter(sCentralParkBoundingBox.getCenterWithDateLine());
 			mMapView.getOverlays().add(mWestPolyline);
 			mMapView.getOverlays().add(mEastPolyline);

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/events/SampleLimitedScrollArea.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/events/SampleLimitedScrollArea.java
@@ -3,9 +3,8 @@ package org.osmdroid.samplefragments.events;
 import org.osmdroid.samplefragments.BaseSampleFragment;
 import org.osmdroid.util.BoundingBox;
 import org.osmdroid.util.GeoPoint;
-import org.osmdroid.views.overlay.Polygon;
+import org.osmdroid.views.overlay.Polyline;
 
-import android.graphics.Color;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -25,7 +24,8 @@ public class SampleLimitedScrollArea extends BaseSampleFragment {
 
 	public static final String TITLE = "Limited scroll area";
 
-	private final int MENU_LIMIT_SCROLLING_ID = Menu.FIRST;
+	private final int MENU_LIMIT_SCROLLING_LAT_ID = Menu.FIRST;
+	private final int MENU_LIMIT_SCROLLING_LNG_ID = Menu.FIRST + 1;
 
 	private BoundingBox sCentralParkBoundingBox;
 
@@ -43,36 +43,81 @@ public class SampleLimitedScrollArea extends BaseSampleFragment {
 	// Constructors
 	// ===========================================================
 
+	private final Polyline mNorthPolyline = new Polyline();
+	private final Polyline mSouthPolyline = new Polyline();
+	private final Polyline mWestPolyline = new Polyline();
+	private final Polyline mEastPolyline = new Polyline();
 
 
 	@Override
 	protected void addOverlays() {
 		super.addOverlays();
 
-		final Polygon polygon = new Polygon();
 		final ArrayList<GeoPoint> list = new ArrayList<>();
-		list.add(new GeoPoint(sCentralParkBoundingBox.getLatNorth(), sCentralParkBoundingBox.getLonEast()));
-		list.add(new GeoPoint(sCentralParkBoundingBox.getLatNorth(), sCentralParkBoundingBox.getLonWest()));
-		list.add(new GeoPoint(sCentralParkBoundingBox.getLatSouth(), sCentralParkBoundingBox.getLonWest()));
-		list.add(new GeoPoint(sCentralParkBoundingBox.getLatSouth(), sCentralParkBoundingBox.getLonEast()));
-		polygon.setPoints(list);
-		polygon.setFillColor(Color.argb(75, 255,0,0));
-		mMapView.getOverlays().add(polygon);
+
+		list.clear();
+		list.add(new GeoPoint(sCentralParkBoundingBox.getActualNorth(), -85));
+		list.add(new GeoPoint(sCentralParkBoundingBox.getActualNorth(), -65));
+		mNorthPolyline.setPoints(list);
+		mMapView.getOverlays().add(mNorthPolyline);
+
+		list.clear();
+		list.add(new GeoPoint(sCentralParkBoundingBox.getActualSouth(), -85));
+		list.add(new GeoPoint(sCentralParkBoundingBox.getActualSouth(), -65));
+		mSouthPolyline.setPoints(list);
+		mMapView.getOverlays().add(mSouthPolyline);
+
+		list.clear();
+		list.add(new GeoPoint(45, sCentralParkBoundingBox.getLonWest()));
+		list.add(new GeoPoint(35, sCentralParkBoundingBox.getLonWest()));
+		mWestPolyline.setPoints(list);
+		mMapView.getOverlays().add(mWestPolyline);
+
+		list.clear();
+		list.add(new GeoPoint(45, sCentralParkBoundingBox.getLonEast()));
+		list.add(new GeoPoint(35, sCentralParkBoundingBox.getLonEast()));
+		mEastPolyline.setPoints(list);
+		mMapView.getOverlays().add(mEastPolyline);
+
 		mMapView.getController().setZoom(13.);
 
-		setLimitScrolling(true);
+		setLimitScrollingLatitude(true);
+		setLimitScrollingLongitude(true);
 		setHasOptionsMenu(true);
 	}
 
-	protected void setLimitScrolling(boolean limitScrolling) {
-		if (limitScrolling) {
-			mMapView.setScrollableAreaLimitDouble(sCentralParkBoundingBox);
-			mMapView.getController().animateTo(sCentralParkBoundingBox.getCenterWithDateLine());
-			mMapView.invalidate();
+	/**
+	 * @since 6.0.0
+	 */
+	private void setLimitScrollingLatitude(boolean pLimitScrolling) {
+		mMapView.getOverlays().remove(mNorthPolyline);
+		mMapView.getOverlays().remove(mSouthPolyline);
+		if (pLimitScrolling) {
+			mMapView.setScrollableAreaLimitLatitude(sCentralParkBoundingBox.getActualNorth(), sCentralParkBoundingBox.getActualSouth());
+			mMapView.setCenter(sCentralParkBoundingBox.getCenterWithDateLine());
+			mMapView.getOverlays().add(mNorthPolyline);
+			mMapView.getOverlays().add(mSouthPolyline);
 		} else {
-			mMapView.setScrollableAreaLimitDouble(null);
-			mMapView.invalidate();
+			mMapView.resetScrollableAreaLimitLatitude();
 		}
+		mMapView.invalidate();
+	}
+
+	/**
+	 * @since 6.0.0
+	 */
+	private void setLimitScrollingLongitude(boolean pLimitScrolling) {
+		mMapView.getOverlays().remove(mWestPolyline);
+		mMapView.getOverlays().remove(mEastPolyline);
+		if (pLimitScrolling) {
+			mMapView.setScrollableAreaLimitLongitude(sCentralParkBoundingBox.getLonWest(), sCentralParkBoundingBox.getLonEast());
+			mMapView.setCenter(sCentralParkBoundingBox.getCenterWithDateLine());
+			mMapView.getOverlays().add(mWestPolyline);
+			mMapView.getOverlays().add(mEastPolyline);
+		} else {
+			mMapView.resetScrollableAreaLimitLongitude();
+		}
+		mMapView.invalidate();
 	}
 
 	// ===========================================================
@@ -85,24 +130,28 @@ public class SampleLimitedScrollArea extends BaseSampleFragment {
 
 	@Override
 	public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
-		menu.add(0, MENU_LIMIT_SCROLLING_ID, Menu.NONE, "Limit scrolling").setCheckable(true);
+		menu.add(0, MENU_LIMIT_SCROLLING_LAT_ID, Menu.NONE, "Latitude: Limit scrolling").setCheckable(true);
+		menu.add(0, MENU_LIMIT_SCROLLING_LNG_ID, Menu.NONE, "Longitude: Limit scrolling").setCheckable(true);
 
 		super.onCreateOptionsMenu(menu, inflater);
 	}
 
 	@Override
 	public void onPrepareOptionsMenu(Menu menu) {
-		MenuItem item = menu.findItem(MENU_LIMIT_SCROLLING_ID);
-		item.setChecked(mMapView.getScrollableAreaLimit() != null);
+		menu.findItem(MENU_LIMIT_SCROLLING_LAT_ID).setChecked(mMapView.isScrollableAreaLimitLatitude());
+		menu.findItem(MENU_LIMIT_SCROLLING_LNG_ID).setChecked(mMapView.isScrollableAreaLimitLongitude());
 		super.onPrepareOptionsMenu(menu);
 	}
 
 	@Override
 	public boolean onOptionsItemSelected(MenuItem item) {
 		switch (item.getItemId()) {
-		case MENU_LIMIT_SCROLLING_ID:
-			setLimitScrolling(mMapView.getScrollableAreaLimit() == null);
-			return true;
+			case MENU_LIMIT_SCROLLING_LAT_ID:
+				setLimitScrollingLatitude(!mMapView.isScrollableAreaLimitLatitude());
+				return true;
+			case MENU_LIMIT_SCROLLING_LNG_ID:
+				setLimitScrollingLongitude(!mMapView.isScrollableAreaLimitLongitude());
+				return true;
 		}
 		return false;
 	}

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
@@ -119,8 +119,8 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
 	private boolean mScrollableAreaLimitLongitude;
 	private double mScrollableAreaLimitWest;
 	private double mScrollableAreaLimitEast;
-	private int mScrollableAreaLimitExtraWidth;
-	private int mScrollableAreaLimitExtraHeight;
+	private int mScrollableAreaLimitExtraPixelWidth;
+	private int mScrollableAreaLimitExtraPixelHeight;
 
 	private MapTileProviderBase mTileProvider;
 	private Handler mTileRequestCompleteHandler;
@@ -342,12 +342,12 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
 			if (mScrollableAreaLimitLatitude) {
 				mProjection.adjustOffsets(
 						mScrollableAreaLimitNorth, mScrollableAreaLimitSouth, true,
-						mScrollableAreaLimitExtraHeight);
+						mScrollableAreaLimitExtraPixelHeight);
 			}
 			if (mScrollableAreaLimitLongitude) {
 				mProjection.adjustOffsets(
 						mScrollableAreaLimitWest, mScrollableAreaLimitEast, false,
-						mScrollableAreaLimitExtraWidth);
+						mScrollableAreaLimitExtraPixelWidth);
 			}
 			mImpossibleFlinging = mProjection.setMapScroll(this);
 		}
@@ -716,22 +716,22 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
 	 * @since 6.0.0
 	 */
 	public void setScrollableAreaLimitLatitude(final double pNorth, final double pSouth,
-											   final int pExtraHeight) {
+											   final int pExtraPixelHeight) {
 		mScrollableAreaLimitLatitude = true;
 		mScrollableAreaLimitNorth = pNorth;
 		mScrollableAreaLimitSouth = pSouth;
-		mScrollableAreaLimitExtraHeight = pExtraHeight;
+		mScrollableAreaLimitExtraPixelHeight = pExtraPixelHeight;
 	}
 
 	/**
 	 * @since 6.0.0
 	 */
 	public void setScrollableAreaLimitLongitude(final double pWest, final double pEast,
-												final int pExtraWidth) {
+												final int pExtraPixelWidth) {
 		mScrollableAreaLimitLongitude = true;
 		mScrollableAreaLimitWest = pWest;
 		mScrollableAreaLimitEast = pEast;
-		mScrollableAreaLimitExtraWidth = pExtraWidth;
+		mScrollableAreaLimitExtraPixelWidth = pExtraPixelWidth;
 	}
 
 	/**

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
@@ -108,7 +108,12 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
 	private float mapOrientation = 0;
 	private final Rect mInvalidateRect = new Rect();
 
-	protected BoundingBox mScrollableAreaBoundingBox;
+	private boolean mScrollableAreaLimitLatitude;
+	private double mScrollableAreaLimitNorth;
+	private double mScrollableAreaLimitSouth;
+	private boolean mScrollableAreaLimitLongitude;
+	private double mScrollableAreaLimitWest;
+	private double mScrollableAreaLimitEast;
 
 	private MapTileProviderBase mTileProvider;
 	private Handler mTileRequestCompleteHandler;
@@ -327,7 +332,12 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
 		if (mProjection == null) {
 			mProjection = new Projection(this);
 			mProjection.adjustOffsets(mMultiTouchScaleGeoPoint, mMultiTouchScaleCurrentPoint);
-			mProjection.adjustOffsets(mScrollableAreaBoundingBox);
+			if (mScrollableAreaLimitLatitude) {
+				mProjection.adjustOffsets(mScrollableAreaLimitNorth, mScrollableAreaLimitSouth, true);
+			}
+			if (mScrollableAreaLimitLongitude) {
+				mProjection.adjustOffsets(mScrollableAreaLimitWest, mScrollableAreaLimitEast, false);
+			}
 			setMapScroll(mProjection.getScrollX(), mProjection.getScrollY());
 		}
 		return mProjection;
@@ -667,14 +677,63 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
      *            A lat/long bounding box to limit scrolling to, or null to remove any scrolling
      *            limitations
      */
-    public void setScrollableAreaLimitDouble(BoundingBox boundingBox) {
-        mScrollableAreaBoundingBox = boundingBox;
-    }
+    @Deprecated
+	public void setScrollableAreaLimitDouble(BoundingBox boundingBox) {
+    	if (boundingBox == null) {
+    		resetScrollableAreaLimitLatitude();
+    		resetScrollableAreaLimitLongitude();
+		} else {
+			setScrollableAreaLimitLatitude(boundingBox.getActualNorth(), boundingBox.getActualSouth());
+			setScrollableAreaLimitLongitude(boundingBox.getLonWest(), boundingBox.getLonEast());
+		}
+	}
 
+	/**
+	 * @since 6.0.0
+	 */
+	public void resetScrollableAreaLimitLatitude() {
+		mScrollableAreaLimitLatitude = false;
+	}
 
-    public BoundingBox getScrollableAreaLimit() {
-        return mScrollableAreaBoundingBox;
-    }
+	/**
+	 * @since 6.0.0
+	 */
+	public void resetScrollableAreaLimitLongitude() {
+		mScrollableAreaLimitLongitude = false;
+	}
+
+	/**
+	 * @since 6.0.0
+	 */
+	public void setScrollableAreaLimitLatitude(final double pNorth, final double pSouth) {
+		mScrollableAreaLimitLatitude = true;
+		mScrollableAreaLimitNorth = pNorth;
+		mScrollableAreaLimitSouth = pSouth;
+	}
+
+	/**
+	 * @since 6.0.0
+	 */
+	public void setScrollableAreaLimitLongitude(final double pWest, final double pEast) {
+		mScrollableAreaLimitLongitude = true;
+		mScrollableAreaLimitWest = pWest;
+		mScrollableAreaLimitEast = pEast;
+	}
+
+	/**
+	 * @since 6.0.0
+	 */
+	public boolean isScrollableAreaLimitLatitude() {
+		return mScrollableAreaLimitLatitude;
+	}
+
+	/**
+	 * @since 6.0.0
+	 */
+	public boolean isScrollableAreaLimitLongitude() {
+		return mScrollableAreaLimitLongitude;
+	}
+
 
 	public void invalidateMapCoordinates(Rect dirty) {
 		invalidateMapCoordinates(dirty.left, dirty.top, dirty.right, dirty.bottom, false);

--- a/osmdroid-android/src/main/java/org/osmdroid/views/Projection.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/Projection.java
@@ -675,16 +675,34 @@ public class Projection implements IProjection {
 	 * or it is smaller and it is centered
 	 * @since 6.0.0
 	 */
+	@Deprecated
 	public void adjustOffsets(final BoundingBox pBoundingBox) {
 		if (pBoundingBox == null) {
 			return;
 		}
-		final long left = getLongPixelXFromLongitude(pBoundingBox.getLonWest());
-		final long right = getLongPixelXFromLongitude(pBoundingBox.getLonEast());
-		final long top = getLongPixelYFromLatitude(pBoundingBox.getActualNorth());
-		final long bottom = getLongPixelYFromLatitude(pBoundingBox.getActualSouth());
-		final long deltaX = checkScrollableOffset(left, right, mMercatorMapSize, mIntrinsicScreenRectProjection.width());
-		final long deltaY = checkScrollableOffset(top, bottom, mMercatorMapSize, mIntrinsicScreenRectProjection.height());
+		adjustOffsets(pBoundingBox.getLonWest(), pBoundingBox.getLonEast(), false);
+		adjustOffsets(pBoundingBox.getActualNorth(), pBoundingBox.getActualSouth(), true);
+	}
+
+	/**
+	 * @since 6.0.0
+	 */
+	public void adjustOffsets(final double pNorthOrWest, final double pSouthOrEast, final boolean isLatitude) {
+		final long min;
+		final long max;
+		final long deltaX;
+		final long deltaY;
+		if (isLatitude) {
+			min = getLongPixelYFromLatitude(pNorthOrWest);
+			max = getLongPixelYFromLatitude(pSouthOrEast);
+			deltaX = 0;
+			deltaY = checkScrollableOffset(min, max, mMercatorMapSize, mIntrinsicScreenRectProjection.height());
+		} else {
+			min = getLongPixelXFromLongitude(pNorthOrWest);
+			max = getLongPixelXFromLongitude(pSouthOrEast);
+			deltaX = checkScrollableOffset(min, max, mMercatorMapSize, mIntrinsicScreenRectProjection.width());
+			deltaY = 0;
+		}
 		adjustOffsets(-deltaX, -deltaY);
 	}
 

--- a/osmdroid-android/src/main/java/org/osmdroid/views/Projection.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/Projection.java
@@ -685,10 +685,13 @@ public class Projection implements IProjection {
 	}
 
 	/**
+	 * Adjust offsets so that north and south (if latitude, west and east if longitude)
+	 * actually "fit" into the screen, with a tolerance of extraSize pixels.
+	 * Used in order to ensure scroll limits.
 	 * @since 6.0.0
 	 */
-	public void adjustOffsets(final double pNorthOrWest, final double pSouthOrEast,
-							  final boolean isLatitude, final int pExtraSize) {
+	void adjustOffsets(final double pNorthOrWest, final double pSouthOrEast,
+					   final boolean isLatitude, final int pExtraSize) {
 		final long min;
 		final long max;
 		final long deltaX;

--- a/osmdroid-android/src/test/java/org/osmdroid/util/ProjectionTest.java
+++ b/osmdroid-android/src/test/java/org/osmdroid/util/ProjectionTest.java
@@ -183,6 +183,38 @@ public class ProjectionTest {
         }
     }
 
+    /**
+     * @since 6.0.0
+     */
+    @Test
+    public void testCheckScrollableOffset() {
+        // more than enough
+        testCheckScrollableOffset(0, -100, 5000);
+        // limits
+        testCheckScrollableOffset(0, 50, 950);
+        // shorter than possible, in the middle
+        testCheckScrollableOffset(-1, 52, 950);
+        // shorter than possible, on the left side
+        testCheckScrollableOffset(550, -100, 0);
+        // shorter than possible, on the right side
+        testCheckScrollableOffset(-650, 1100, 1200);
+        // to the left
+        testCheckScrollableOffset(-50, 100, 1950);
+        // to the right
+        testCheckScrollableOffset(450, -1000, 500);
+    }
+
+    /**
+     * @since 6.0.0
+     */
+    private void testCheckScrollableOffset(final int pExpected, final int pMin, final int pMax) {
+        final double worldSize = 20000;
+        final int screenSize = 1000;
+        final int extraSize = 50;
+        Assert.assertEquals(pExpected,
+                Projection.getScrollableOffset(pMin, pMax, worldSize, screenSize, extraSize));
+    }
+
     private Point getRandomPixel(final double pMapSize) {
         final Point pixel = new Point();
         pixel.x = mRandom.nextInt((int)Math.min(mWidth, (long) pMapSize));


### PR DESCRIPTION
How is it possible?
Now you can add an `int extraSize` parameter when you set the scroll limits.
And if you use
* `mapView.getWidth()/2` for longitude extra size limit
* `mapView.getHeight()/2` for latitude extra size limit
you have enough flexibility to
* comply with the limits
* and set the map center to a `GeoPoint` within these limits