### PR TITLE
bug/#989 - adding an increasing delay in tile fetch repetition

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderArray.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderArray.java
@@ -45,9 +45,14 @@ public class MapTileProviderArray extends MapTileProviderBase {
 	/**
 	 * @since 6.0.2
 	 */
-	private static final long[] mExponentialBackoffDurationInMillis = new long[] {
-			1000, 2000, 15000, 60000, 120000, 300000
+	private static final long[] mExponentialBackoffDurationInMillisDefault = new long[] {
+			5000, 15000, 60000, 120000, 300000
 	};
+
+	/**
+	 * @since 6.0.2
+	 */
+	private long[] mExponentialBackoffDurationInMillis = mExponentialBackoffDurationInMillisDefault;
 
 	/**
 	 * @since 6.0.2
@@ -315,5 +320,12 @@ public class MapTileProviderArray extends MapTileProviderBase {
 		synchronized (mTileDelays) {
 			mTileDelays.remove(pMapTileIndex);
 		}
+	}
+
+	/**
+	 * @since 6.0.2
+	 */
+	public void setExponentialBackoffDurationInMillis(final long[] pExponentialBackoffDurationInMillis) {
+		mExponentialBackoffDurationInMillis = pExponentialBackoffDurationInMillis;
 	}
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileDownloader.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileDownloader.java
@@ -56,6 +56,11 @@ public class MapTileDownloader extends MapTileModuleProviderBase {
 
 	private final INetworkAvailablityCheck mNetworkAvailablityCheck;
 
+	/**
+	 * @since 6.0.2
+	 */
+	private final TileLoader mTileLoader = new TileLoader();
+
 	// ===========================================================
 	// Constructors
 	// ===========================================================
@@ -116,7 +121,7 @@ public class MapTileDownloader extends MapTileModuleProviderBase {
 
 	@Override
 	public TileLoader getTileLoader() {
-		return new TileLoader();
+		return mTileLoader;
 	}
 
 	@Override
@@ -254,10 +259,8 @@ public class MapTileDownloader extends MapTileModuleProviderBase {
 
 				return result;
 			} catch (final UnknownHostException e) {
-				// no network connection so empty the queue
 				Log.w(IMapView.LOGTAG,"UnknownHostException downloading MapTile: " + MapTileIndex.toString(pMapTileIndex) + " : " + e);
 				Counters.tileDownloadErrors++;
-				throw new CantContinueException(e);
 			} catch (final LowMemoryException e) {
 				// low memory so empty the queue
 				Counters.countOOM++;

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileDownloader.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileDownloader.java
@@ -214,6 +214,7 @@ public class MapTileDownloader extends MapTileModuleProviderBase {
 						Log.d(IMapView.LOGTAG, tileURLString);
 					}
 					Counters.tileDownloadErrors++;
+					in = c.getErrorStream(); // in order to have the error stream purged by the finally block
 					return null;
 				}
 				if (Configuration.getInstance().isDebugMapTileDownloader()) {

--- a/osmdroid-android/src/main/java/org/osmdroid/util/Delay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/Delay.java
@@ -1,0 +1,49 @@
+package org.osmdroid.util;
+
+/**
+ * @since 6.0.2
+ * @author Fabrice Fontaine
+ */
+public class Delay {
+
+    private final long[] mDurations;
+    private long mDuration;
+    private long mNextTime;
+    private int mIndex;
+
+    public Delay(final long pDuration) {
+        mDurations = null;
+        mDuration = pDuration;
+        next();
+    }
+
+    public Delay(final long[] pDurations) {
+        if (pDurations == null || pDurations.length == 0) {
+            throw new IllegalArgumentException();
+        }
+        mDurations = pDurations;
+        next();
+    }
+
+    public long next() {
+        final long duration;
+        if (mDurations == null) {
+            duration = mDuration;
+        } else {
+            duration = mDurations[mIndex];
+            if (mIndex < mDurations.length - 1) {
+                mIndex ++;
+            }
+        }
+        mNextTime = now() + duration;
+        return duration;
+    }
+
+    public boolean shouldWait() {
+        return now() < mNextTime;
+    }
+
+    private long now() {
+        return System.nanoTime() / 1000000L;
+    }
+}

--- a/osmdroid-android/src/test/java/org/osmdroid/util/DelayTest.java
+++ b/osmdroid-android/src/test/java/org/osmdroid/util/DelayTest.java
@@ -1,0 +1,56 @@
+package org.osmdroid.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Random;
+
+/**
+ * @since 6.0.2
+ * @author Fabrice Fontaine
+ */
+public class DelayTest {
+
+    @Test
+    public void testDelayOne() {
+        final long millis = 500;
+        final Delay delay = new Delay(millis);
+        for (int i = 0 ; i < 5 ; i ++) {
+            check(delay, millis);
+            final long next = delay.next();
+            Assert.assertEquals(millis, next);
+        }
+    }
+
+    @Test
+    public void testDelayMulti() {
+        final long[] millis = new long[] {500, 600, 800, 1000};
+        final long lastDuration = millis[millis.length - 1];
+        long next;
+        final Delay delay = new Delay(millis);
+        for (int i = 0 ; i < millis.length ; i ++) {
+            check(delay, millis[i]);
+            next = delay.next();
+            Assert.assertEquals(i < millis.length - 1 ? millis[i + 1] : lastDuration, next);
+        }
+        check(delay, lastDuration);
+        next = delay.next();
+        Assert.assertEquals(lastDuration, next);
+        check(delay, lastDuration);
+    }
+
+    private void check(final Delay pDelay, final long pMillis) {
+        sleep((pMillis * 3) / 4);
+        Assert.assertTrue(pDelay.shouldWait());
+        sleep(pMillis / 2);
+        Assert.assertFalse(pDelay.shouldWait());
+    }
+
+    private void sleep(final long pMillis) {
+        try {
+            Thread.sleep(pMillis, 0);
+        } catch (InterruptedException e) {
+            //
+        }
+    }
+}


### PR DESCRIPTION
When for some reason we could not get an up-to-date version of a tile, the tile fetch process went in an endless loop in the search of this up-to-date version.
The endless loop is not good itself, and it's even worse when there's a provider that uses the network: tons of useless network tries.
The fix is to consider that if we can't get the up-to-date version, we wait before trying again. And the delay is increasing.

New classes:
* `Delay`: successive delays container
* `DelayTest`: the unit test class around `Delay`

Impacted classes:
* `MapTileDownloader`: unrelated optimization regarding the instantiation of `TileLoader`; considered `UnknownHostException` as similar to other `IOException`s
* `MapTileProviderArray`: added member `mTileDelays` as a `Map<tile, Delay>` and an exponential backoff delay array `mExponentialBackoffDurationInMillis`; added a check in `getMapTile` in order to delay the next tile fetch; adapted `mapTileRequest*` methods in order to affect the tile delay; created methods `shouldWait`, `nextDelay` and `removeDelay`