### PR TITLE
 Introducing an additional tiles scale factor and possible fix for #776

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderArray.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderArray.java
@@ -78,7 +78,6 @@ public class MapTileProviderArray extends MapTileProviderBase {
 			}
 		}
 
-		mTileCache.clear();
 		synchronized (mWorking) {
 			mWorking.clear();
 		}

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderArray.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderArray.java
@@ -70,18 +70,15 @@ public class MapTileProviderArray extends MapTileProviderBase {
 
 	@Override
 	public void detach() {
-
 		synchronized (mTileProviderList) {
 			for (final MapTileModuleProviderBase tileProvider : mTileProviderList) {
 				tileProvider.detach();
 
 			}
 		}
-
 		synchronized (mWorking) {
 			mWorking.clear();
 		}
-		clearTileCache();
 		if (mRegisterReceiver!=null) {
 			mRegisterReceiver.destroy();
 			mRegisterReceiver = null;

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderBase.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderBase.java
@@ -65,6 +65,7 @@ public abstract class MapTileProviderBase implements IMapTileProviderCallback {
 	 * Updated 5.2+
 	 */
 	public void detach(){
+		clearTileCache();
 		if (mTileNotFoundImage!=null){
 			// Only recycle if we are running on a project less than 2.3.3 Gingerbread.
 			if (Build.VERSION.SDK_INT < Build.VERSION_CODES.GINGERBREAD) {

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
@@ -413,7 +413,7 @@ public class MapView extends ViewGroup implements IMapView,
 	/**
 	 * Setting an additional scale factor both for ScaledToDpi and standard size	 
 	 * > 1.0 enlarges map display, < 1.0 shrinks map display
-	 * @since 6.0.0
+	 * @since 6.1.0
 	 */	 
 	public void setTilesScaleFactor(float pTilesScaleFactor) {
 		mTilesScaleFactor = pTilesScaleFactor;

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
@@ -978,7 +978,6 @@ public class MapView extends ViewGroup implements IMapView,
 	public void onDetach() {
 		this.getOverlayManager().onDetach(this);
 		mTileProvider.detach();
-		mTileProvider.clearTileCache();
 		mZoomController.setVisible(false);
 
 		//https://github.com/osmdroid/osmdroid/issues/390

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
@@ -128,6 +128,7 @@ public class MapView extends ViewGroup implements IMapView,
 	private MapTileProviderBase mTileProvider;
 	private Handler mTileRequestCompleteHandler;
 	private boolean mTilesScaledToDpi = false;
+	private float mTilesScaleFactor = 1f;
 
 	final Point mRotateScalePoint = new Point();
 
@@ -404,11 +405,30 @@ public class MapView extends ViewGroup implements IMapView,
 		mTilesScaledToDpi = tilesScaledToDpi;
 		updateTileSizeForDensity(getTileProvider().getTileSource());
 	}
+	
+	public float getTilesScaleFactor() {
+		return mTilesScaleFactor;
+	}
+	
+	/**
+	 * Setting an additional scale factor both for ScaledToDpi and standard size	 
+	 * > 1.0 enlarges map display, < 1.0 shrinks map display
+	 * @since 6.0.0
+	 */	 
+	public void setTilesScaleFactor(float pTilesScaleFactor) {
+		mTilesScaleFactor = pTilesScaleFactor;
+		updateTileSizeForDensity(getTileProvider().getTileSource());
+	}	
+	
+	public void resetTilesScaleFactor() {
+		mTilesScaleFactor = 1f;
+		updateTileSizeForDensity(getTileProvider().getTileSource());
+	}
 
 	private void updateTileSizeForDensity(final ITileSource aTileSource) {
 		int tile_size = aTileSource.getTileSizePixels();
 		float density =  getResources().getDisplayMetrics().density * 256 / tile_size ;
-		int size = (int) ( tile_size * (isTilesScaledToDpi() ? density : 1));
+		int size = (int) ( tile_size * (isTilesScaledToDpi() ? density * mTilesScaleFactor : mTilesScaleFactor));
 		if (Configuration.getInstance().isDebugMapView())
 			Log.d(IMapView.LOGTAG, "Scaling tiles to " + size);
 		TileSystem.setTileSize(size);


### PR DESCRIPTION
Based on what @roman-nevr proposed in #728, it is now possible to set an additional tiles scale factor for map scaling. This now works both for ScaledToDpi and standard size display.

Also removed redundant `MapTileProviderBase.clearTileCache()` from `MapTileProviderArray.detach()` and `MapView.detach()` and moved it to `MapTileProviderBase.detach()` where it should belong. Might be a fix for #776.