### PR TITLE
New method in order to clear tile delays

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderArray.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderArray.java
@@ -325,6 +325,15 @@ public class MapTileProviderArray extends MapTileProviderBase {
 	/**
 	 * @since 6.0.2
 	 */
+	public void clearDelays() {
+		synchronized (mTileDelays) {
+			mTileDelays.clear();
+		}
+	}
+
+	/**
+	 * @since 6.0.2
+	 */
 	public void setExponentialBackoffDurationInMillis(final long[] pExponentialBackoffDurationInMillis) {
 		mExponentialBackoffDurationInMillis = pExponentialBackoffDurationInMillis;
 	}


### PR DESCRIPTION
To be called when something relevant happened (e.g. internet connectivity back on) in order to discard the previous delays and download without delay!

Impacted class:
* `MapTileProviderArray`: created method `MapTileProviderArray.clearDelays`