### PR TITLE
Bug/#992: Refactored code and cleaned javadoc in class Projection

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/util/RectL.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/RectL.java
@@ -316,4 +316,40 @@ public class RectL {
                                    final double pCos, final double pSin) {
         return pCenterY + Math.round((pX - pCenterX) * pSin + (pY - pCenterY) * pCos);
     }
+
+    /**
+     * @since 6.0.2
+     */
+    public void offset(final long pDx, final long pDy) {
+        left += pDx;
+        top += pDy;
+        right += pDx;
+        bottom += pDy;
+    }
+
+    /**
+     * @since 6.0.2
+     */
+    public void union(final long pLeft, final long pTop, final long pRight, final long pBottom) {
+        if ((pLeft < pRight) && (pTop < pBottom)) {
+            if ((left < right) && (top < bottom)) {
+                if (left > pLeft) left = pLeft;
+                if (top > pTop) top = pTop;
+                if (right < pRight) right = pRight;
+                if (bottom < pBottom) bottom = pBottom;
+            } else {
+                left = pLeft;
+                top = pTop;
+                right = pRight;
+                bottom = pBottom;
+            }
+        }
+    }
+
+    /**
+     * @since 6.0.2
+     */
+    public void union(final RectL pRect) {
+        union(pRect.left, pRect.top, pRect.right, pRect.bottom);
+    }
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polygon.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polygon.java
@@ -354,9 +354,8 @@ public class Polygon extends OverlayWithIW {
 			mInfoWindowLocation = new GeoPoint(0.0, 0.0);
 			return;
 		}
-		BoundingBox bb = BoundingBox.fromGeoPoints(mOutline.getPoints());
 		//TODO: as soon as the polygon bounding box will be a class member, don't compute it again here.
-		mInfoWindowLocation = bb.getCenterWithDateLine();
+		mInfoWindowLocation = mOutline.getCenter(null);
 	}
 
 	/**


### PR DESCRIPTION
Impacted classes:
* `MyLocationNewOverlay`: replaced deprecated `Rect` and `Point` method calls from `Projection` by the `RectL` and `PointL` version
* `Projection`: fixed some javadoc comments; deprecated the version of `toProjectedPixels` still using `1E6 int` coordinates; added an explicit javadoc `@deprecated` comment for every `@Deprecated` annotation; removed useless private methods `getPixelXFromMercator`, `getPixelYFromMercator` and `getPixelFromMercator`; removed int/long duplicate code in the deprecated methods
* `RectL`: added methods `offset` and `union`, inspired from `Rect`'s, in order to be able to deprecate some `Projection` methods