### PR TITLE
Displayed tiles are now safely stored in memory

### DIFF
--- a/osmdroid-android/src/main/java/microsoft/mappoint/TileSystem.java
+++ b/osmdroid-android/src/main/java/microsoft/mappoint/TileSystem.java
@@ -30,7 +30,7 @@ public final class TileSystem {
 	 * because it gives enough space for y(29bits), x(29bits) and zoom(5bits in order to code 29),
 	 * total: 63 bits used, just small enough for a `long` variable of 4 bytes
 	 */
-	private static final int primaryKeyMaxZoomLevel = 29;
+	public static final int primaryKeyMaxZoomLevel = 29;
 
 	public static final int projectionZoomLevel = primaryKeyMaxZoomLevel + 1;
 

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileCache.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileCache.java
@@ -3,6 +3,7 @@ package org.osmdroid.tileprovider;
 
 import org.osmdroid.config.Configuration;
 import org.osmdroid.tileprovider.constants.OpenStreetMapTileProviderConstants;
+import org.osmdroid.util.MapTileList;
 
 import android.graphics.drawable.Drawable;
 
@@ -22,6 +23,7 @@ public class MapTileCache {
 
 	protected final Object mCachedTilesLockObject = new Object();
 	protected LRUMapTileCache mCachedTiles;
+	private final MapTileList mMapTileList = new MapTileList();
 
 	// ===========================================================
 	// Constructors
@@ -36,7 +38,7 @@ public class MapTileCache {
 	 *            Maximum amount of MapTiles to be hold within.
 	 */
 	public MapTileCache(final int aMaximumCacheSize) {
-		this.mCachedTiles = new LRUMapTileCache(aMaximumCacheSize);
+		this.mCachedTiles = new LRUMapTileCache(aMaximumCacheSize, mMapTileList);
 	}
 
 	// ===========================================================
@@ -61,6 +63,13 @@ public class MapTileCache {
 				this.mCachedTiles.put(aTile, aDrawable);
 			}
 		}
+	}
+
+	/**
+	 * @since 6.0.0
+	 */
+	public MapTileList getMapTileList() {
+		return  mMapTileList;
 	}
 
 	// ===========================================================

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderBase.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderBase.java
@@ -16,6 +16,7 @@ import org.osmdroid.config.Configuration;
 import org.osmdroid.tileprovider.modules.IFilesystemCache;
 import org.osmdroid.tileprovider.modules.MapTileApproximater;
 import org.osmdroid.tileprovider.tilesource.ITileSource;
+import org.osmdroid.util.MapTileList;
 import org.osmdroid.util.PointL;
 import org.osmdroid.util.RectL;
 import org.osmdroid.util.TileLooper;
@@ -481,4 +482,10 @@ public abstract class MapTileProviderBase implements IMapTileProviderCallback {
      */
 	public abstract long getQueueSize();
 
+	/**
+	 * @since 6.0.0
+	 */
+	public MapTileList getCacheMapTileList() {
+		return mTileCache.getMapTileList();
+	}
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/util/MapTileIndex.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/MapTileIndex.java
@@ -1,0 +1,42 @@
+package org.osmdroid.util;
+
+import org.osmdroid.tileprovider.MapTile;
+
+import microsoft.mappoint.TileSystem;
+
+/**
+ * Computes a map tile index as `long` to/from zoom/x/y
+ * Algorithm unfortunately different from SqlTileWriter.getIndex for historical reasons.
+ * This version is better, because it's easy to get zoom, X and Y back from the index.
+ * This version is limited to zooms between 0 and 29, which should be enough.
+ * @since 6.0.0
+ * @author Fabrice Fontaine
+ */
+
+public class MapTileIndex {
+
+    private static int mMaxZoomLevel = TileSystem.primaryKeyMaxZoomLevel;
+    private static int mModulo = 1 << mMaxZoomLevel;
+
+    public static long getTileIndex(final MapTile pMapTile) {
+        return getTileIndex(pMapTile.getZoomLevel(), pMapTile.getX(), pMapTile.getY());
+    }
+
+    public static long getTileIndex(final int pZoom, final int pX, final int pY) {
+        return (((long)pZoom) << (mMaxZoomLevel * 2))
+                + (((long)pX) << mMaxZoomLevel)
+                + (long)pY;
+    }
+
+    public static int getZoom(final long pTileIndex) {
+        return (int) (pTileIndex >> (mMaxZoomLevel * 2));
+    }
+
+    public static int getX(final long pTileIndex) {
+        return (int) ((pTileIndex >> mMaxZoomLevel) % mModulo);
+    }
+
+    public static int getY(final long pTileIndex) {
+        return (int) (pTileIndex % mModulo);
+    }
+}

--- a/osmdroid-android/src/main/java/org/osmdroid/util/MapTileList.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/MapTileList.java
@@ -1,0 +1,50 @@
+package org.osmdroid.util;
+
+/**
+ * An optimized list of map tile indices
+ * @since 6.0.0
+ * @author Fabrice Fontaine
+ */
+
+public class MapTileList {
+
+    private long[] mTileIndices = new long[1];
+    private int mSize;
+
+    public void clear() {
+        mSize = 0;
+    }
+
+    public int getSize() {
+        return mSize;
+    }
+
+    public long get(final int pIndex) {
+        return mTileIndices[pIndex];
+    }
+
+    public void put(final long pTileIndex) {
+        ensureCapacity(mSize + 1);
+        mTileIndices[mSize ++] = pTileIndex;
+    }
+
+    public void ensureCapacity(final int pCapacity) {
+        if (mTileIndices.length >= pCapacity) {
+            return;
+        }
+        synchronized(this) {
+            final long[] tmp = new long[pCapacity];
+            System.arraycopy(mTileIndices, 0, tmp, 0, mTileIndices.length);
+            mTileIndices = tmp;
+        }
+    }
+
+    public boolean contains(final long pTileIndex) {
+        for (int i = 0 ; i < mSize ; i ++) {
+            if (mTileIndices[i] == pTileIndex) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/DefaultOverlayManager.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/DefaultOverlayManager.java
@@ -120,6 +120,13 @@ public class DefaultOverlayManager extends AbstractList<Overlay> implements Over
     @Override
     public void onDraw(final Canvas c, final MapView pMapView) {
 
+        mTilesOverlay.protectDisplayedTilesForCache(c, pMapView);
+        for (final Overlay overlay : mOverlayList) {
+            if (overlay!=null && overlay.isEnabled() && overlay instanceof TilesOverlay) {
+                ((TilesOverlay) overlay).protectDisplayedTilesForCache(c, pMapView);
+            }
+        }
+
         //always pass false, the shadow parameter will be removed in a later version of osmdroid, this change should result in the on draw being called twice
         if (mTilesOverlay != null && mTilesOverlay.isEnabled()) {
             mTilesOverlay.draw(c, pMapView, false);

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/MinimapOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/MinimapOverlay.java
@@ -121,16 +121,10 @@ public class MinimapOverlay extends TilesOverlay {
 			return;
 		}
 
-		final double zoomLevel = osmv.getProjection().getZoomLevel() - getZoomDifference();
-		if (zoomLevel < mTileProvider.getMinimumZoomLevel()) {
+		if (!setViewPort(c, osmv)) {
 			return;
 		}
 
-		final int left = c.getWidth() - getPadding() - getWidth();
-		final int top = c.getHeight() - getPadding() - getHeight();
-		setCanvasRect(new Rect(left, top, left + getWidth(), top + getHeight()));
-		setProjection(osmv.getProjection().getOffspring(zoomLevel, getCanvasRect()));
-		getProjection().getMercatorViewPort(mViewPort);
 		// Draw a solid background where the minimap will be drawn with a 2 pixel inset
 		osmv.getProjection().save(c, false, true);
 		c.drawRect(
@@ -225,5 +219,20 @@ public class MinimapOverlay extends TilesOverlay {
 	private boolean contains(final MotionEvent pEvent) {
 		final Rect canvasRect = getCanvasRect();
 		return canvasRect != null && canvasRect.contains((int) pEvent.getX(), (int) pEvent.getY());
+	}
+
+	@Override
+	protected boolean setViewPort(final Canvas pCanvas, final MapView pMapView) {
+		final double zoomLevel = pMapView.getProjection().getZoomLevel() - getZoomDifference();
+		if (zoomLevel < mTileProvider.getMinimumZoomLevel()) {
+			return false;
+		}
+
+		final int left = pCanvas.getWidth() - getPadding() - getWidth();
+		final int top = pCanvas.getHeight() - getPadding() - getHeight();
+		setCanvasRect(new Rect(left, top, left + getWidth(), top + getHeight()));
+		setProjection(pMapView.getProjection().getOffspring(zoomLevel, getCanvasRect()));
+		getProjection().getMercatorViewPort(mViewPort);
+		return true;
 	}
 }

--- a/osmdroid-android/src/test/java/org/osmdroid/util/MapTileIndexTest.java
+++ b/osmdroid-android/src/test/java/org/osmdroid/util/MapTileIndexTest.java
@@ -1,0 +1,46 @@
+package org.osmdroid.util;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+import java.util.Random;
+
+import microsoft.mappoint.TileSystem;
+
+/**
+ * Unit tests related to {@link MapTileIndex}
+ * @since 6.0.0
+ * @author Fabrice Fontaine
+ */
+
+public class MapTileIndexTest {
+
+    private static final Random random = new Random();
+
+    @Test
+    public void testIndex() {
+        final int iterations = 1000;
+        for (int i = 0 ; i < iterations ; i ++) {
+            final int zoom = getRandomZoom();
+            final int x = getRandomXY(zoom);
+            final int y = getRandomXY(zoom);
+            final long index = MapTileIndex.getTileIndex(zoom, x, y);
+            checkIndex(index, zoom, x, y);
+        }
+    }
+
+    private void checkIndex(final long pIndex, final int pZoom, final int pX, final int pY) {
+        Assert.assertEquals(pZoom, MapTileIndex.getZoom(pIndex));
+        Assert.assertEquals(pX, MapTileIndex.getX(pIndex));
+        Assert.assertEquals(pY, MapTileIndex.getY(pIndex));
+    }
+
+    private int getRandomZoom() {
+        return random.nextInt(TileSystem.primaryKeyMaxZoomLevel + 1);
+    }
+
+    private int getRandomXY(final int pZoom) {
+        return random.nextInt(1 << pZoom);
+    }
+}

--- a/osmdroid-android/src/test/java/org/osmdroid/util/MapTileListTest.java
+++ b/osmdroid-android/src/test/java/org/osmdroid/util/MapTileListTest.java
@@ -1,0 +1,47 @@
+package org.osmdroid.util;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+import java.util.Random;
+
+import microsoft.mappoint.TileSystem;
+
+/**
+ * Unit tests related to {@link MapTileList}
+ * @since 6.0.0
+ * @author Fabrice Fontaine
+ */
+
+public class MapTileListTest {
+
+    private static final Random random = new Random();
+
+    @Test
+    public void testGetPut() {
+        final int iterations = 100;
+        final int maxSize = 20;
+        for (int i = 0 ; i < iterations ; i ++) {
+            final int size = 1 + random.nextInt(maxSize);
+            final long[] array = new long[size];
+            for (int j = 0 ; j < size ; j ++) {
+                array[j] = random.nextLong();
+            }
+            final MapTileList list = new MapTileList();
+            for (int j = 0 ; j < size ; j ++) {
+                list.put(array[j]);
+            }
+            checkList(array, list);
+            list.clear();
+            checkList(new long[0], list);
+        }
+    }
+
+    private void checkList(final long[] pArray, final MapTileList pList) {
+        Assert.assertEquals(pArray.length, pList.getSize());
+        for (int i = 0 ; i < pArray.length ; i ++) {
+            Assert.assertEquals(pArray[i], pList.get(i));
+        }
+    }
+}


### PR DESCRIPTION
We could even have a cache capacity of 0!

How do we do that?
* just before drawing the tiles, we list them
* using that list, we specifically ask the cache not to remove the LRU tile if it's among the displayed tiles

Isn't using the LRU enough?
* apparently not (cf. #846)
* neither theoretically (cf. `MapTileApproximater` potential side effects)

Now that we have the current list of all displayed tiles, we can do more refined cache as @shiroyagi suggested ("introducing some hysteresis to reduce disk/network access")