### PR TITLE
bug/#1012 - stronger code against not "synchronized" map access in "clear"

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileCache.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileCache.java
@@ -162,7 +162,7 @@ public class MapTileCache {
 	 */
 	public void clear() {
 		// remove them all individually so that they get recycled
-		final MapTileList list = new MapTileList(mCachedTiles.size());
+		final MapTileList list = new MapTileList();
 		populateSyncCachedTiles(list);
 		for (int i = 0; i < list.getSize() ; i ++) {
 			final long index = list.get(i);

--- a/osmdroid-android/src/main/java/org/osmdroid/util/MapTileList.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/MapTileList.java
@@ -11,20 +11,6 @@ public class MapTileList {
     private long[] mTileIndices;
     private int mSize;
 
-    /**
-     * @since 6.0.0
-     */
-    public MapTileList() {
-        this(1);
-    }
-
-    /**
-     * @since 6.0.0
-     */
-    public MapTileList(final int initialCapacity) {
-        mTileIndices = new long[initialCapacity];
-    }
-
     public void clear() {
         mSize = 0;
     }
@@ -68,17 +54,25 @@ public class MapTileList {
     }
 
     public void ensureCapacity(final int pCapacity) {
-        if (mTileIndices.length >= pCapacity) {
+        if (pCapacity == 0) {
+            return;
+        }
+        if (mTileIndices != null && mTileIndices.length >= pCapacity) {
             return;
         }
         synchronized(this) {
             final long[] tmp = new long[pCapacity];
-            System.arraycopy(mTileIndices, 0, tmp, 0, mTileIndices.length);
+            if (mTileIndices != null) {
+                System.arraycopy(mTileIndices, 0, tmp, 0, mTileIndices.length);
+            }
             mTileIndices = tmp;
         }
     }
 
     public boolean contains(final long pTileIndex) {
+        if (mTileIndices == null) {
+            return false;
+        }
         for (int i = 0 ; i < mSize ; i ++) {
             if (mTileIndices[i] == pTileIndex) {
                 return true;
@@ -92,7 +86,9 @@ public class MapTileList {
      */
     public long[] toArray() {
         final long[] result = new long[mSize];
-        System.arraycopy(mTileIndices, 0, result, 0, mSize);
+        if (mTileIndices != null) {
+            System.arraycopy(mTileIndices, 0, result, 0, mSize);
+        }
         return result;
     }
 }

--- a/osmdroid-android/src/test/java/org/osmdroid/util/MapTileListTest.java
+++ b/osmdroid-android/src/test/java/org/osmdroid/util/MapTileListTest.java
@@ -101,4 +101,15 @@ public class MapTileListTest {
             }
         }
     }
+
+    /**
+     * @since 6.0.2
+     */
+    @Test
+    public void testEmpty() {
+        final MapTileList list = new MapTileList();
+        Assert.assertEquals(0, list.getSize());
+        // we don't care about 1234 but about a possible side-effect NPE
+        Assert.assertFalse(list.contains(1234));
+    }
 }


### PR DESCRIPTION
Impacted classes:
* `MapTileCache`: in method `clear()` we don't try anymore to get the `mCachedTiles` map size outside of a `synchronized` block
* `MapTileList`: removed both constructors (we only use the default constructor now); handled the `mTileIndices == null` init case in all methods
* `MapTileListTest`: created method `testEmpty` about empty list side-effect