### PR TITLE
Fix creating tilepackage from temp directory

### DIFF
--- a/OSMMapTilePackager/src/main/java/org/osmdroid/mtp/OSMMapTilePackager.java
+++ b/OSMMapTilePackager/src/main/java/org/osmdroid/mtp/OSMMapTilePackager.java
@@ -186,7 +186,11 @@ public class OSMMapTilePackager {
           final int pMinZoom, final int pMaxZoom, final double pNorth, final double pSouth,
           final double pEast, final double pWest, final ProgressNotification callbackNotification) {
           System.out.println("---------------------------");
-          runDownloading(pServerURL, pTempFolder, pThreadCount, pFileAppendix, pMinZoom, pMaxZoom, pNorth, pSouth, pEast, pWest, callbackNotification);
+          if (pServerURL!=null) {
+		     runDownloading(pServerURL, pTempFolder, pThreadCount, pFileAppendix, pMinZoom, pMaxZoom, pNorth, pSouth, pEast, pWest, callbackNotification);
+	     } else {
+               System.out.println("using temporary directory content");
+	     }
           System.out.println("---------------------------");
           if (callbackNotification != null) {
                callbackNotification.updateProgress("Download complete, creating archive");


### PR DESCRIPTION
Bug fix: runDownloading should not be called if packaging from a temp directory
(serverURL==null && tempFolder.exists())