### PR TITLE
Added flexibility when computing tiles to be kept in memory cache

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileCache.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileCache.java
@@ -51,7 +51,7 @@ public class MapTileCache {
 	 */
 	private final MapTileList mGC = new MapTileList();
 
-	private final List<MapTileListComputer> computers = new ArrayList<>();
+	private final List<MapTileListComputer> mComputers = new ArrayList<>();
 
 	private int mCapacity;
 
@@ -69,8 +69,16 @@ public class MapTileCache {
 	 */
 	public MapTileCache(final int aMaximumCacheSize) {
 		ensureCapacity(aMaximumCacheSize);
-		computers.add(new MapTileListZoomComputer(-1));
-		computers.add(new MapTileListZoomComputer(1));
+		// default computers
+		mComputers.add(new MapTileListZoomComputer(-1));
+		mComputers.add(new MapTileListZoomComputer(1));
+	}
+
+	/**
+	 * @since 6.0.2
+	 */
+	public List<MapTileListComputer> getProtectedTileComputers() {
+		return mComputers;
 	}
 
 	// ===========================================================
@@ -109,7 +117,7 @@ public class MapTileCache {
 			return;
 		}
 		mAdditionalMapTileList.clear();
-		for (final MapTileListComputer computer : computers) {
+		for (final MapTileListComputer computer : mComputers) {
 			computer.computeFromSource(mMapTileList, mAdditionalMapTileList);
 		}
 		populateSyncCachedTiles(mGC);

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileCache.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileCache.java
@@ -4,11 +4,15 @@ package org.osmdroid.tileprovider;
 import org.osmdroid.api.IMapView;
 import org.osmdroid.config.Configuration;
 import org.osmdroid.util.MapTileList;
+import org.osmdroid.util.MapTileListComputer;
+import org.osmdroid.util.MapTileListZoomComputer;
 
 import android.graphics.drawable.Drawable;
 import android.util.Log;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * In memory cache of tiles
@@ -47,6 +51,8 @@ public class MapTileCache {
 	 */
 	private final MapTileList mGC = new MapTileList();
 
+	private final List<MapTileListComputer> computers = new ArrayList<>();
+
 	private int mCapacity;
 
 	// ===========================================================
@@ -63,6 +69,8 @@ public class MapTileCache {
 	 */
 	public MapTileCache(final int aMaximumCacheSize) {
 		ensureCapacity(aMaximumCacheSize);
+		computers.add(new MapTileListZoomComputer(-1));
+		computers.add(new MapTileListZoomComputer(1));
 	}
 
 	// ===========================================================
@@ -101,8 +109,9 @@ public class MapTileCache {
 			return;
 		}
 		mAdditionalMapTileList.clear();
-		mAdditionalMapTileList.populateFrom(mMapTileList, -1);
-		mAdditionalMapTileList.populateFrom(mMapTileList, 1);
+		for (final MapTileListComputer computer : computers) {
+			computer.computeFromSource(mMapTileList, mAdditionalMapTileList);
+		}
 		populateSyncCachedTiles(mGC);
 		for (int i = 0; i < mGC.getSize() ; i ++) {
 			final long index = mGC.get(i);

--- a/osmdroid-android/src/main/java/org/osmdroid/util/MapTileList.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/MapTileList.java
@@ -42,6 +42,31 @@ public class MapTileList {
         mTileIndices[mSize ++] = pTileIndex;
     }
 
+    /**
+     * @since 6.0.2
+     */
+    public void put(final int pZoom, final int pLeft, final int pTop, final int pRight, final int pBottom) {
+        final int max = 1 << pZoom;
+        final int spanX = (pRight - pLeft + 1) + (pRight < pLeft ? max : 0);
+        final int spanY = (pBottom - pTop + 1) + (pBottom < pTop ? max : 0);
+        ensureCapacity(getSize() + spanX * spanY);
+        for (int i = 0 ; i < spanX ; i ++) {
+            for (int j = 0 ; j < spanY ; j ++) {
+                final int x = (pLeft + i) % max;
+                final int y = (pTop + j) % max;
+                put(MapTileIndex.getTileIndex(pZoom, x, y));
+            }
+        }
+    }
+
+    /**
+     * @since 6.0.2
+     */
+    public void put(final int pZoom) {
+        final int max = 1 << pZoom;
+        put(pZoom, 0, 0, max - 1, max - 1);
+    }
+
     public void ensureCapacity(final int pCapacity) {
         if (mTileIndices.length >= pCapacity) {
             return;

--- a/osmdroid-android/src/main/java/org/osmdroid/util/MapTileList.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/MapTileList.java
@@ -63,36 +63,6 @@ public class MapTileList {
     }
 
     /**
-     * Compute the map tile list corresponding to a map tile list source, but on another zoom level
-     * @param pSource Map tile list to convert data from
-     * @param pZoomDelta Zoom delta to apply to the source data
-     */
-    public void populateFrom(final MapTileList pSource, final int pZoomDelta) {
-        for (int i = 0 ; i < pSource.mSize ; i ++) {
-            final long sourceIndex = pSource.mTileIndices[i];
-            final int sourceZoom = MapTileIndex.getZoom(sourceIndex);
-            final int destZoom = sourceZoom + pZoomDelta;
-            if (destZoom < 0 || destZoom > MapTileIndex.mMaxZoomLevel) {
-                continue;
-            }
-            final int sourceX = MapTileIndex.getX(sourceIndex);
-            final int sourceY = MapTileIndex.getY(sourceIndex);
-            if (pZoomDelta <= 0) {
-                put(MapTileIndex.getTileIndex(destZoom, sourceX >> -pZoomDelta, sourceY >> -pZoomDelta));
-                continue;
-            }
-            final int power = 1 << pZoomDelta;
-            final int destX = sourceX << pZoomDelta;
-            final int destY = sourceY << pZoomDelta;
-            for (int j = 0 ; j < power ; j ++) {
-                for (int k = 0 ; k < power ; k ++) {
-                    put(MapTileIndex.getTileIndex(destZoom, destX + j, destY + k));
-                }
-            }
-        }
-    }
-
-    /**
      * @since 6.0.0
      */
     public long[] toArray() {

--- a/osmdroid-android/src/main/java/org/osmdroid/util/MapTileListBorderComputer.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/MapTileListBorderComputer.java
@@ -1,0 +1,65 @@
+package org.osmdroid.util;
+
+/**
+ * Compute a map tile list from a map tile list source: its border
+ * @since 6.0.2
+ * @author Fabrice Fontaine
+ */
+
+public class MapTileListBorderComputer implements MapTileListComputer {
+
+    private final int mBorder;
+    private final boolean mIncludeAll;
+
+    public MapTileListBorderComputer(final int pBorder, final boolean pIncludeAll) {
+        mBorder = pBorder;
+        mIncludeAll = pIncludeAll;
+    }
+
+    public int getBorder() {
+        return mBorder;
+    }
+
+    public boolean isIncludeAll() {
+        return mIncludeAll;
+    }
+
+    @Override
+    public MapTileList computeFromSource(final MapTileList pSource, final MapTileList pReuse) {
+        final MapTileList out = pReuse != null ? pReuse : new MapTileList();
+        for (int i = 0 ; i < pSource.getSize() ; i ++) {
+            final long sourceIndex = pSource.get(i);
+            final int zoom = MapTileIndex.getZoom(sourceIndex);
+            final int sourceX = MapTileIndex.getX(sourceIndex);
+            final int sourceY = MapTileIndex.getY(sourceIndex);
+            final int power = 1 << zoom;
+            for (int j = -mBorder ; j <= mBorder ; j ++) {
+                for (int k = -mBorder ; k <= mBorder ; k ++) {
+                    int destX = sourceX + j;
+                    int destY = sourceY + k;
+                    while (destX < 0) {
+                        destX += power;
+                    }
+                    while (destY < 0) {
+                        destY += power;
+                    }
+                    while (destX >= power) {
+                        destX -= power;
+                    }
+                    while (destY >= power) {
+                        destY -= power;
+                    }
+                    final long index = MapTileIndex.getTileIndex(zoom, destX, destY);
+                    if (out.contains(index)) {
+                        continue;
+                    }
+                    if (pSource.contains(index) && !mIncludeAll) {
+                        continue;
+                    }
+                    out.put(index);
+                }
+            }
+        }
+        return out;
+    }
+}

--- a/osmdroid-android/src/main/java/org/osmdroid/util/MapTileListComputer.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/MapTileListComputer.java
@@ -1,0 +1,12 @@
+package org.osmdroid.util;
+
+/**
+ * Compute a map tile list from a map tile list source
+ * @since 6.0.2
+ * @author Fabrice Fontaine
+ */
+
+public interface MapTileListComputer {
+
+    MapTileList computeFromSource(final MapTileList pSource, final MapTileList pReuse);
+}

--- a/osmdroid-android/src/main/java/org/osmdroid/util/MapTileListZoomComputer.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/MapTileListZoomComputer.java
@@ -1,0 +1,48 @@
+package org.osmdroid.util;
+
+/**
+ * Compute a map tile list from a map tile list source, on another zoom level
+ * @since 6.0.2
+ * @author Fabrice Fontaine
+ */
+
+public class MapTileListZoomComputer implements MapTileListComputer {
+
+    private final int mZoomDelta;
+
+    public MapTileListZoomComputer(final int pZoomDelta) {
+        mZoomDelta = pZoomDelta;
+    }
+
+    public int getZoomDelta() {
+        return mZoomDelta;
+    }
+
+    @Override
+    public MapTileList computeFromSource(final MapTileList pSource, final MapTileList pReuse) {
+        final MapTileList out = pReuse != null ? pReuse : new MapTileList();
+        for (int i = 0 ; i < pSource.getSize() ; i ++) {
+            final long sourceIndex = pSource.get(i);
+            final int sourceZoom = MapTileIndex.getZoom(sourceIndex);
+            final int destZoom = sourceZoom + mZoomDelta;
+            if (destZoom < 0 || destZoom > MapTileIndex.mMaxZoomLevel) {
+                continue;
+            }
+            final int sourceX = MapTileIndex.getX(sourceIndex);
+            final int sourceY = MapTileIndex.getY(sourceIndex);
+            if (mZoomDelta <= 0) {
+                out.put(MapTileIndex.getTileIndex(destZoom, sourceX >> -mZoomDelta, sourceY >> -mZoomDelta));
+                continue;
+            }
+            final int power = 1 << mZoomDelta;
+            final int destX = sourceX << mZoomDelta;
+            final int destY = sourceY << mZoomDelta;
+            for (int j = 0 ; j < power ; j ++) {
+                for (int k = 0 ; k < power ; k ++) {
+                    out.put(MapTileIndex.getTileIndex(destZoom, destX + j, destY + k));
+                }
+            }
+        }
+        return out;
+    }
+}

--- a/osmdroid-android/src/main/java/org/osmdroid/util/TileSystem.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/TileSystem.java
@@ -442,14 +442,22 @@ public final class TileSystem {
 	/**
 	 * @since 6.0.0
 	 */
-	public static long ClipToLong(final double value, final double max, boolean wrapEnabled) {
-		long longValue =  MyMath.floorToLong(value - 0.5);
-		return wrapEnabled ? Clip(longValue, 0, MyMath.floorToLong(max - 1)) : longValue;
+	public static long ClipToLong(final double pValue, final double pMax, final boolean pWrapEnabled) {
+		final long longValue =  MyMath.floorToLong(pValue);
+		if (!pWrapEnabled) {
+			return longValue;
+		}
+		if (longValue <= 0) {
+			return 0;
+		}
+		final long longMax = MyMath.floorToLong(pMax - 1);
+		return longValue >= pMax ? longMax : longValue;
 	}
 
 	/**
 	 * @since 6.0.0
 	 */
+	@Deprecated
 	public static long Clip(final long n, final long minValue, final long maxValue) {
 		return Math.min(Math.max(n, minValue), maxValue);
 	}

--- a/osmdroid-android/src/test/java/org/osmdroid/util/MapTileListBorderComputerTest.java
+++ b/osmdroid-android/src/test/java/org/osmdroid/util/MapTileListBorderComputerTest.java
@@ -1,0 +1,114 @@
+package org.osmdroid.util;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Unit tests related to {@link MapTileListBorderComputer}
+ * @since 6.0.2
+ * @author Fabrice Fontaine
+ */
+
+public class MapTileListBorderComputerTest {
+
+    /**
+     * Checking border on one point, with modulo side effects, in "include all" mode on
+     */
+    @Test
+    public void testOnePointModuloInclude() {
+        final MapTileList source = new MapTileList();
+        final MapTileList dest = new MapTileList();
+        final Set<Long> set = new HashSet<>();
+        final int border = 2;
+        final MapTileListBorderComputer computer = new MapTileListBorderComputer(border, true);
+        final int zoom = 5;
+        final int sourceX = 1;
+        final int sourceY = 31;
+        source.put(MapTileIndex.getTileIndex(zoom, sourceX, sourceY));
+        add(set, zoom, sourceX, sourceY, border);
+        computer.computeFromSource(source, dest);
+        check(dest, set, zoom);
+    }
+
+    /**
+     * Checking border on one point, with modulo side effects, in "include all" mode off
+     */
+    @Test
+    public void testOnePointModulo() {
+        final MapTileList source = new MapTileList();
+        final MapTileList dest = new MapTileList();
+        final Set<Long> set = new HashSet<>();
+        final int border = 2;
+        final MapTileListBorderComputer computer = new MapTileListBorderComputer(border, false);
+        final int zoom = 5;
+        final int sourceX = 1;
+        final int sourceY = 31;
+        source.put(MapTileIndex.getTileIndex(zoom, sourceX, sourceY));
+        add(set, zoom, sourceX, sourceY, border);
+        set.remove(MapTileIndex.getTileIndex(zoom, sourceX, sourceY));
+        computer.computeFromSource(source, dest);
+        check(dest, set, zoom);
+    }
+
+    /**
+     * Checking border on two contiguous points, with modulo side effects, in "include all" mode on
+     */
+    @Test
+    public void testTwoContiguousPointsModuloInclude() {
+        final MapTileList source = new MapTileList();
+        final MapTileList dest = new MapTileList();
+        final Set<Long> set = new HashSet<>();
+        final int border = 2;
+        final MapTileListBorderComputer computer = new MapTileListBorderComputer(border, true);
+        final int zoom = 5;
+        final int sourceX = 1;
+        final int sourceY = 31;
+        source.put(MapTileIndex.getTileIndex(zoom, sourceX, sourceY));
+        source.put(MapTileIndex.getTileIndex(zoom, sourceX + 1, sourceY));
+        add(set, zoom, sourceX, sourceY, border);
+        add(set, zoom, sourceX + 1, sourceY, border);
+        computer.computeFromSource(source, dest);
+        check(dest, set, zoom);
+    }
+
+    private void check(final MapTileList pMapTileList, final Set<Long> pSet, final int pZoom) {
+        checkUnique(pMapTileList);
+        checkZoom(pMapTileList, pZoom);
+        checkEquals(pMapTileList, pSet);
+    }
+
+    private void checkEquals(final MapTileList pMapTileList, final Set<Long> pSet) {
+        Assert.assertEquals(pSet.size(), pMapTileList.getSize());
+        for (int i = 0 ; i < pMapTileList.getSize() ; i ++) {
+            Assert.assertTrue(pSet.contains(pMapTileList.get(i)));
+        }
+    }
+
+    private void checkUnique(final MapTileList pMapTileList) {
+        final Set<Long> set = new HashSet<>();
+        for (int i = 0 ; i < pMapTileList.getSize() ; i ++) {
+            Assert.assertTrue(set.add(pMapTileList.get(i)));
+        }
+    }
+
+    private void checkZoom(final MapTileList pMapTileList, final int pZoom) {
+        for (int i = 0 ; i < pMapTileList.getSize() ; i ++) {
+            final long index = pMapTileList.get(i);
+            Assert.assertEquals(pZoom, MapTileIndex.getZoom(index));
+        }
+    }
+
+    private void add(final Set<Long> pSet, final int pZoom, final int pX, final int pY, final int pBorder) {
+        final int power = 1 << pZoom;
+        for (int i = pX - pBorder ; i <= pX + pBorder ; i ++) {
+            for (int j = pY - pBorder ; j <= pY + pBorder ; j ++) {
+                pSet.add(MapTileIndex.getTileIndex(pZoom, (i + power) % power, (j + power) % power));
+            }
+        }
+
+    }
+}

--- a/osmdroid-android/src/test/java/org/osmdroid/util/MapTileListTest.java
+++ b/osmdroid-android/src/test/java/org/osmdroid/util/MapTileListTest.java
@@ -42,4 +42,63 @@ public class MapTileListTest {
             Assert.assertEquals(pArray[i], pList.get(i));
         }
     }
+
+    /**
+     * @since 6.0.2
+     */
+    @Test
+    public void testPutBoundingBox() {
+        final int iterations = 100;
+        final int zoom = 4;
+        final int max = 1 << zoom;
+        final MapTileList list = new MapTileList();
+        for (int i = 0 ; i < iterations ; i ++) {
+            final int left = random.nextInt(max);
+            final int top = random.nextInt(max);
+            final int right = random.nextInt(max);
+            final int bottom = random.nextInt(max);
+            list.clear();
+            list.put(zoom, left, top, right, bottom);
+            final int spanX = (right - left + 1) + (right < left ? max : 0);
+            final int spanY = (bottom - top + 1) + (bottom < top ? max : 0);
+            final int expectedSize = spanX * spanY;
+            Assert.assertEquals(expectedSize, list.getSize());
+            Assert.assertTrue(list.contains(MapTileIndex.getTileIndex(zoom, left, top)));
+            Assert.assertTrue(list.contains(MapTileIndex.getTileIndex(zoom, left, bottom)));
+            Assert.assertTrue(list.contains(MapTileIndex.getTileIndex(zoom, right, top)));
+            Assert.assertTrue(list.contains(MapTileIndex.getTileIndex(zoom, right, bottom)));
+            for (int j = 0 ; j < list.getSize() ; j ++) {
+                Assert.assertEquals(zoom, MapTileIndex.getZoom(list.get(j)));
+            }
+        }
+    }
+
+    /**
+     * @since 6.0.2
+     */
+    @Test
+    public void testPutZoom() {
+        final int maxZoom = 3;
+        final int left = 0;
+        final int top = 0;
+        final MapTileList list = new MapTileList();
+        for (int zoom = 0 ; zoom <= maxZoom ; zoom ++) {
+            final int max = 1 << zoom;
+            final int right = max - 1;
+            final int bottom = max - 1;
+            list.clear();
+            list.put(zoom);
+            final int spanX = (right - left + 1) + (right < left ? max : 0);
+            final int spanY = (bottom - top + 1) + (bottom < top ? max : 0);
+            final int expectedSize = spanX * spanY;
+            Assert.assertEquals(expectedSize, list.getSize());
+            Assert.assertTrue(list.contains(MapTileIndex.getTileIndex(zoom, left, top)));
+            Assert.assertTrue(list.contains(MapTileIndex.getTileIndex(zoom, left, bottom)));
+            Assert.assertTrue(list.contains(MapTileIndex.getTileIndex(zoom, right, top)));
+            Assert.assertTrue(list.contains(MapTileIndex.getTileIndex(zoom, right, bottom)));
+            for (int j = 0 ; j < list.getSize() ; j ++) {
+                Assert.assertEquals(zoom, MapTileIndex.getZoom(list.get(j)));
+            }
+        }
+    }
 }

--- a/osmdroid-android/src/test/java/org/osmdroid/util/MapTileListTest.java
+++ b/osmdroid-android/src/test/java/org/osmdroid/util/MapTileListTest.java
@@ -4,9 +4,7 @@ import junit.framework.Assert;
 
 import org.junit.Test;
 
-import java.util.HashSet;
 import java.util.Random;
-import java.util.Set;
 
 /**
  * Unit tests related to {@link MapTileList}
@@ -38,84 +36,10 @@ public class MapTileListTest {
         }
     }
 
-    private void check(final HashSet<Long> pSet, final int pZoom,
-                       final int pXMin, final int pXMax, final int pYMin, final int pYMax) {
-        Assert.assertEquals((pXMax - pXMin + 1) * (pYMax - pYMin + 1), pSet.size());
-        for (int expectedX = pXMin ; expectedX <= pXMax ; expectedX ++) {
-            for (int expectedY = pYMax ; expectedY <= pYMax ; expectedY ++) {
-                Assert.assertTrue(pSet.contains(MapTileIndex.getTileIndex(pZoom, expectedX, expectedY)));
-            }
-        }
-    }
-
     private void check(final long[] pArray, final MapTileList pList) {
         Assert.assertEquals(pArray.length, pList.getSize());
         for (int i = 0 ; i < pArray.length ; i ++) {
             Assert.assertEquals(pArray[i], pList.get(i));
-        }
-    }
-
-    @Test
-    public void testPopulateFrom() {
-        final MapTileList source = new MapTileList();
-        final MapTileList dest = new MapTileList();
-        final HashSet<Long> set = new HashSet<>();
-        final int sourceZoom = 5;
-        final int sourceXMin = 10;
-        final int sourceXMax = 15;
-        final int sourceYMin = 20;
-        final int sourceYMax = 22;
-        final int destMinus1XMin = sourceXMin >> 1;
-        final int destMinus1XMax = sourceXMax >> 1;
-        final int destMinus1YMin = sourceYMin >> 1;
-        final int destMinus1YMax = sourceYMax >> 1;
-        final int destPlus1XMin = sourceXMin << 1;
-        final int destPlus1XMax = (sourceXMax << 1) + 1;
-        final int destPlus1YMin = sourceYMin << 1;
-        final int destPlus1YMax = (sourceYMax << 1) + 1;
-        for (int i = sourceXMin ; i <= sourceXMax ; i ++) {
-            for (int j = sourceYMin ; j <= sourceYMax ; j ++) {
-                source.put(MapTileIndex.getTileIndex(sourceZoom, i, j));
-            }
-        }
-        Assert.assertEquals((sourceXMax - sourceXMin + 1) * (sourceYMax - sourceYMin + 1), source.getSize());
-
-        // count checking
-        final int minMaxDelta = 4;
-        for (int zoomDelta = -minMaxDelta ; zoomDelta < minMaxDelta ; zoomDelta ++) {
-            dest.clear();
-            dest.populateFrom(source, zoomDelta);
-            final String tag = "zoomDelta=" + zoomDelta;
-            if (sourceZoom + zoomDelta < 0 || sourceZoom + zoomDelta > MapTileIndex.mMaxZoomLevel) {
-                Assert.assertEquals(tag, 0, dest.getSize());
-            } else if (zoomDelta <= 0) {
-                Assert.assertEquals(tag, source.getSize(), dest.getSize());
-            } else {
-                Assert.assertEquals(tag, source.getSize() << (2 * zoomDelta), dest.getSize());
-            }
-        }
-
-        int zoomDelta;
-        // data checking for -1
-        zoomDelta = -1;
-        dest.clear();
-        dest.populateFrom(source, zoomDelta);
-        set.clear();
-        populateSet(set, dest);
-        check(set, sourceZoom + zoomDelta, destMinus1XMin, destMinus1XMax, destMinus1YMin, destMinus1YMax);
-
-        // data checking for +1
-        zoomDelta = 1;
-        dest.clear();
-        dest.populateFrom(source, zoomDelta);
-        set.clear();
-        populateSet(set, dest);
-        check(set, sourceZoom + zoomDelta, destPlus1XMin, destPlus1XMax, destPlus1YMin, destPlus1YMax);
-    }
-
-    private void populateSet(final Set<Long> pSet, final MapTileList pMapTileList) {
-        for (int i = 0 ; i < pMapTileList.getSize() ; i ++) {
-            pSet.add(pMapTileList.get(i));
         }
     }
 }

--- a/osmdroid-android/src/test/java/org/osmdroid/util/MapTileListZoomComputerTest.java
+++ b/osmdroid-android/src/test/java/org/osmdroid/util/MapTileListZoomComputerTest.java
@@ -1,0 +1,92 @@
+package org.osmdroid.util;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Unit tests related to {@link MapTileListZoomComputer}
+ * @since 6.0.2
+ * @author Fabrice Fontaine
+ */
+
+public class MapTileListZoomComputerTest {
+
+    @Test
+    public void testComputeFromSource() {
+        final MapTileList source = new MapTileList();
+        final MapTileList dest = new MapTileList();
+        final HashSet<Long> set = new HashSet<>();
+        final int sourceZoom = 5;
+        final int sourceXMin = 10;
+        final int sourceXMax = 15;
+        final int sourceYMin = 20;
+        final int sourceYMax = 22;
+        final int destMinus1XMin = sourceXMin >> 1;
+        final int destMinus1XMax = sourceXMax >> 1;
+        final int destMinus1YMin = sourceYMin >> 1;
+        final int destMinus1YMax = sourceYMax >> 1;
+        final int destPlus1XMin = sourceXMin << 1;
+        final int destPlus1XMax = (sourceXMax << 1) + 1;
+        final int destPlus1YMin = sourceYMin << 1;
+        final int destPlus1YMax = (sourceYMax << 1) + 1;
+        for (int i = sourceXMin ; i <= sourceXMax ; i ++) {
+            for (int j = sourceYMin ; j <= sourceYMax ; j ++) {
+                source.put(MapTileIndex.getTileIndex(sourceZoom, i, j));
+            }
+        }
+        Assert.assertEquals((sourceXMax - sourceXMin + 1) * (sourceYMax - sourceYMin + 1), source.getSize());
+
+        // count checking
+        final int minMaxDelta = 4;
+        for (int zoomDelta = -minMaxDelta ; zoomDelta < minMaxDelta ; zoomDelta ++) {
+            final MapTileListZoomComputer computer = new MapTileListZoomComputer(zoomDelta);
+            dest.clear();
+            computer.computeFromSource(source, dest);
+            final String tag = "zoomDelta=" + zoomDelta;
+            if (sourceZoom + zoomDelta < 0 || sourceZoom + zoomDelta > MapTileIndex.mMaxZoomLevel) {
+                Assert.assertEquals(tag, 0, dest.getSize());
+            } else if (zoomDelta <= 0) {
+                Assert.assertEquals(tag, source.getSize(), dest.getSize());
+            } else {
+                Assert.assertEquals(tag, source.getSize() << (2 * zoomDelta), dest.getSize());
+            }
+        }
+
+        MapTileListZoomComputer computer;
+        // data checking for -1
+        computer = new MapTileListZoomComputer(-1);
+        dest.clear();
+        computer.computeFromSource(source, dest);
+        set.clear();
+        populateSet(set, dest);
+        check(set, sourceZoom + computer.getZoomDelta(), destMinus1XMin, destMinus1XMax, destMinus1YMin, destMinus1YMax);
+
+        // data checking for +1
+        computer = new MapTileListZoomComputer(1);
+        dest.clear();
+        computer.computeFromSource(source, dest);
+        set.clear();
+        populateSet(set, dest);
+        check(set, sourceZoom + computer.getZoomDelta(), destPlus1XMin, destPlus1XMax, destPlus1YMin, destPlus1YMax);
+    }
+
+    private void check(final HashSet<Long> pSet, final int pZoom,
+                       final int pXMin, final int pXMax, final int pYMin, final int pYMax) {
+        Assert.assertEquals((pXMax - pXMin + 1) * (pYMax - pYMin + 1), pSet.size());
+        for (int expectedX = pXMin ; expectedX <= pXMax ; expectedX ++) {
+            for (int expectedY = pYMax ; expectedY <= pYMax ; expectedY ++) {
+                Assert.assertTrue(pSet.contains(MapTileIndex.getTileIndex(pZoom, expectedX, expectedY)));
+            }
+        }
+    }
+
+    private void populateSet(final Set<Long> pSet, final MapTileList pMapTileList) {
+        for (int i = 0 ; i < pMapTileList.getSize() ; i ++) {
+            pSet.add(pMapTileList.get(i));
+        }
+    }
+}


### PR DESCRIPTION
Not to be merged; this only the first step, though the goal is not very far:
* having a consistent default mode, similar to what we have now (displayed tiles and zooms +-1)
* making it easy to override this mode for explicit needs - for the moment we need to explicitly override `MapTileCache`'s constructor, and I'd prefer something smoother

New interface:
* `MapTileListComputer`: compute a map tile list from a map tile list source

New classes:
* `MapTileListBorderComputer`: compute a map tile list from a map tile list source: its border
* `MapTileListZoomComputer`: compute a map tile list from a map tile list source, on another zoom level
* `MapTileListBorderComputerTest`: unit test class for `MapTileListBorderComputer`
* `MapTileListZoomComputerTest`: unit test class for `MapTileListZoomComputer`

Impacted classes:
* `MapTileCache`: impacted method `garbageCollection` with new classes
* `MapTileList`: moved code of method `populatedFrom` to new class `MapTileListZoomComputer`
* `MapTileListTest`: moved unit test code of method `testPopulatedFrom` to new class `MapTileListZoomComputerTest`