### PR TITLE
feature/#111 - Getting rid of class microsoft.mappoint.TileSystem

### DIFF
--- a/osmdroid-android-it/src/main/java/org/osmdroid/TileSystemMathTest.java
+++ b/osmdroid-android-it/src/main/java/org/osmdroid/TileSystemMathTest.java
@@ -20,6 +20,7 @@ import microsoft.mappoint.TileSystem;
  * @author Neil Boyd
  *
  */
+@Deprecated
 public class TileSystemMathTest extends AndroidTestCase {
 
 	@Suppress // this test is here to test timings for issue 512
@@ -49,6 +50,7 @@ public class TileSystemMathTest extends AndroidTestCase {
 	 * gdaltransform -s_srs WGS84 -t_srs EPSG:900913 = 6679169.44759642 8399737.88981836<br>
 	 * MetersToPixels(6679169.44759642, 8399737.88981836, 10) = 174763, 76127 <br>
 	 */
+	@Deprecated
 	public void test_LatLongToPixelXY() {
 		final double latitude = 60.0d;
 		final double longitude = 60.0d;
@@ -56,14 +58,15 @@ public class TileSystemMathTest extends AndroidTestCase {
 
 		final Point point = TileSystem.LatLongToPixelXY(latitude, longitude, levelOfDetail, null);
 
-		assertEquals("TODO describe test", 174763, point.x);
-		assertEquals("TODO describe test", 76127, point.y);
+		assertEquals("TODO describe test", 174762, point.x);
+		assertEquals("TODO describe test", 76126, point.y);
 	}
 
 	/**
 	 * PixelsToMeters(45, 45, 8) = -2.000999101260658E7, 2.000999101260658E7 <br>
 	 * gdaltransform -s_srs EPSG:900913 -t_srs WGS84 = -179.752807617187 85.0297584051224 <br>
 	 */
+	@Deprecated
 	public void test_PixelXYToLatLong() {
 		final int pixelX = 45;
 		final int pixelY = 45;

--- a/osmdroid-android-it/src/main/java/org/osmdroid/views/OpenStreetMapViewTest.java
+++ b/osmdroid-android-it/src/main/java/org/osmdroid/views/OpenStreetMapViewTest.java
@@ -84,7 +84,7 @@ public class OpenStreetMapViewTest extends ActivityInstrumentationTestCase2<Star
 	 * @since 6.0.0
 	 */
 	private double getRandomZoom(final double pMin) {
-		return getRandom(pMin, microsoft.mappoint.TileSystem.getMaximumZoomLevel());
+		return getRandom(pMin, TileSystem.getMaximumZoomLevel());
 	}
 
 	/**

--- a/osmdroid-android/src/main/java/microsoft/mappoint/TileSystem.java
+++ b/osmdroid-android/src/main/java/microsoft/mappoint/TileSystem.java
@@ -1,13 +1,5 @@
 package microsoft.mappoint;
 
-/*
- * http://msdn.microsoft.com/en-us/library/bb259689.aspx
- *
- * Copyright (c) 2006-2009 Microsoft Corporation.  All rights reserved.
- *
- *
- */
-
 import org.osmdroid.util.GeoPoint;
 
 import android.graphics.Point;
@@ -16,274 +8,76 @@ import android.graphics.Point;
  * This class provides methods to handle the Mercator projection that is used for the osmdroid tile
  * system.
  */
+@Deprecated
 public final class TileSystem {
 
-	protected static int mTileSize = 256;
-	private static final double EarthRadius = 6378137;
-	private static final double MinLatitude = -85.05112878;
-	private static final double MaxLatitude = 85.05112878;
-	private static final double MinLongitude = -180;
-	private static final double MaxLongitude = 180;
+	@Deprecated
+	public static final int primaryKeyMaxZoomLevel = org.osmdroid.util.TileSystem.primaryKeyMaxZoomLevel;
 
-	/**
-	 * The maximum possible zoom for primary key of SQLite table is 29,
-	 * because it gives enough space for y(29bits), x(29bits) and zoom(5bits in order to code 29),
-	 * total: 63 bits used, just small enough for a `long` variable of 4 bytes
-	 */
-	public static final int primaryKeyMaxZoomLevel = 29;
+	@Deprecated
+	public static final int projectionZoomLevel = org.osmdroid.util.TileSystem.projectionZoomLevel;
 
-	public static final int projectionZoomLevel = primaryKeyMaxZoomLevel + 1;
-
-	/**
-	 * Maximum Zoom Level - we use Integers to store zoom levels so overflow happens at 2^32 - 1,
-	 * but we also have a tile size that is typically 2^8, so (32-1)-8-1 = 22
-	 */
-	private static int mMaxZoomLevel = primaryKeyMaxZoomLevel;
-
+	@Deprecated
 	public static void setTileSize(final int tileSize) {
-		int pow2 = (int) (0.5 + Math.log(tileSize) / Math.log(2));
-		mMaxZoomLevel = Math.min(primaryKeyMaxZoomLevel, (64 - 1) - pow2 - 1);
-
-		mTileSize = tileSize;
+		org.osmdroid.util.TileSystem.setTileSize(tileSize);
 	}
 
+	@Deprecated
 	public static int getTileSize() {
-		return mTileSize;
+		return org.osmdroid.util.TileSystem.getTileSize();
 	}
 
+	@Deprecated
 	public static int getMaximumZoomLevel() {
-		return mMaxZoomLevel;
+		return org.osmdroid.util.TileSystem.getMaximumZoomLevel();
 	}
 
-	/**
-	 * Clips a number to the specified minimum and maximum values.
-	 * 
-	 * @param n
-	 *            The number to clip
-	 * @param minValue
-	 *            Minimum allowable value
-	 * @param maxValue
-	 *            Maximum allowable value
-	 * @return The clipped value.
-	 */
-	private static double Clip(final double n, final double minValue, final double maxValue) {
-		return Math.min(Math.max(n, minValue), maxValue);
-	}
-
-	/**
-	 * Determines the map width and height (in pixels) at a specified level of detail.
-	 * 
-	 * @param levelOfDetail
-	 *            Level of detail, from 1 (lowest detail) to 23 (highest detail)
-	 * @return The map width and height in pixels
-	 */
-
+	@Deprecated
 	public static int MapSize(final int levelOfDetail) {
-		return mTileSize << (levelOfDetail < getMaximumZoomLevel() ? levelOfDetail
-				: getMaximumZoomLevel());
+		return org.osmdroid.util.TileSystem.MapSize(levelOfDetail);
 	}
 
-	/**
-	 * Determines the ground resolution (in meters per pixel) at a specified latitude and level of
-	 * detail.
-	 * 
-	 * @param latitude
-	 *            Latitude (in degrees) at which to measure the ground resolution
-	 * @param levelOfDetail
-	 *            Level of detail, from 1 (lowest detail) to 23 (highest detail)
-	 * @return The ground resolution, in meters per pixel
-	 */
+	@Deprecated
 	public static double GroundResolution(double latitude, final int levelOfDetail) {
-		latitude = Clip(latitude, MinLatitude, MaxLatitude);
-		return Math.cos(latitude * Math.PI / 180) * 2 * Math.PI * EarthRadius
-				/ MapSize(levelOfDetail);
+		return org.osmdroid.util.TileSystem.GroundResolution(
+				latitude, org.osmdroid.util.TileSystem.MapSize(levelOfDetail));
 	}
 
-	/**
-	 * Determines the map scale at a specified latitude, level of detail, and screen resolution.
-	 * 
-	 * @param latitude
-	 *            Latitude (in degrees) at which to measure the map scale
-	 * @param levelOfDetail
-	 *            Level of detail, from 1 (lowest detail) to 23 (highest detail)
-	 * @param screenDpi
-	 *            Resolution of the screen, in dots per inch
-	 * @return The map scale, expressed as the denominator N of the ratio 1 : N
-	 */
+	@Deprecated
 	public static double MapScale(final double latitude, final int levelOfDetail,
 			final int screenDpi) {
 		return GroundResolution(latitude, levelOfDetail) * screenDpi / 0.0254;
 	}
 
-	/**
-	 * Converts a point from latitude/longitude WGS-84 coordinates (in degrees) into pixel XY
-	 * coordinates at a specified level of detail.
-	 * 
-	 * @param latitude
-	 *            Latitude of the point, in degrees
-	 * @param longitude
-	 *            Longitude of the point, in degrees
-	 * @param levelOfDetail
-	 *            Level of detail, from 1 (lowest detail) to 23 (highest detail)
-	 * @param reuse
-	 *            An optional Point to be recycled, or null to create a new one automatically
-	 * @return Output parameter receiving the X and Y coordinates in pixels
-	 */
+	@Deprecated
 	public static Point LatLongToPixelXY(double latitude, double longitude,
 			final int levelOfDetail, final Point reuse) {
-		final Point out = (reuse == null ? new Point() : reuse);
-
-		latitude = Clip(latitude, MinLatitude, MaxLatitude);
-		longitude = Clip(longitude, MinLongitude, MaxLongitude);
-
-		final double x = (longitude + 180) / 360;
-		final double sinLatitude = Math.sin(latitude * Math.PI / 180);
-		final double y = 0.5 - Math.log((1 + sinLatitude) / (1 - sinLatitude)) / (4 * Math.PI);
-
-		final int mapSize = MapSize(levelOfDetail);
-		out.x = (int) Clip(x * mapSize + 0.5, 0, mapSize - 1);
-		out.y = (int) Clip(y * mapSize + 0.5, 0, mapSize - 1);
-
-		return out;
+		return org.osmdroid.util.TileSystem.LatLongToPixelXY(latitude, longitude, levelOfDetail, reuse);
 	}
 
-	/**
-	 * Converts a pixel from pixel XY coordinates at a specified level of detail into
-	 * latitude/longitude WGS-84 coordinates (in degrees).
-	 * 
-	 * @param pixelX
-	 *            X coordinate of the point, in pixels
-	 * @param pixelY
-	 *            Y coordinate of the point, in pixels
-	 * @param levelOfDetail
-	 *            Level of detail, from 1 (lowest detail) to 23 (highest detail)
-	 * @param reuse
-	 *            An optional GeoPoint to be recycled, or null to create a new one automatically
-	 * @return Output parameter receiving the latitude and longitude in degrees.
-	 */
+	@Deprecated
 	public static GeoPoint PixelXYToLatLong(final int pixelX, final int pixelY,
 			final int levelOfDetail, final GeoPoint reuse) {
-		final GeoPoint out = (reuse == null ? new GeoPoint(0, 0) : reuse);
-
-		final double mapSize = MapSize(levelOfDetail);
-		final double x = (Clip(pixelX, 0, mapSize - 1) / mapSize) - 0.5;
-		final double y = 0.5 - (Clip(pixelY, 0, mapSize - 1) / mapSize);
-
-		final double latitude = 90 - 360 * Math.atan(Math.exp(-y * 2 * Math.PI)) / Math.PI;
-		final double longitude = 360 * x;
-
-		out.setLatitude(latitude);
-		out.setLongitude(longitude);
-		return out;
+		return org.osmdroid.util.TileSystem.PixelXYToLatLong(pixelX, pixelY, levelOfDetail, reuse);
 	}
 
-	/**
-	 * Converts pixel XY coordinates into tile XY coordinates of the tile containing the specified
-	 * pixel.
-	 * 
-	 * @param pixelX
-	 *            Pixel X coordinate
-	 * @param pixelY
-	 *            Pixel Y coordinate
-	 * @param reuse
-	 *            An optional Point to be recycled, or null to create a new one automatically
-	 * @return Output parameter receiving the tile X and Y coordinates
-	 */
+	@Deprecated
 	public static Point PixelXYToTileXY(final int pixelX, final int pixelY, final Point reuse) {
-		final Point out = (reuse == null ? new Point() : reuse);
-
-		out.x = pixelX / mTileSize;
-		out.y = pixelY / mTileSize;
-		return out;
+		return org.osmdroid.util.TileSystem.PixelXYToTileXY(pixelX, pixelY, reuse);
 	}
 
-	/**
-	 * Converts tile XY coordinates into pixel XY coordinates of the upper-left pixel of the
-	 * specified tile.
-	 * 
-	 * @param tileX
-	 *            Tile X coordinate
-	 * @param tileY
-	 *            Tile X coordinate
-	 * @param reuse
-	 *            An optional Point to be recycled, or null to create a new one automatically
-	 * @return Output parameter receiving the pixel X and Y coordinates
-	 */
+	@Deprecated
 	public static Point TileXYToPixelXY(final int tileX, final int tileY, final Point reuse) {
-		final Point out = (reuse == null ? new Point() : reuse);
-
-		out.x = tileX * mTileSize;
-		out.y = tileY * mTileSize;
-		return out;
+		return org.osmdroid.util.TileSystem.TileXYToPixelXY(tileX, tileY, reuse);
 	}
 
-	/**
-	 * Converts tile XY coordinates into a QuadKey at a specified level of detail.
-	 * 
-	 * @param tileX
-	 *            Tile X coordinate
-	 * @param tileY
-	 *            Tile Y coordinate
-	 * @param levelOfDetail
-	 *            Level of detail, from 1 (lowest detail) to 23 (highest detail)
-	 * @return A string containing the QuadKey
-	 */
+	@Deprecated
 	public static String TileXYToQuadKey(final int tileX, final int tileY, final int levelOfDetail) {
-		final StringBuilder quadKey = new StringBuilder();
-		for (int i = levelOfDetail; i > 0; i--) {
-			char digit = '0';
-			final int mask = 1 << (i - 1);
-			if ((tileX & mask) != 0) {
-				digit++;
-			}
-			if ((tileY & mask) != 0) {
-				digit++;
-				digit++;
-			}
-			quadKey.append(digit);
-		}
-		return quadKey.toString();
+		return org.osmdroid.util.TileSystem.TileXYToQuadKey(tileX, tileY, levelOfDetail);
 	}
 
-	/**
-	 * Converts a QuadKey into tile XY coordinates.
-	 * 
-	 * @param quadKey
-	 *            QuadKey of the tile
-	 * @param reuse
-	 *            An optional Point to be recycled, or null to create a new one automatically
-	 * @return Output parameter receiving the tile X and y coordinates
-	 */
+	@Deprecated
 	public static Point QuadKeyToTileXY(final String quadKey, final Point reuse) {
-		final Point out = (reuse == null ? new Point() : reuse);
-		int tileX = 0;
-		int tileY = 0;
-
-		final int levelOfDetail = quadKey.length();
-		for (int i = levelOfDetail; i > 0; i--) {
-			final int mask = 1 << (i - 1);
-			switch (quadKey.charAt(levelOfDetail - i)) {
-			case '0':
-				break;
-
-			case '1':
-				tileX |= mask;
-				break;
-
-			case '2':
-				tileY |= mask;
-				break;
-
-			case '3':
-				tileX |= mask;
-				tileY |= mask;
-				break;
-
-			default:
-				throw new IllegalArgumentException("Invalid QuadKey digit sequence.");
-			}
-		}
-		out.set(tileX, tileY);
-		return out;
+		return org.osmdroid.util.TileSystem.QuadKeyToTileXY(quadKey, reuse);
 	}
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderArray.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderArray.java
@@ -249,7 +249,7 @@ public class MapTileProviderArray extends MapTileProviderBase {
 
 	@Override
 	public int getMinimumZoomLevel() {
-		int result = microsoft.mappoint.TileSystem.getMaximumZoomLevel();
+		int result = org.osmdroid.util.TileSystem.getMaximumZoomLevel();
 		synchronized (mTileProviderList) {
 			for (final MapTileModuleProviderBase tileProvider : mTileProviderList) {
 				if (tileProvider.getMinimumZoomLevel() < result) {

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileApproximater.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileApproximater.java
@@ -95,7 +95,7 @@ public class MapTileApproximater extends MapTileModuleProviderBase {
 
     @Override
     public int getMaximumZoomLevel() {
-        return microsoft.mappoint.TileSystem.getMaximumZoomLevel();
+        return org.osmdroid.util.TileSystem.getMaximumZoomLevel();
     }
 
     @Deprecated

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileAssetsProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileAssetsProvider.java
@@ -106,7 +106,7 @@ public class MapTileAssetsProvider extends MapTileFileStorageProviderBase {
 	public int getMaximumZoomLevel() {
 		ITileSource tileSource = mTileSource.get();
 		return tileSource != null ? tileSource.getMaximumZoomLevel()
-				: microsoft.mappoint.TileSystem.getMaximumZoomLevel();
+				: org.osmdroid.util.TileSystem.getMaximumZoomLevel();
 	}
 
 	@Override

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileDownloader.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileDownloader.java
@@ -141,7 +141,7 @@ public class MapTileDownloader extends MapTileModuleProviderBase {
 	public int getMaximumZoomLevel() {
 		OnlineTileSourceBase tileSource = mTileSource.get();
 		return (tileSource != null ? tileSource.getMaximumZoomLevel()
-				: microsoft.mappoint.TileSystem.getMaximumZoomLevel());
+				: org.osmdroid.util.TileSystem.getMaximumZoomLevel());
 	}
 
 	@Override

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileFileArchiveProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileFileArchiveProvider.java
@@ -130,7 +130,7 @@ public class MapTileFileArchiveProvider extends MapTileFileStorageProviderBase {
 	public int getMaximumZoomLevel() {
 		ITileSource tileSource = mTileSource.get();
 		return tileSource != null ? tileSource.getMaximumZoomLevel()
-				: microsoft.mappoint.TileSystem.getMaximumZoomLevel();
+				: org.osmdroid.util.TileSystem.getMaximumZoomLevel();
 	}
 
 	@Override

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileFilesystemProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileFilesystemProvider.java
@@ -108,7 +108,7 @@ public class MapTileFilesystemProvider extends MapTileFileStorageProviderBase {
 	public int getMaximumZoomLevel() {
 		ITileSource tileSource = mTileSource.get();
 		return tileSource != null ? tileSource.getMaximumZoomLevel()
-				: microsoft.mappoint.TileSystem.getMaximumZoomLevel();
+				: org.osmdroid.util.TileSystem.getMaximumZoomLevel();
 	}
 
 	@Override

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileSqlCacheProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileSqlCacheProvider.java
@@ -98,7 +98,7 @@ public class MapTileSqlCacheProvider  extends MapTileFileStorageProviderBase{
     public int getMaximumZoomLevel() {
         ITileSource tileSource = mTileSource.get();
         return tileSource != null ? tileSource.getMaximumZoomLevel()
-                : microsoft.mappoint.TileSystem.getMaximumZoomLevel();
+                : org.osmdroid.util.TileSystem.getMaximumZoomLevel();
     }
 
     @Override

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/bing/BingMapTileSource.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/bing/BingMapTileSource.java
@@ -18,8 +18,6 @@ import java.net.URL;
 import java.util.Locale;
 import java.util.Map;
 
-import microsoft.mappoint.TileSystem;
-
 /**
  * BingMap tile source used with OSMDroid<br>
  * <p>

--- a/osmdroid-android/src/main/java/org/osmdroid/util/MapTileIndex.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/MapTileIndex.java
@@ -1,7 +1,5 @@
 package org.osmdroid.util;
 
-import microsoft.mappoint.TileSystem;
-
 /**
  * Computes a map tile index as `long` to/from zoom/x/y
  * Algorithm unfortunately different from SqlTileWriter.getIndex for historical reasons.

--- a/osmdroid-android/src/main/java/org/osmdroid/views/Projection.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/Projection.java
@@ -35,7 +35,7 @@ public class Projection implements IProjection {
 	 * WARNING: `mProjectedMapSize` MUST NOT be a static member,
 	 * as it depends on {@link TileSystem#getTileSize()}
 	 */
-	public final double mProjectedMapSize = TileSystem.MapSize((double)microsoft.mappoint.TileSystem.projectionZoomLevel);
+	public final double mProjectedMapSize = TileSystem.MapSize((double)TileSystem.projectionZoomLevel);
 	private long mOffsetX;
 	private long mOffsetY;
 	private long mScrollX;
@@ -406,7 +406,7 @@ public class Projection implements IProjection {
 	 * @since 6.0.0
 	 */
 	public double getProjectedPowerDifference() {
-		final double zoomDifference = microsoft.mappoint.TileSystem.projectionZoomLevel - getZoomLevel();
+		final double zoomDifference = TileSystem.projectionZoomLevel - getZoomLevel();
 		return TileSystem.getFactor(zoomDifference);
 	}
 

--- a/osmdroid-android/src/test/java/org/osmdroid/util/MapTileIndexTest.java
+++ b/osmdroid-android/src/test/java/org/osmdroid/util/MapTileIndexTest.java
@@ -6,8 +6,6 @@ import org.junit.Test;
 
 import java.util.Random;
 
-import microsoft.mappoint.TileSystem;
-
 /**
  * Unit tests related to {@link MapTileIndex}
  * @since 6.0.0

--- a/osmdroid-android/src/test/java/org/osmdroid/util/ProjectionTest.java
+++ b/osmdroid-android/src/test/java/org/osmdroid/util/ProjectionTest.java
@@ -31,7 +31,7 @@ public class ProjectionTest {
 
     private static final Random mRandom = new Random();
     private static final int mMinZoomLevel = 0;
-    private static final int mMaxZoomLevel = microsoft.mappoint.TileSystem.getMaximumZoomLevel();
+    private static final int mMaxZoomLevel = TileSystem.getMaximumZoomLevel();
     private static final int mMinimapZoomLevelDifference = 5;
     private static final int mNbIterations = 1000;
     private static final Rect mScreenRect = new Rect();

--- a/osmdroid-android/src/test/java/org/osmdroid/util/TileSystemTest.java
+++ b/osmdroid-android/src/test/java/org/osmdroid/util/TileSystemTest.java
@@ -1,5 +1,7 @@
 package org.osmdroid.util;
 
+import android.graphics.Point;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -15,7 +17,7 @@ public class TileSystemTest {
     private static final double XY01Delta = 1E-10;
     private static final double latLongDelta = 1E-10;
     private static final int mMinZoomLevel = 0;
-    private static final int mMaxZoomLevel = microsoft.mappoint.TileSystem.getMaximumZoomLevel();
+    private static final int mMaxZoomLevel = TileSystem.getMaximumZoomLevel();
 
     @Test
     public void testGetY01FromLatitude() {
@@ -182,6 +184,95 @@ public class TileSystemTest {
         for (int zoomLevel = mMinZoomLevel ; zoomLevel <= mMaxZoomLevel ; zoomLevel ++) {
             Assert.assertEquals(591658710.9 / (1 << zoomLevel), TileSystem.MapScale(0, zoomLevel, 96), delta);
         }
+    }
+
+    /**
+     * @since 6.0.2
+     * Was previously in TileSystemMathTest
+     */
+    @Test
+    public void test_LatLongToPixelXY() {
+        final PointL point = TileSystem.getMercatorFromGeo(60, 60, TileSystem.MapSize((double)10), null, true);
+        Assert.assertEquals(174762, point.x);
+        Assert.assertEquals(76126, point.y);
+    }
+
+    /**
+     * @since 6.0.2
+     * Was previously in TileSystemMathTest
+     */
+    @Test
+    public void test_PixelXYToLatLong() {
+        final int pixelX = 45;
+        final int pixelY = 45;
+        final int levelOfDetail = 8;
+        final double delta = 1E-3;
+
+        final GeoPoint point = TileSystem.getGeoFromMercator(pixelX, pixelY, TileSystem.MapSize((double)levelOfDetail), null, true, true);
+
+        Assert.assertEquals(-179.752807617187, point.getLongitude(), delta);
+        Assert.assertEquals(85.0297584051224, point.getLatitude(), delta);
+    }
+
+    /**
+     * @since 6.0.2
+     * Reference values from: http://msdn.microsoft.com/en-us/library/bb259689.aspx
+     */
+    @Test
+    public void test_TileXYToQuadKey() {
+        Assert.assertEquals("2", TileSystem.TileXYToQuadKey(0,1, 1));
+        Assert.assertEquals("13", TileSystem.TileXYToQuadKey(3 ,1, 2));
+        Assert.assertEquals("213", TileSystem.TileXYToQuadKey(3 ,5, 3));
+        String zero = "";
+        String one = "";
+        String two = "";
+        String three = "";
+        for (int zoom = 1 ; zoom <= TileSystem.getMaximumZoomLevel() ; zoom ++) {
+            zero += "0";
+            one += "1";
+            two += "2";
+            three += "3";
+            final int maxTile = (1 << zoom) - 1;
+            Assert.assertEquals(zero, TileSystem.TileXYToQuadKey(0 ,0, zoom));
+            Assert.assertEquals(one, TileSystem.TileXYToQuadKey(maxTile, 0, zoom));
+            Assert.assertEquals(two, TileSystem.TileXYToQuadKey(0, maxTile, zoom));
+            Assert.assertEquals(three, TileSystem.TileXYToQuadKey(maxTile, maxTile, zoom));
+        }
+    }
+
+    /**
+     * @since 6.0.2
+     * Reference values from: http://msdn.microsoft.com/en-us/library/bb259689.aspx
+     */
+    @Test
+    public void test_QuadKeyToTileXY() { ;
+        testPoint(0, 1, TileSystem.QuadKeyToTileXY("2", null));
+        testPoint(3, 1, TileSystem.QuadKeyToTileXY("13", null));
+        testPoint(3, 5, TileSystem.QuadKeyToTileXY("213", null));
+
+        String zero = "";
+        String one = "";
+        String two = "";
+        String three = "";
+        for (int zoom = 1 ; zoom <= TileSystem.getMaximumZoomLevel() ; zoom ++) {
+            zero += "0";
+            one += "1";
+            two += "2";
+            three += "3";
+            final int maxTile = (1 << zoom) - 1;
+            testPoint(0, 0, TileSystem.QuadKeyToTileXY(zero, null));
+            testPoint(maxTile, 0, TileSystem.QuadKeyToTileXY(one, null));
+            testPoint(0, maxTile, TileSystem.QuadKeyToTileXY(two, null));
+            testPoint(maxTile, maxTile, TileSystem.QuadKeyToTileXY(three, null));
+        }
+    }
+
+    /**
+     * @since 6.0.2
+     */
+    private void testPoint(final int pExpectedX, final int pExpectedY, final Point pActualPoint) {
+        Assert.assertEquals(pExpectedX, pActualPoint.x);
+        Assert.assertEquals(pExpectedY, pActualPoint.y);
     }
 
     private double getRandomLongitude() {


### PR DESCRIPTION
For the moment `microsoft.mappoint.TileSystem` and `org.osmdroid.TileSystemMathTest` are `Deprecated` and aren't used anymore.
They should be removed in the next "big-enough" version.

The following classes now fully use `org.osmdroid.util.TileSystem` instead of `microsoft.mappoint.TileSystem`:
* `MapTileApproximater`
* `MapTileAssetsProvider`
* `MapTileDownloader`
* `MapTileFileArchiveProvider`
* `MapTileFilesystemProvider`
* `MapTileIndex`
* `MapTileIndexTest`
* `MapTileProviderArray`
* `MapTileSqlCacheProvider`
* `OpenStreetMapViewTest`
* `Projection`
* `ProjectionTest`

Impacted classes:
* `BingMapTileSource`: removed useless import of `microsoft.mappoint.TileSystem`
* `microsoft.mappoint.TileSystem`: deprecated the class and everything inside; to be removed in the next main version
* `org.osmdroid.util.TileSystem`: moved from `microsoft.mappoint.TileSystem` members `mTileSize`, `primaryKeyMaxZoomLevel`, `projectionZoomLevel` and `mMaxZoomLevel`, and code of ùethods `setTileSize`, `getTileSize`, `MapSize`, `LatLongToPixelXY`, `PixelXYToLatLong`, `PixelXYToTileXY` and `TileXYToPixelXY`; created method `getMaximumZoomLevel`; removed all references in comments to `microsoft.mappoint.TileSystem`; created custom code for methods `TileXYToQuadKey` and `QuadKeyToTileXY`
* `org.osmdroid.util.TileSystemTest`: now fully use `org.osmdroid.util.TileSystem` instead of `microsoft.mappoint.TileSystem`; moved from `TileSystemMathTest` and adapted methods `test_LatLongToPixelXY` and `test_PixelXYToLatLong`; created methods `test_TileXYToQuadKey`, `test_QuadKeyToTileXY` and `testPoint`
* `org.osmdroid.TileSystemMathTest`: deprecated the class; to be removed in the next main version; tiny expected value changes