### PR TITLE
Smooth tile garbage collection, with new SQL index

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/config/DefaultConfigurationProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/config/DefaultConfigurationProvider.java
@@ -56,6 +56,9 @@ public class DefaultConfigurationProvider implements IConfigurationProvider {
     protected int animationSpeedShort =500;
     protected boolean mapViewRecycler=true;
     protected short cacheTileOvershoot=0;
+    protected long mTileGCFrequencyInMillis = 300000;
+    protected int mTileGCBulkSize = 20;
+    protected long mTileGCBulkPauseInMillis = 500;
 
     public DefaultConfigurationProvider(){
 
@@ -498,5 +501,35 @@ public class DefaultConfigurationProvider implements IConfigurationProvider {
     @Override
     public short getCacheMapTileOvershoot() {
         return cacheTileOvershoot;
+    }
+
+    @Override
+    public long getTileGCFrequencyInMillis() {
+        return mTileGCFrequencyInMillis;
+    }
+
+    @Override
+    public void setTileGCFrequencyInMillis(final long pMillis) {
+        mTileGCFrequencyInMillis = pMillis;
+    }
+
+    @Override
+    public int getTileGCBulkSize() {
+        return mTileGCBulkSize;
+    }
+
+    @Override
+    public void setTileGCBulkSize(final int pSize) {
+        mTileGCBulkSize = pSize;
+    }
+
+    @Override
+    public long getTileGCBulkPauseInMillis() {
+        return mTileGCBulkPauseInMillis;
+    }
+
+    @Override
+    public void setTileGCBulkPauseInMillis(final long pMillis) {
+        mTileGCBulkPauseInMillis = pMillis;
     }
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/config/IConfigurationProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/config/IConfigurationProvider.java
@@ -393,4 +393,37 @@ public interface IConfigurationProvider {
      * @return
      */
     short getCacheMapTileOvershoot();
+
+    /**
+     * Delay between tile garbage collection calls
+     * @since 6.0.2
+     */
+    long getTileGCFrequencyInMillis();
+
+    /**
+     * @since 6.0.2
+     */
+    void setTileGCFrequencyInMillis(final long pMillis);
+
+    /**
+     * Tile garbage collection bulk size
+     * @since 6.0.2
+     */
+    int getTileGCBulkSize();
+
+    /**
+     * @since 6.0.2
+     */
+    void setTileGCBulkSize(final int pSize);
+
+    /**
+     * Pause during tile garbage collection bulk deletions
+     * @since 6.0.2
+     */
+    long getTileGCBulkPauseInMillis();
+
+    /**
+     * @since 6.0.2
+     */
+    void setTileGCBulkPauseInMillis(final long pMillis);
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/SqlTileWriter.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/SqlTileWriter.java
@@ -14,6 +14,7 @@ import org.osmdroid.tileprovider.tilesource.ITileSource;
 import org.osmdroid.tileprovider.util.Counters;
 import org.osmdroid.tileprovider.util.StreamUtils;
 import org.osmdroid.util.MapTileIndex;
+import org.osmdroid.util.GarbageCollector;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
@@ -27,6 +28,7 @@ import java.util.List;
 
 import static org.osmdroid.tileprovider.modules.DatabaseFileArchive.COLUMN_PROVIDER;
 import static org.osmdroid.tileprovider.modules.DatabaseFileArchive.COLUMN_KEY;
+import static org.osmdroid.tileprovider.modules.DatabaseFileArchive.COLUMN_TILE;
 import static org.osmdroid.tileprovider.modules.DatabaseFileArchive.TABLE;
 
 /**
@@ -44,6 +46,7 @@ import static org.osmdroid.tileprovider.modules.DatabaseFileArchive.TABLE;
 public class SqlTileWriter implements IFilesystemCache {
     public static final String DATABASE_FILENAME = "cache.db";
     public static final String COLUMN_EXPIRES ="expires";
+    public static final String COLUMN_EXPIRES_INDEX ="expires_index";
 
     private static boolean cleanOnStartup=true;
     /*
@@ -60,12 +63,13 @@ public class SqlTileWriter implements IFilesystemCache {
     protected File db_file;
     protected SQLiteDatabase db;
     protected long lastSizeCheck=0;
+    private final GarbageCollector garbageCollector = new GarbageCollector(new Runnable() {
+        @Override
+        public void run() {
+            runCleanupOperation();
+        }
+    });
 
-    /**
-     * mean tile size computed on first use.
-     * Sizes are quite variable and a significant underestimate will result in too many tiles being purged.
-     */
-    long tileSize=0l;
     static boolean hasInited=false;
 
     public SqlTileWriter() {
@@ -84,15 +88,7 @@ public class SqlTileWriter implements IFilesystemCache {
             hasInited = true;
 
             if (cleanOnStartup) {
-                // do this in the background because it takes a long time
-                final Thread t = new Thread() {
-                    @Override
-                    public void run() {
-                        runCleanupOperation();
-                    }
-                };
-                t.setPriority(Thread.MIN_PRIORITY);
-                t.start();
+                garbageCollector.gc();
             }
         }
     }
@@ -111,46 +107,39 @@ public class SqlTileWriter implements IFilesystemCache {
             return;
         }
 
-        try {
-            if (db_file.length() > Configuration.getInstance().getTileFileSystemCacheMaxBytes()) {
-                //run the reaper (remove all old expired tiles)
-                //keep if now is < expiration date
-                //delete if now is > expiration date
-                long now = System.currentTimeMillis();
-                //this part will nuke all expired tiles, not super useful if you're offline
-                //int rows = db.delete(TABLE, "expires < ?", new String[]{System.currentTimeMillis() + ""});
-                //Log.d(IMapView.LOGTAG, "Local storage cache purged " + rows + " expired tiles in " + (System.currentTimeMillis() - now) + "ms, cache size is " + db_file.length() + "bytes");
-
-                //attempt to trim the database
-                //note, i considered adding a looping mechanism here but sqlite can behave differently
-                //i.e. there's no guarantee that the database file size shrinks immediately.
-                Log.i(IMapView.LOGTAG, "Local cache is now " + db_file.length() + " max size is " + Configuration.getInstance().getTileFileSystemCacheMaxBytes());
-                long diff = db_file.length() - Configuration.getInstance().getTileFileSystemCacheTrimBytes();
-                if (tileSize == 0l) {
-                    long count = getRowCount(null);
-                    tileSize = count > 0l ? db_file.length() / count : 4000;
-                    if (Configuration.getInstance().isDebugMode()) {
-                        Log.d(IMapView.LOGTAG, "Number of cached tiles is " + count + ", mean size is " + tileSize);
-                    }
-                }
-                long tilesToKill = diff / tileSize;
-                Log.d(IMapView.LOGTAG, "Local cache purging " + tilesToKill + " tiles.");
-                if (tilesToKill > 0)
-                    try {
-                        db.execSQL("DELETE FROM " + TABLE + " WHERE " + COLUMN_KEY + " in (SELECT " + COLUMN_KEY + " FROM " + TABLE + " ORDER BY " + COLUMN_EXPIRES + " ASC LIMIT " + tilesToKill + ")");
-                    } catch (Throwable t) {
-                        Log.e(IMapView.LOGTAG, "error purging tiles from the tile cache", t);
-                    }
-                Log.d(IMapView.LOGTAG, "purge completed in " + (System.currentTimeMillis() - now) + "ms, cache size is " + db_file.length() + " bytes");
-            }
-        } catch (Exception ex) {
-            if (Configuration.getInstance().isDebugMode()) {
-                Log.d(IMapView.LOGTAG, "SqliteTileWriter init thread crash, db is probably not available", ex);
-            }
+        final long dbLength = db_file.length();
+        if (dbLength <= Configuration.getInstance().getTileFileSystemCacheMaxBytes()) {
+            return;
         }
 
-        if (Configuration.getInstance().isDebugMode()) {
-            Log.d(IMapView.LOGTAG, "Finished init thread");
+        db.execSQL("CREATE INDEX IF NOT EXISTS " + COLUMN_EXPIRES_INDEX + " ON " + TABLE + " (" + COLUMN_EXPIRES +");");
+
+        long diff = dbLength - Configuration.getInstance().getTileFileSystemCacheTrimBytes();
+        while(diff > 0) {
+            final long now = System.currentTimeMillis();
+            final Cursor cur = db.rawQuery(
+                    "SELECT " + COLUMN_KEY + ",LENGTH(HEX(" + COLUMN_TILE + "))/2 " +
+                    "FROM " + DatabaseFileArchive.TABLE + " " +
+                    "WHERE " + COLUMN_EXPIRES + " IS NOT NULL AND " + COLUMN_EXPIRES + " < " + now + " " +
+                    "ORDER BY " + COLUMN_EXPIRES + " DESC " +
+                    "LIMIT 1", null);
+
+            final long key;
+            final long size;
+            if (cur.moveToFirst()){
+                key = cur.getLong(0);
+                size = cur.getLong(1);
+            } else {
+                key = 0;
+                size = 0;
+            }
+            cur.close();
+            if (size <= 0) {
+                return;
+            }
+
+            db.execSQL("DELETE FROM " + TABLE + " WHERE " + COLUMN_KEY + " = " + key);
+            diff -= size;
         }
     }
 
@@ -184,14 +173,12 @@ public class SqlTileWriter implements IFilesystemCache {
                 Log.d(IMapView.LOGTAG, "tile inserted " + pTileSourceInfo.name() + MapTileIndex.toString(pMapTileIndex));
             if (System.currentTimeMillis() > lastSizeCheck + 300000){
                 lastSizeCheck = System.currentTimeMillis();
-                if (db_file!=null && db_file.length() > Configuration.getInstance().getTileFileSystemCacheMaxBytes()) {
-                    runCleanupOperation();
-                }
+                garbageCollector.gc();
             }
         } catch (SQLiteFullException ex) {
             //the drive is full! trigger the clean up operation
             //may want to consider reducing the trim size automagically
-            runCleanupOperation();
+            garbageCollector.gc();
         } catch (Throwable ex) {
             //note, although we check for db null state at the beginning of this method, it's possible for the
             //db to be closed during the execution of this method

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/SqlTileWriter.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/SqlTileWriter.java
@@ -107,12 +107,14 @@ public class SqlTileWriter implements IFilesystemCache {
             return;
         }
 
+        // index creation is run now (regardless of the table size)
+        // therefore potentially on a small table, for better index creation performances
+        db.execSQL("CREATE INDEX IF NOT EXISTS " + COLUMN_EXPIRES_INDEX + " ON " + TABLE + " (" + COLUMN_EXPIRES +");");
+
         final long dbLength = db_file.length();
         if (dbLength <= Configuration.getInstance().getTileFileSystemCacheMaxBytes()) {
             return;
         }
-
-        db.execSQL("CREATE INDEX IF NOT EXISTS " + COLUMN_EXPIRES_INDEX + " ON " + TABLE + " (" + COLUMN_EXPIRES +");");
 
         long diff = dbLength - Configuration.getInstance().getTileFileSystemCacheTrimBytes();
         final int limit = 20;

--- a/osmdroid-android/src/main/java/org/osmdroid/util/GarbageCollector.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/GarbageCollector.java
@@ -1,0 +1,45 @@
+package org.osmdroid.util;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * "Garbage Collector" tool
+ * The principles are:
+ * * it runs smoothly and asynchronously
+ * * only one execution at the same time
+ * @author Fabrice Fontaine
+ * @since 6.0.2
+ */
+
+public class GarbageCollector {
+
+    private final AtomicBoolean mRunning = new AtomicBoolean(false);
+    private final Runnable mAction;
+
+    public GarbageCollector(final Runnable pAction) {
+        mAction = pAction;
+    }
+
+    public boolean gc() {
+        if (mRunning.getAndSet(true)) {
+            return false;
+        }
+        final Thread thread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    mAction.run();
+                } finally {
+                    mRunning.set(false);
+                }
+            }
+        });
+        thread.setPriority(Thread.MIN_PRIORITY);
+        thread.start();
+        return true;
+    }
+
+    public boolean isRunning() {
+        return mRunning.get();
+    }
+}

--- a/osmdroid-android/src/test/java/org/osmdroid/util/GarbageCollectorTest.java
+++ b/osmdroid-android/src/test/java/org/osmdroid/util/GarbageCollectorTest.java
@@ -1,0 +1,97 @@
+package org.osmdroid.util;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @author Fabrice Fontaine
+ * @since 6.0.2
+ */
+
+public class GarbageCollectorTest {
+
+    private final AtomicInteger mCount = new AtomicInteger(0);
+
+    @Test
+    public void testInit() {
+        final GarbageCollector garbageCollector = new GarbageCollector(getAction());
+        mCount.set(0);
+
+        Assert.assertFalse(garbageCollector.isRunning());
+        Assert.assertEquals(0, mCount.get());
+    }
+
+    @Test
+    public void testFirst() {
+        final GarbageCollector garbageCollector = new GarbageCollector(getAction());
+        mCount.set(0);
+
+        garbageCollector.gc();
+        sleep(100);
+        Assert.assertEquals(1, mCount.get());
+        Assert.assertTrue(garbageCollector.isRunning());
+        sleep(500);
+        Assert.assertFalse(garbageCollector.isRunning());
+        Assert.assertEquals(1, mCount.get());
+    }
+
+    @Test
+    public void testSecond() {
+        final GarbageCollector garbageCollector = new GarbageCollector(getAction());
+        mCount.set(0);
+
+        garbageCollector.gc();
+        sleep(100);
+        Assert.assertEquals(1, mCount.get());
+        Assert.assertTrue(garbageCollector.isRunning());
+        sleep(500);
+        Assert.assertFalse(garbageCollector.isRunning());
+        Assert.assertEquals(1, mCount.get());
+
+        garbageCollector.gc();
+        sleep(100);
+        Assert.assertEquals(2, mCount.get());
+        Assert.assertTrue(garbageCollector.isRunning());
+        sleep(500);
+        Assert.assertFalse(garbageCollector.isRunning());
+        Assert.assertEquals(2, mCount.get());
+    }
+
+    @Test
+    public void testMulti() {
+        final GarbageCollector garbageCollector = new GarbageCollector(getAction());
+        mCount.set(0);
+
+        garbageCollector.gc();
+        garbageCollector.gc();
+        garbageCollector.gc();
+        garbageCollector.gc();
+        sleep(100);
+        Assert.assertEquals(1, mCount.get());
+        Assert.assertTrue(garbageCollector.isRunning());
+        sleep(500);
+        Assert.assertFalse(garbageCollector.isRunning());
+        Assert.assertEquals(1, mCount.get());
+    }
+
+    private Runnable getAction() {
+        return new Runnable() {
+            @Override
+            public void run() {
+                mCount.incrementAndGet();
+                sleep(500);
+            }
+        };
+    }
+
+    private void sleep(final long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch(InterruptedException e) {
+            //
+        }
+    }
+}


### PR DESCRIPTION
New classes:
* `GarbageCollector`: running a task smoothly and asynchronously, only one execution at the same time
* `GarbageCollectorTest`: unit test class related to `GarbageCollector`

Impacted class:
* `SqlTileWriter`: included index creation inside `runCleanupOperation` and one-by-one tile removal; replaced `runCleanupOperation` calls to garbage collection calls