### PR TITLE
Let DatabaseFileArchive and ZipFileArchive ignore the TileSource

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/DatabaseFileArchive.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/DatabaseFileArchive.java
@@ -83,7 +83,6 @@ public class DatabaseFileArchive implements IArchiveFile {
 			Cursor cur;
 			if(!mIgnoreTileSource) {
 				cur = mDatabase.query(TABLE, tile, COLUMN_KEY+" = " + index + " and "+COLUMN_PROVIDER+" = '" + pTileSource.name() + "'", null, null, null, null);
-
 			} else {
 				cur = mDatabase.query(TABLE, tile, COLUMN_KEY+" = " + index, null, null, null, null);
 			}

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/DatabaseFileArchive.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/DatabaseFileArchive.java
@@ -30,6 +30,7 @@ public class DatabaseFileArchive implements IArchiveFile {
 	public static final String COLUMN_KEY = "key";
 	static final String[] tile_column = {"tile"};
 	private SQLiteDatabase mDatabase;
+	private boolean mIgnoreTileSource = false;
 
 	public DatabaseFileArchive(){}
 
@@ -40,6 +41,14 @@ public class DatabaseFileArchive implements IArchiveFile {
 	public static DatabaseFileArchive getDatabaseFileArchive(final File pFile) throws SQLiteException {
 		return new DatabaseFileArchive(SQLiteDatabase.openDatabase(pFile.getAbsolutePath(), null, SQLiteDatabase.OPEN_READONLY & SQLiteDatabase.NO_LOCALIZED_COLLATORS));
 
+	}
+	
+	/**
+	 * @since 6.0
+	 * If set to true, tiles from this archive will be loaded regardless of their associated tile source name
+	 */
+	public void setIgnoreTileSource(boolean pIgnoreTileSource) {
+		mIgnoreTileSource = pIgnoreTileSource;
 	}
 
 	public Set<String> getTileSources(){
@@ -70,8 +79,15 @@ public class DatabaseFileArchive implements IArchiveFile {
 			final long y = (long) pTile.getY();
 			final long z = (long) pTile.getZoomLevel();
 			final long index = ((z << z) + x << z) + y;
-			final Cursor cur = mDatabase.query(TABLE, tile, COLUMN_KEY+" = " + index + " and "+COLUMN_PROVIDER+" = '" + pTileSource.name() + "'", null, null, null, null);
+			
+			Cursor cur;
+			if(!mIgnoreTileSource) {
+				cur = mDatabase.query(TABLE, tile, COLUMN_KEY+" = " + index + " and "+COLUMN_PROVIDER+" = '" + pTileSource.name() + "'", null, null, null, null);
 
+			} else {
+				cur = mDatabase.query(TABLE, tile, COLUMN_KEY+" = " + index, null, null, null, null);
+			}
+			
 			if(cur.getCount() != 0) {
 				cur.moveToFirst();
 				bits = (cur.getBlob(0));

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/ZipFileArchive.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/ZipFileArchive.java
@@ -18,7 +18,8 @@ import org.osmdroid.tileprovider.tilesource.ITileSource;
 
 public class ZipFileArchive implements IArchiveFile {
 
-	protected ZipFile mZipFile;
+	protected ZipFile mZipFile;	
+	private boolean mIgnoreTileSource = false;
 
 	public ZipFileArchive(){}
 
@@ -29,6 +30,14 @@ public class ZipFileArchive implements IArchiveFile {
 	public static ZipFileArchive getZipFileArchive(final File pFile) throws ZipException, IOException {
 		return new ZipFileArchive(new ZipFile(pFile));
 	}
+	
+	/**
+	 * @since 6.0
+	 * If set to true, tiles from this archive will be loaded regardless of their associated tile source name
+	 */
+	public void setIgnoreTileSource(boolean pIgnoreTileSource) {
+		mIgnoreTileSource = pIgnoreTileSource;
+	}
 
 	@Override
 	public void init(File pFile) throws Exception {
@@ -37,17 +46,50 @@ public class ZipFileArchive implements IArchiveFile {
 
 	@Override
 	public InputStream getInputStream(final ITileSource pTileSource, final MapTile pTile) {
-		final String path = pTileSource.getTileRelativeFilenameString(pTile);
 		try {
-			final ZipEntry entry = mZipFile.getEntry(path);
-			if (entry != null) {
-				return mZipFile.getInputStream(entry);
+			if(!mIgnoreTileSource) {
+				final String path = pTileSource.getTileRelativeFilenameString(pTile);
+				final ZipEntry entry = mZipFile.getEntry(path);
+				if (entry != null) {
+					return mZipFile.getInputStream(entry);
+				}
+			} else {
+				// Search all sources in ZIP internal order
+				Enumeration<? extends ZipEntry> entries = mZipFile.entries();
+				while (entries.hasMoreElements()) {
+					ZipEntry nextElement = entries.nextElement();
+					String str=nextElement.getName();
+					if (str.contains("/")) {
+						String path = getTileRelativeFilenameString(pTile, str.split("/")[0]);
+						ZipEntry entry = mZipFile.getEntry(path);
+						if (entry != null) {
+							return mZipFile.getInputStream(entry);
+						}
+					}
+				}
 			}
 		} catch (final IOException e) {
 			Log.w(IMapView.LOGTAG,"Error getting zip stream: " + pTile, e);
 		}
 		return null;
 	}
+	
+	/**
+	 * @since 6.0
+	 * Creating paths for ZIP scanning
+	 */
+    	private String getTileRelativeFilenameString(final MapTile tile, final String pathBase) {
+		final StringBuilder sb = new StringBuilder();
+		sb.append(pathBase);
+		sb.append('/');
+		sb.append(tile.getZoomLevel());
+		sb.append('/');
+		sb.append(tile.getX());
+		sb.append('/');
+		sb.append(tile.getY());
+		sb.append(".png");
+		return sb.toString();
+    	}
 
 	public Set<String> getTileSources(){
 		Set<String> ret = new HashSet<String>();


### PR DESCRIPTION
As discussed in #688, it would be great to have all offline tile providers work in a way that tiles will be loaded regardless of their associated tile source name. `MBTilesFileArchive` and `GEMFFileArchive` have this behaviour by default.

This PR makes it possible for `DatabaseFileArchive` and `ZipFileArchive` to work the same way by introducing the new method `setIgnoreTileSource(boolean pIgnoreTileSource)` for both of them. When set true, the first available tile will be loaded regardless of the given tile source. (Default remains `false`)