### PR TITLE
New projection systems: class TileSystem is now abstract and can be extended

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/bookmarks/BookmarkSample.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/bookmarks/BookmarkSample.java
@@ -89,9 +89,9 @@ public class BookmarkSample extends BaseSampleFragment {
                             valid = false;
                         }
 
-                        if (latD > mMapView.getTileSystem().getMaxLatitude() || latD < mMapView.getTileSystem().getMinLatitude())
+                        if (!mMapView.getTileSystem().isValidLatitude(latD))
                             valid = false;
-                        if (lonD > mMapView.getTileSystem().getMaxLongitude() || lonD < mMapView.getTileSystem().getMinLongitude())
+                        if (!mMapView.getTileSystem().isValidLongitude(lonD))
                             valid = false;
 
                         if (valid) {

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/bookmarks/BookmarkSample.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/bookmarks/BookmarkSample.java
@@ -9,7 +9,6 @@ import org.osmdroid.R;
 import org.osmdroid.events.MapEventsReceiver;
 import org.osmdroid.samplefragments.BaseSampleFragment;
 import org.osmdroid.util.GeoPoint;
-import org.osmdroid.util.TileSystem;
 import org.osmdroid.views.overlay.MapEventsOverlay;
 import org.osmdroid.views.overlay.Marker;
 
@@ -90,9 +89,9 @@ public class BookmarkSample extends BaseSampleFragment {
                             valid = false;
                         }
 
-                        if (latD > TileSystem.MaxLatitude || latD < TileSystem.MinLatitude)
+                        if (latD > mMapView.getTileSystem().getMaxLatitude() || latD < mMapView.getTileSystem().getMinLatitude())
                             valid = false;
-                        if (lonD > TileSystem.MaxLongitude || lonD < TileSystem.MinLongitude)
+                        if (lonD > mMapView.getTileSystem().getMaxLongitude() || lonD < mMapView.getTileSystem().getMinLongitude())
                             valid = false;
 
                         if (valid) {

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/drawing/IconPlottingOverlay.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/drawing/IconPlottingOverlay.java
@@ -5,7 +5,6 @@ import android.graphics.drawable.Drawable;
 import android.view.MotionEvent;
 
 import org.osmdroid.util.GeoPoint;
-import org.osmdroid.util.TileSystem;
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.overlay.Marker;
 import org.osmdroid.views.overlay.Overlay;
@@ -54,10 +53,10 @@ public class IconPlottingOverlay extends Overlay {
             if (pt.getLongitude() > 180)
                 pt.setLongitude(pt.getLongitude()-360);
             //latitude is a bit harder. see https://en.wikipedia.org/wiki/Mercator_projection
-            if (pt.getLatitude() > TileSystem.MaxLatitude)
-                pt.setLatitude(TileSystem.MaxLatitude);
-            if (pt.getLatitude() < TileSystem.MinLatitude)
-                pt.setLatitude(TileSystem.MinLatitude);
+            if (pt.getLatitude() > mapView.getTileSystem().getMaxLatitude())
+                pt.setLatitude(mapView.getTileSystem().getMaxLatitude());
+            if (pt.getLatitude() < mapView.getTileSystem().getMinLatitude())
+                pt.setLatitude(mapView.getTileSystem().getMinLatitude());
 
             Marker m = new Marker(mapView);
             m.setPosition(pt);

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/events/SampleAnimateTo.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/events/SampleAnimateTo.java
@@ -129,7 +129,7 @@ public class SampleAnimateTo extends BaseSampleFragment {
         final BoundingBox box = state.getBox();
         final double lat = box.getCenterLatitude();
         final double lon = box.getCenterLongitude();
-        final double zoom = TileSystem.getBoundingBoxZoom(box,
+        final double zoom = mMapView.getTileSystem().getBoundingBoxZoom(box,
                 mMapView.getWidth() - 2 * borderSizeInPixels, mMapView.getHeight() - 2 * borderSizeInPixels);
         ((MapController)mMapView.getController()).animateTo(new GeoPoint(lat, lon), zoom, 2000L);
         Toast.makeText(getActivity(), state.getName(), Toast.LENGTH_SHORT).show();

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/events/SampleZoomToBounding.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/events/SampleZoomToBounding.java
@@ -73,7 +73,7 @@ public class SampleZoomToBounding extends BaseSampleFragment implements View.OnC
                         Toast.makeText(getActivity(), text, Toast.LENGTH_LONG).show();
                         final List<GeoPoint> points = new ArrayList<>();
                         if (west > east) {
-                            east += 2 * tileSystem.getMaxLongitude();
+                            east += 360;
                         }
                         addPoints(points, north, west, north, east);
                         addPoints(points, north, east, south, east);

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/events/SampleZoomToBounding.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/events/SampleZoomToBounding.java
@@ -10,10 +10,10 @@ import android.widget.Toast;
 
 import org.osmdroid.R;
 import org.osmdroid.samplefragments.BaseSampleFragment;
-import org.osmdroid.tileprovider.cachemanager.CacheManager;
 import org.osmdroid.util.BoundingBox;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.util.TileSystem;
+import org.osmdroid.util.TileSystemWebMercator;
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.overlay.Polygon;
 
@@ -26,6 +26,7 @@ import java.util.List;
 public class SampleZoomToBounding extends BaseSampleFragment implements View.OnClickListener {
 
     private static final int border = 10;
+    private static final TileSystem tileSystem = new TileSystemWebMercator();
 
     private Polygon polygon;
     Button btnCache;
@@ -60,19 +61,19 @@ public class SampleZoomToBounding extends BaseSampleFragment implements View.OnC
             case R.id.btnCache:
                 boolean ok = false;
                 while (!ok) {
-                    final double south = getRandomLatitude(TileSystem.MinLatitude);
+                    final double south = getRandomLatitude(mMapView.getTileSystem().getMinLatitude());
                     final double north = getRandomLatitude(south);
                     final double west = getRandomLongitude();
                     double east = getRandomLongitude();
                     final BoundingBox boundingBox = new BoundingBox(north, east, south, west);
-                    final double zoom = TileSystem.getBoundingBoxZoom(boundingBox, mMapView.getWidth() - 2 * border, mMapView.getHeight() - 2 * border);
+                    final double zoom = mMapView.getTileSystem().getBoundingBoxZoom(boundingBox, mMapView.getWidth() - 2 * border, mMapView.getHeight() - 2 * border);
                     ok = zoom >= mMapView.getMinZoomLevel() && zoom <= mMapView.getMaxZoomLevel();
                     if (ok) {
                         final String text = "with a border of " + border + " the computed zoom is " + zoom + " for box " + boundingBox;
                         Toast.makeText(getActivity(), text, Toast.LENGTH_LONG).show();
                         final List<GeoPoint> points = new ArrayList<>();
                         if (west > east) {
-                            east += 2 * TileSystem.MaxLongitude;
+                            east += 2 * tileSystem.getMaxLongitude();
                         }
                         addPoints(points, north, west, north, east);
                         addPoints(points, north, east, south, east);
@@ -133,10 +134,10 @@ public class SampleZoomToBounding extends BaseSampleFragment implements View.OnC
     }
 
     private double getRandomLongitude() {
-        return Math.random() * (TileSystem.MaxLongitude - TileSystem.MinLongitude) + TileSystem.MinLongitude;
+        return tileSystem.getRandomLongitude(Math.random());
     }
 
     private double getRandomLatitude(final double pMinLatitude) {
-        return Math.random() * (TileSystem.MaxLatitude - pMinLatitude) + pMinLatitude;
+        return tileSystem.getRandomLatitude(Math.random(), pMinLatitude);
     }
 }

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/events/SampleZoomToBounding.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/events/SampleZoomToBounding.java
@@ -13,7 +13,6 @@ import org.osmdroid.samplefragments.BaseSampleFragment;
 import org.osmdroid.util.BoundingBox;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.util.TileSystem;
-import org.osmdroid.util.TileSystemWebMercator;
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.overlay.Polygon;
 
@@ -26,7 +25,7 @@ import java.util.List;
 public class SampleZoomToBounding extends BaseSampleFragment implements View.OnClickListener {
 
     private static final int border = 10;
-    private static final TileSystem tileSystem = new TileSystemWebMercator();
+    private final TileSystem tileSystem = MapView.getTileSystem();
 
     private Polygon polygon;
     Button btnCache;

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/milstd2525/MilStdPointPlottingOverlay.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/milstd2525/MilStdPointPlottingOverlay.java
@@ -54,10 +54,10 @@ public class MilStdPointPlottingOverlay extends Overlay {
             if (pt.getLongitude() > 180)
                 pt.setLongitude(pt.getLongitude() - 360);
             //latitude is a bit harder. see https://en.wikipedia.org/wiki/Mercator_projection
-            if (pt.getLatitude() > TileSystem.MaxLatitude)
-                pt.setLatitude(TileSystem.MaxLatitude);
-            if (pt.getLatitude() < TileSystem.MinLatitude)
-                pt.setLatitude(TileSystem.MinLatitude);
+            if (pt.getLatitude() > mapView.getTileSystem().getMaxLatitude())
+                pt.setLatitude(mapView.getTileSystem().getMaxLatitude());
+            if (pt.getLatitude() < mapView.getTileSystem().getMinLatitude())
+                pt.setLatitude(mapView.getTileSystem().getMinLatitude());
 
             String code = def.getSymbolCode().replace("*", "-");
             //TODO if (!def.isMultiPoint())

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/tileproviders/SampleAssetsOnlyRepetitionModes.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/tileproviders/SampleAssetsOnlyRepetitionModes.java
@@ -56,8 +56,8 @@ public class SampleAssetsOnlyRepetitionModes extends BaseSampleFragment {
             @Override public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                 if(isChecked) {
                     mMapView.setScrollableAreaLimitDouble(new BoundingBox(
-                            TileSystem.MaxLatitude, TileSystem.MaxLongitude,
-                            TileSystem.MinLatitude, TileSystem.MinLongitude));
+                            mMapView.getTileSystem().getMaxLatitude(), mMapView.getTileSystem().getMaxLongitude(),
+                            mMapView.getTileSystem().getMinLatitude(), mMapView.getTileSystem().getMinLongitude()));
                 } else {
                     mMapView.setScrollableAreaLimitDouble(null);
                 }

--- a/osmdroid-android-it/src/main/java/org/osmdroid/views/OpenStreetMapViewTest.java
+++ b/osmdroid-android-it/src/main/java/org/osmdroid/views/OpenStreetMapViewTest.java
@@ -18,6 +18,7 @@ import org.osmdroid.StarterMapFragment;
 import org.osmdroid.tileprovider.util.Counters;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.util.TileSystem;
+import org.osmdroid.util.TileSystemWebMercator;
 
 import java.util.Random;
 
@@ -28,6 +29,8 @@ import java.util.Random;
 public class OpenStreetMapViewTest extends ActivityInstrumentationTestCase2<StarterMapActivity> {
 
 	private static final Random random = new Random();
+
+	private static final TileSystem tileSystem = new TileSystemWebMercator();
 
 	public OpenStreetMapViewTest() {
         super(StarterMapActivity.class);
@@ -70,14 +73,14 @@ public class OpenStreetMapViewTest extends ActivityInstrumentationTestCase2<Star
 	 * @since 6.0.0
 	 */
 	private double getRandomLongitude() {
-		return TileSystem.getRandomLongitude(random.nextDouble());
+		return tileSystem.getRandomLongitude(random.nextDouble());
 	}
 
 	/**
 	 * @since 6.0.0
 	 */
 	private double getRandomLatitude() {
-		return TileSystem.getRandomLatitude(random.nextDouble(), TileSystem.MinLatitude);
+		return tileSystem.getRandomLatitude(random.nextDouble(), tileSystem.getMinLatitude());
 	}
 
 	/**

--- a/osmdroid-android/src/main/java/microsoft/mappoint/TileSystem.java
+++ b/osmdroid-android/src/main/java/microsoft/mappoint/TileSystem.java
@@ -1,6 +1,7 @@
 package microsoft.mappoint;
 
 import org.osmdroid.util.GeoPoint;
+import org.osmdroid.util.TileSystemWebMercator;
 
 import android.graphics.Point;
 
@@ -10,6 +11,8 @@ import android.graphics.Point;
  */
 @Deprecated
 public final class TileSystem {
+
+	private static final TileSystemWebMercator tileSystem = new TileSystemWebMercator();
 
 	@Deprecated
 	public static final int primaryKeyMaxZoomLevel = org.osmdroid.util.TileSystem.primaryKeyMaxZoomLevel;
@@ -52,23 +55,23 @@ public final class TileSystem {
 	@Deprecated
 	public static Point LatLongToPixelXY(double latitude, double longitude,
 			final int levelOfDetail, final Point reuse) {
-		return org.osmdroid.util.TileSystem.LatLongToPixelXY(latitude, longitude, levelOfDetail, reuse);
+		return tileSystem.LatLongToPixelXY(latitude, longitude, levelOfDetail, reuse);
 	}
 
 	@Deprecated
 	public static GeoPoint PixelXYToLatLong(final int pixelX, final int pixelY,
 			final int levelOfDetail, final GeoPoint reuse) {
-		return org.osmdroid.util.TileSystem.PixelXYToLatLong(pixelX, pixelY, levelOfDetail, reuse);
+		return tileSystem.PixelXYToLatLong(pixelX, pixelY, levelOfDetail, reuse);
 	}
 
 	@Deprecated
 	public static Point PixelXYToTileXY(final int pixelX, final int pixelY, final Point reuse) {
-		return org.osmdroid.util.TileSystem.PixelXYToTileXY(pixelX, pixelY, reuse);
+		return tileSystem.PixelXYToTileXY(pixelX, pixelY, reuse);
 	}
 
 	@Deprecated
 	public static Point TileXYToPixelXY(final int tileX, final int tileY, final Point reuse) {
-		return org.osmdroid.util.TileSystem.TileXYToPixelXY(tileX, tileY, reuse);
+		return tileSystem.TileXYToPixelXY(tileX, tileY, reuse);
 	}
 
 	@Deprecated

--- a/osmdroid-android/src/main/java/org/osmdroid/util/BoundingBox.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/BoundingBox.java
@@ -25,7 +25,6 @@ public class BoundingBox implements Parcelable, Serializable {
 	// ===========================================================
 
 	static final long serialVersionUID = 2L;
-	private static final TileSystem tileSystem = new TileSystemWebMercator();
 
 	// ===========================================================
 	// Fields
@@ -63,6 +62,7 @@ public class BoundingBox implements Parcelable, Serializable {
 		//  30 > 0 OK
 		// 30 < 0 not ok
 
+        final TileSystem tileSystem = org.osmdroid.views.MapView.getTileSystem();
 		if (!tileSystem.isValidLatitude(north))
 			throw new IllegalArgumentException("north must be in " + tileSystem.toStringLatitudeSpan());
 		if (!tileSystem.isValidLatitude(south))
@@ -145,7 +145,7 @@ public class BoundingBox implements Parcelable, Serializable {
 		if (pEast < pWest) {
 			longitude += 180;
 		}
-		return tileSystem.cleanLongitude(longitude);
+		return org.osmdroid.views.MapView.getTileSystem().cleanLongitude(longitude);
 	}
 
 	/**

--- a/osmdroid-android/src/main/java/org/osmdroid/util/BoundingBox.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/BoundingBox.java
@@ -25,6 +25,7 @@ public class BoundingBox implements Parcelable, Serializable {
 	// ===========================================================
 
 	static final long serialVersionUID = 2L;
+	private static final TileSystem tileSystem = new TileSystemWebMercator();
 
 	// ===========================================================
 	// Fields
@@ -55,14 +56,14 @@ public class BoundingBox implements Parcelable, Serializable {
 		//  30 > 0 OK
 		// 30 < 0 not ok
 
-		if (north > TileSystem.MaxLongitude || north < TileSystem.MinLatitude)
-			throw new IllegalArgumentException("north must be less than " +TileSystem.MaxLongitude + " value was " + toString());
-		if (south < TileSystem.MinLatitude || south > TileSystem.MaxLatitude)
-			throw new IllegalArgumentException("south more than " + TileSystem.MinLatitude + " value was " + toString());
-		if (west <	 TileSystem.MinLongitude || west > TileSystem.MaxLongitude)
-			throw new IllegalArgumentException("west must be more than " + TileSystem.MinLongitude + " value was " + toString());
-		if (east > TileSystem.MaxLongitude || east < TileSystem.MinLongitude)
-			throw new IllegalArgumentException("east must be less than " + TileSystem.MaxLongitude + " value was " + toString());
+		if (north > tileSystem.getMaxLongitude() || north < tileSystem.getMinLatitude())
+			throw new IllegalArgumentException("north must be less than " +tileSystem.getMaxLongitude() + " value was " + toString());
+		if (south < tileSystem.getMinLatitude() || south > tileSystem.getMaxLatitude())
+			throw new IllegalArgumentException("south more than " + tileSystem.getMinLatitude() + " value was " + toString());
+		if (west <	 tileSystem.getMinLongitude() || west > tileSystem.getMaxLongitude())
+			throw new IllegalArgumentException("west must be more than " + tileSystem.getMinLongitude() + " value was " + toString());
+		if (east > tileSystem.getMaxLongitude() || east < tileSystem.getMinLongitude())
+			throw new IllegalArgumentException("east must be less than " + tileSystem.getMaxLongitude() + " value was " + toString());
 	}
 
 	public BoundingBox clone(){
@@ -135,13 +136,13 @@ public class BoundingBox implements Parcelable, Serializable {
 	public static double getCenterLongitude(final double pWest, final double pEast) {
 		double longitude = (pEast + pWest) / 2.0;
 		if (pEast < pWest) {
-			longitude += TileSystem.MaxLongitude;
+			longitude += tileSystem.getMaxLongitude();
 		}
-		while (longitude > TileSystem.MaxLongitude) {
-			longitude -= 2 * TileSystem.MaxLongitude;
+		while (longitude > tileSystem.getMaxLongitude()) {
+			longitude -= 2 * tileSystem.getMaxLongitude();
 		}
-		while (longitude < TileSystem.MinLongitude) {
-			longitude += 2 * TileSystem.MaxLongitude;
+		while (longitude < tileSystem.getMinLongitude()) {
+			longitude += 2 * tileSystem.getMaxLongitude();
 		}
 		return longitude;
 	}

--- a/osmdroid-android/src/main/java/org/osmdroid/util/BoundingBox.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/BoundingBox.java
@@ -45,6 +45,13 @@ public class BoundingBox implements Parcelable, Serializable {
 	}
 
 	/**
+	 * @since 6.0.2
+	 * In order to avoid longitude and latitude checks that will crash
+	 * in TileSystem configurations with a bounding box that doesn't include [0,0]
+	 */
+	public BoundingBox() {}
+
+	/**
 	 * @since 6.0.0
 	 */
 	public void set(final double north, final double east, final double south, final double west) {
@@ -56,14 +63,14 @@ public class BoundingBox implements Parcelable, Serializable {
 		//  30 > 0 OK
 		// 30 < 0 not ok
 
-		if (north > tileSystem.getMaxLongitude() || north < tileSystem.getMinLatitude())
-			throw new IllegalArgumentException("north must be less than " +tileSystem.getMaxLongitude() + " value was " + toString());
-		if (south < tileSystem.getMinLatitude() || south > tileSystem.getMaxLatitude())
-			throw new IllegalArgumentException("south more than " + tileSystem.getMinLatitude() + " value was " + toString());
-		if (west <	 tileSystem.getMinLongitude() || west > tileSystem.getMaxLongitude())
-			throw new IllegalArgumentException("west must be more than " + tileSystem.getMinLongitude() + " value was " + toString());
-		if (east > tileSystem.getMaxLongitude() || east < tileSystem.getMinLongitude())
-			throw new IllegalArgumentException("east must be less than " + tileSystem.getMaxLongitude() + " value was " + toString());
+		if (!tileSystem.isValidLatitude(north))
+			throw new IllegalArgumentException("north must be in " + tileSystem.toStringLatitudeSpan());
+		if (!tileSystem.isValidLatitude(south))
+			throw new IllegalArgumentException("south must be in " + tileSystem.toStringLatitudeSpan());
+		if (!tileSystem.isValidLongitude(west))
+			throw new IllegalArgumentException("west must be in " + tileSystem.toStringLongitudeSpan());
+		if (!tileSystem.isValidLongitude(east))
+			throw new IllegalArgumentException("east must be in " + tileSystem.toStringLongitudeSpan());
 	}
 
 	public BoundingBox clone(){
@@ -136,15 +143,9 @@ public class BoundingBox implements Parcelable, Serializable {
 	public static double getCenterLongitude(final double pWest, final double pEast) {
 		double longitude = (pEast + pWest) / 2.0;
 		if (pEast < pWest) {
-			longitude += tileSystem.getMaxLongitude();
+			longitude += 180;
 		}
-		while (longitude > tileSystem.getMaxLongitude()) {
-			longitude -= 2 * tileSystem.getMaxLongitude();
-		}
-		while (longitude < tileSystem.getMinLongitude()) {
-			longitude += 2 * tileSystem.getMaxLongitude();
-		}
-		return longitude;
+		return tileSystem.cleanLongitude(longitude);
 	}
 
 	/**

--- a/osmdroid-android/src/main/java/org/osmdroid/util/TileSystem.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/TileSystem.java
@@ -634,11 +634,73 @@ abstract public class TileSystem {
 		return Math.round(pTile * pTileSize);
 	}
 
+	/**
+	 * @since 6.0.2
+     */
 	abstract public double getMinLatitude();
 
+	/**
+	 * @since 6.0.2
+     */
     abstract public double getMaxLatitude();
 
+	/**
+	 * @since 6.0.2
+     */
     abstract public double getMinLongitude();
 
+	/**
+	 * @since 6.0.2
+     */
     abstract public double getMaxLongitude();
+
+    /**
+     * @since 6.0.2
+     */
+    public double cleanLongitude(final double pLongitude) {
+        double result = pLongitude;
+
+        while (result < -180) {
+            result += 360;
+        }
+        while (result > 180) {
+            result -= 360;
+        }
+        return Clip(result, getMinLongitude(), getMaxLongitude());
+    }
+
+    /**
+     * @since 6.0.2
+     */
+    public double cleanLatitude(final double pLatitude) {
+        return Clip(pLatitude, getMinLatitude(), getMaxLatitude());
+    }
+
+    /**
+     * @since 6.0.2
+     */
+    public boolean isValidLongitude(final double pLongitude) {
+        return pLongitude >= getMinLongitude() && pLongitude <= getMaxLongitude();
+    }
+
+    /**
+     * @since 6.0.2
+     */
+    public boolean isValidLatitude(final double pLatitude) {
+        return pLatitude >= getMinLatitude() && pLatitude <= getMaxLatitude();
+    }
+
+	/**
+	 * @since 6.0.2
+	 */
+	public String toStringLongitudeSpan() {
+		return "[" + getMinLongitude() + "," + getMaxLongitude() + "]";
+	}
+
+	/**
+	 * @since 6.0.2
+	 */
+	public String toStringLatitudeSpan() {
+		return "[" + getMinLatitude() + "," + getMaxLatitude() + "]";
+	}
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/util/TileSystemWebMercator.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/TileSystemWebMercator.java
@@ -1,0 +1,54 @@
+package org.osmdroid.util;
+
+/**
+ * @since 6.0.2
+ * @author Fabrice Fontaine
+ */
+public class TileSystemWebMercator extends TileSystem{
+
+    private static final double MinLatitude = -85.05112877980659;
+    private static final double MaxLatitude = 85.05112877980659;
+    private static final double MinLongitude = -180;
+    private static final double MaxLongitude = 180;
+
+    @Override
+    public double getX01FromLongitude(final double pLongitude) {
+        return (pLongitude - getMinLongitude()) / (getMaxLongitude() - getMinLongitude());
+    }
+
+    @Override
+    public double getY01FromLatitude(final double pLatitude) {
+        final double sinus = Math.sin(pLatitude * Math.PI / 180);
+        return 0.5 - Math.log((1 + sinus) / (1 - sinus)) / (4 * Math.PI);
+    }
+
+    @Override
+    public double getLongitudeFromX01(final double pX01) {
+        return getMinLongitude() + (getMaxLongitude() - getMinLongitude()) * pX01;
+    }
+
+    @Override
+    public double getLatitudeFromY01(final double pY01) {
+        return 90 - 360 * Math.atan(Math.exp((pY01 - 0.5) * 2 * Math.PI)) / Math.PI;
+    }
+
+    @Override
+    public double getMinLatitude() {
+        return MinLatitude;
+    }
+
+    @Override
+    public double getMaxLatitude() {
+        return MaxLatitude;
+    }
+
+    @Override
+    public double getMinLongitude() {
+        return MinLongitude;
+    }
+
+    @Override
+    public double getMaxLongitude() {
+        return MaxLongitude;
+    }
+}

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapController.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapController.java
@@ -495,11 +495,11 @@ public class MapController implements IMapController, OnFirstLayoutListener {
         }
 
         private double cleanLongitude(double pLongitude) {
-            while (pLongitude < TileSystem.MinLongitude) {
-                pLongitude += (TileSystem.MaxLongitude - TileSystem.MinLongitude);
+            while (pLongitude < mMapController.mMapView.getTileSystem().getMinLongitude()) {
+                pLongitude += (mMapController.mMapView.getTileSystem().getMaxLongitude() - mMapController.mMapView.getTileSystem().getMinLongitude());
             }
-            while (pLongitude > TileSystem.MaxLongitude) {
-                pLongitude -= (TileSystem.MaxLongitude - TileSystem.MinLongitude);
+            while (pLongitude > mMapController.mMapView.getTileSystem().getMaxLongitude()) {
+                pLongitude -= (mMapController.mMapView.getTileSystem().getMaxLongitude() - mMapController.mMapView.getTileSystem().getMinLongitude());
             }
             return pLongitude;
         }

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapController.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapController.java
@@ -482,26 +482,17 @@ public class MapController implements IMapController, OnFirstLayoutListener {
                 mMapController.mMapView.setZoomLevel(zoom);
             }
             if (mCenterEnd != null) {
-                final double longitudeStart = cleanLongitude(mCenterStart.getLongitude());
-                final double longitudeEnd = cleanLongitude(mCenterEnd.getLongitude());
-                final double longitude = cleanLongitude(longitudeStart + (longitudeEnd - longitudeStart) * value);
-                final double latitudeStart = mCenterStart.getLatitude();
-                final double latitudeEnd = mCenterEnd.getLatitude();
-                final double latitude = cleanLongitude(latitudeStart + (latitudeEnd - latitudeStart) * value);
+                final TileSystem tileSystem = mMapController.mMapView.getTileSystem();
+                final double longitudeStart = tileSystem.cleanLongitude(mCenterStart.getLongitude());
+                final double longitudeEnd = tileSystem.cleanLongitude(mCenterEnd.getLongitude());
+                final double longitude = tileSystem.cleanLongitude(longitudeStart + (longitudeEnd - longitudeStart) * value);
+                final double latitudeStart = tileSystem.cleanLatitude(mCenterStart.getLatitude());
+                final double latitudeEnd = tileSystem.cleanLatitude(mCenterEnd.getLatitude());
+                final double latitude = tileSystem.cleanLatitude(latitudeStart + (latitudeEnd - latitudeStart) * value);
                 mCenter.setCoords(latitude, longitude);
                 mMapController.mMapView.setExpectedCenter(mCenter);
             }
             mMapController.mMapView.invalidate();
-        }
-
-        private double cleanLongitude(double pLongitude) {
-            while (pLongitude < mMapController.mMapView.getTileSystem().getMinLongitude()) {
-                pLongitude += (mMapController.mMapView.getTileSystem().getMaxLongitude() - mMapController.mMapView.getTileSystem().getMinLongitude());
-            }
-            while (pLongitude > mMapController.mMapView.getTileSystem().getMaxLongitude()) {
-                pLongitude -= (mMapController.mMapView.getTileSystem().getMaxLongitude() - mMapController.mMapView.getTileSystem().getMinLongitude());
-            }
-            return pLongitude;
         }
     }
 

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
@@ -167,7 +167,7 @@ public class MapView extends ViewGroup implements IMapView,
 		void onFirstLayout(View v, int left, int top, int right, int bottom);
 	}
 
-	private TileSystem mTileSystem = new TileSystemWebMercator();
+	private static TileSystem mTileSystem = new TileSystemWebMercator();
 
 	// ===========================================================
 	// Constructors
@@ -1740,14 +1740,14 @@ public class MapView extends ViewGroup implements IMapView,
 	/**
 	 * @since 6.0.2
 	 */
-	public TileSystem getTileSystem() {
+	public static TileSystem getTileSystem() {
 		return mTileSystem;
 	}
 
 	/**
 	 * @since 6.0.2
 	 */
-	public void setTileSystem(final TileSystem pTileSystem) {
+	public static void setTileSystem(final TileSystem pTileSystem) {
 		mTileSystem = pTileSystem;
 	}
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
@@ -28,6 +28,7 @@ import org.osmdroid.util.BoundingBox;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.util.GeometryMath;
 import org.osmdroid.util.TileSystem;
+import org.osmdroid.util.TileSystemWebMercator;
 import org.osmdroid.views.overlay.DefaultOverlayManager;
 import org.osmdroid.views.overlay.Overlay;
 import org.osmdroid.views.overlay.OverlayManager;
@@ -165,6 +166,8 @@ public class MapView extends ViewGroup implements IMapView,
          */
 		void onFirstLayout(View v, int left, int top, int right, int bottom);
 	}
+
+	private TileSystem mTileSystem = new TileSystemWebMercator();
 
 	// ===========================================================
 	// Constructors
@@ -507,7 +510,7 @@ public class MapView extends ViewGroup implements IMapView,
 	 * @since 6.0.0
 	 */
 	public void zoomToBoundingBox(final BoundingBox boundingBox, final boolean animated, final int borderSizeInPixels) {
-		double nextZoom = TileSystem.getBoundingBoxZoom(boundingBox, getWidth() - 2 * borderSizeInPixels, getHeight() - 2 * borderSizeInPixels);
+		double nextZoom = mTileSystem.getBoundingBoxZoom(boundingBox, getWidth() - 2 * borderSizeInPixels, getHeight() - 2 * borderSizeInPixels);
 		if (nextZoom == Double.MIN_VALUE) {
 			return;
 		}
@@ -1732,5 +1735,19 @@ public class MapView extends ViewGroup implements IMapView,
 	 */
 	public void setZoomRounding(final boolean pZoomRounding) {
 		mZoomRounding = pZoomRounding;
+	}
+
+	/**
+	 * @since 6.0.2
+	 */
+	public TileSystem getTileSystem() {
+		return mTileSystem;
+	}
+
+	/**
+	 * @since 6.0.2
+	 */
+	public void setTileSystem(final TileSystem pTileSystem) {
+		mTileSystem = pTileSystem;
 	}
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/views/Projection.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/Projection.java
@@ -58,13 +58,16 @@ public class Projection implements IProjection {
 	private final float mOrientation;
 	private final GeoPoint mCurrentCenter = new GeoPoint(0., 0);
 
+	private final TileSystem mTileSystem;
+
 	Projection(MapView mapView) {
 		this(
 				mapView.getZoomLevelDouble(), mapView.getIntrinsicScreenRect(null),
 				mapView.getExpectedCenter(),
 				mapView.getMapScrollX(), mapView.getMapScrollY(),
 				mapView.getMapOrientation(),
-				mapView.isHorizontalMapRepetitionEnabled(), mapView.isVerticalMapRepetitionEnabled());
+				mapView.isHorizontalMapRepetitionEnabled(), mapView.isVerticalMapRepetitionEnabled(),
+				mapView.getTileSystem());
 	}
 
 	/**
@@ -75,18 +78,20 @@ public class Projection implements IProjection {
 			final GeoPoint pCenter,
 			final long pScrollX, final long pScrollY,
 			final float pOrientation,
-			boolean horizontalWrapEnabled, boolean verticalWrapEnabled) {
+			boolean horizontalWrapEnabled, boolean verticalWrapEnabled,
+			final TileSystem pTileSystem) {
 		mZoomLevelProjection = pZoomLevel;
 		this.horizontalWrapEnabled = horizontalWrapEnabled;
 		this.verticalWrapEnabled = verticalWrapEnabled;
+		mTileSystem = pTileSystem;
 		mMercatorMapSize = TileSystem.MapSize(mZoomLevelProjection);
 		mTileSize = TileSystem.getTileSize(mZoomLevelProjection);
 		mIntrinsicScreenRectProjection = pScreenRect;
 		final GeoPoint center = pCenter != null ? pCenter : new GeoPoint(0., 0);
 		mScrollX = pScrollX;
 		mScrollY = pScrollY;
-		mOffsetX = getScreenCenterX() - mScrollX - TileSystem.getMercatorXFromLongitude(center.getLongitude(), mMercatorMapSize, this.horizontalWrapEnabled);
-		mOffsetY = getScreenCenterY() - mScrollY - TileSystem.getMercatorYFromLatitude(center.getLatitude(), mMercatorMapSize, this.verticalWrapEnabled);
+		mOffsetX = getScreenCenterX() - mScrollX - mTileSystem.getMercatorXFromLongitude(center.getLongitude(), mMercatorMapSize, this.horizontalWrapEnabled);
+		mOffsetY = getScreenCenterY() - mScrollY - mTileSystem.getMercatorYFromLatitude(center.getLatitude(), mMercatorMapSize, this.verticalWrapEnabled);
 		mOrientation = pOrientation;
 		mRotateAndScaleMatrix.preRotate(mOrientation, getScreenCenterX(), getScreenCenterY());
 		mRotateAndScaleMatrix.invert(mUnrotateAndScaleMatrix);
@@ -101,7 +106,8 @@ public class Projection implements IProjection {
 				pZoomLevel, pScreenRect,
 				mCurrentCenter, 0, 0,
 				mOrientation,
-				horizontalWrapEnabled, verticalWrapEnabled);
+				horizontalWrapEnabled, verticalWrapEnabled,
+				mTileSystem);
 	}
 
 	public double getZoomLevel() {
@@ -156,7 +162,7 @@ public class Projection implements IProjection {
 		//reverting https://github.com/osmdroid/osmdroid/issues/459
 		//due to relapse of https://github.com/osmdroid/osmdroid/issues/507
 		//reverted functionality is now on the method fromPixelsRotationSensitive
-		return TileSystem.getGeoFromMercator(getCleanMercator(getMercatorXFromPixel(pPixelX), horizontalWrapEnabled),
+		return mTileSystem.getGeoFromMercator(getCleanMercator(getMercatorXFromPixel(pPixelX), horizontalWrapEnabled),
 				getCleanMercator(getMercatorYFromPixel(pPixelY), verticalWrapEnabled), mMercatorMapSize, pReuse,
 				horizontalWrapEnabled || forceWrap, verticalWrapEnabled || forceWrap);
 	}
@@ -178,7 +184,7 @@ public class Projection implements IProjection {
 	 * TODO refactor
 	 */
 	public long getLongPixelXFromLongitude(final double pLongitude, boolean forceWrap) {
-		return getLongPixelXFromMercator(TileSystem.getMercatorXFromLongitude(pLongitude, mMercatorMapSize, horizontalWrapEnabled || forceWrap), horizontalWrapEnabled);
+		return getLongPixelXFromMercator(mTileSystem.getMercatorXFromLongitude(pLongitude, mMercatorMapSize, horizontalWrapEnabled || forceWrap), horizontalWrapEnabled);
 	}
 
 	/**
@@ -186,7 +192,7 @@ public class Projection implements IProjection {
 	 * TODO refactor
 	 */
 	public long getLongPixelXFromLongitude(final double pLongitude) {
-		return getLongPixelXFromMercator(TileSystem.getMercatorXFromLongitude(pLongitude, mMercatorMapSize, false), false);
+		return getLongPixelXFromMercator(mTileSystem.getMercatorXFromLongitude(pLongitude, mMercatorMapSize, false), false);
 	}
 
 	/**
@@ -194,7 +200,7 @@ public class Projection implements IProjection {
 	 * TODO refactor
 	 */
 	public long getLongPixelYFromLatitude(final double pLatitude, boolean forceWrap) {
-		return getLongPixelYFromMercator(TileSystem.getMercatorYFromLatitude(pLatitude, mMercatorMapSize, verticalWrapEnabled || forceWrap), verticalWrapEnabled);
+		return getLongPixelYFromMercator(mTileSystem.getMercatorYFromLatitude(pLatitude, mMercatorMapSize, verticalWrapEnabled || forceWrap), verticalWrapEnabled);
 	}
 
 	/**
@@ -202,7 +208,7 @@ public class Projection implements IProjection {
 	 * TODO refactor
 	 */
 	public long getLongPixelYFromLatitude(final double pLatitude) {
-		return getLongPixelYFromMercator(TileSystem.getMercatorYFromLatitude(pLatitude, mMercatorMapSize, false), false);
+		return getLongPixelYFromMercator(mTileSystem.getMercatorYFromLatitude(pLatitude, mMercatorMapSize, false), false);
 	}
 
 	/**
@@ -250,7 +256,7 @@ public class Projection implements IProjection {
 	 * @since 6.0.0
 	 */
 	public PointL toProjectedPixels(final double latitude, final double longitude, final boolean pWrapEnabled, final PointL reuse) {
-		return TileSystem.getMercatorFromGeo(latitude, longitude, mProjectedMapSize, reuse, pWrapEnabled);
+		return mTileSystem.getMercatorFromGeo(latitude, longitude, mProjectedMapSize, reuse, pWrapEnabled);
 	}
 
 	/**
@@ -313,7 +319,7 @@ public class Projection implements IProjection {
 	/**
 	 * @since 6.0
 	 */
-	public static float metersToPixels(final float meters, final double latitude, final double zoomLevel) {
+	public float metersToPixels(final float meters, final double latitude, final double zoomLevel) {
 		return (float) (meters / TileSystem.GroundResolution(latitude, zoomLevel));
 	}
 
@@ -584,7 +590,7 @@ public class Projection implements IProjection {
 	 * @since 6.0.0
 	 */
 	public long getCleanMercator(final long pMercator, final boolean wrapEnabled) {
-		return TileSystem.getCleanMercator(pMercator, mMercatorMapSize, wrapEnabled);
+		return mTileSystem.getCleanMercator(pMercator, mMercatorMapSize, wrapEnabled);
 	}
 
 	/**

--- a/osmdroid-android/src/main/java/org/osmdroid/views/Projection.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/Projection.java
@@ -45,7 +45,7 @@ public class Projection implements IProjection {
 	private final Matrix mUnrotateAndScaleMatrix = new Matrix();
 	private final float[] mRotateScalePoints = new float[2];
 
-	private final BoundingBox mBoundingBoxProjection = new BoundingBox(0, 0,0, 0);
+	private final BoundingBox mBoundingBoxProjection = new BoundingBox();
 	private final double mZoomLevelProjection;
 	private final Rect mScreenRectProjection = new Rect();
 	private final Rect mIntrinsicScreenRectProjection;

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/LinearRing.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/LinearRing.java
@@ -13,6 +13,7 @@ import org.osmdroid.util.PointAccepter;
 import org.osmdroid.util.PointL;
 import org.osmdroid.util.SegmentClipper;
 import org.osmdroid.util.TileSystem;
+import org.osmdroid.util.TileSystemWebMercator;
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.Projection;
 import org.osmdroid.views.util.constants.MathConstants;
@@ -465,8 +466,9 @@ class LinearRing{
 		final PointL previous = new PointL();
 		final PointL current = new PointL();
 		final long projectedMapSize = 1L << 60; // should be accurate enough
+		final TileSystem tileSystem = new TileSystemWebMercator();
 		for (final GeoPoint currentGeo : mOriginalPoints) {
-			TileSystem.getMercatorFromGeo(currentGeo.getLatitude(), currentGeo.getLongitude(), projectedMapSize, current, false);
+			tileSystem.getMercatorFromGeo(currentGeo.getLatitude(), currentGeo.getLongitude(), projectedMapSize, current, false);
 			if (first) {
 				first = false;
 				minX = maxX = current.x;
@@ -502,6 +504,6 @@ class LinearRing{
 		while (centerY >= projectedMapSize) {
 			centerY -= projectedMapSize;
 		}
-		return TileSystem.getGeoFromMercator(centerX, centerY, projectedMapSize, out, false, false);
+		return tileSystem.getGeoFromMercator(centerX, centerY, projectedMapSize, out, false, false);
 	}
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/LinearRing.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/LinearRing.java
@@ -466,7 +466,7 @@ class LinearRing{
 		final PointL previous = new PointL();
 		final PointL current = new PointL();
 		final long projectedMapSize = 1L << 60; // should be accurate enough
-		final TileSystem tileSystem = new TileSystemWebMercator();
+		final TileSystem tileSystem = MapView.getTileSystem();
 		for (final GeoPoint currentGeo : mOriginalPoints) {
 			tileSystem.getMercatorFromGeo(currentGeo.getLatitude(), currentGeo.getLongitude(), projectedMapSize, current, false);
 			if (first) {

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Overlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Overlay.java
@@ -52,7 +52,7 @@ public abstract class Overlay implements OverlayConstants {
 
 	private static final Rect mRect = new Rect();
 	private boolean mEnabled = true;
-	private static final TileSystem tileSystem = new TileSystemWebMercator(); // used only for the default bounding box
+	private final TileSystem tileSystem = MapView.getTileSystem(); // used only for the default bounding box
 	protected BoundingBox mBounds = new BoundingBox(tileSystem.getMaxLatitude(), tileSystem.getMaxLongitude(),tileSystem.getMinLatitude(),tileSystem.getMinLongitude());
 
 	// ===========================================================

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Overlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Overlay.java
@@ -6,6 +6,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.osmdroid.api.IMapView;
 import org.osmdroid.util.BoundingBox;
 import org.osmdroid.util.TileSystem;
+import org.osmdroid.util.TileSystemWebMercator;
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.util.constants.OverlayConstants;
 
@@ -51,8 +52,8 @@ public abstract class Overlay implements OverlayConstants {
 
 	private static final Rect mRect = new Rect();
 	private boolean mEnabled = true;
-	protected BoundingBox mBounds = new BoundingBox(TileSystem.MaxLatitude, TileSystem.MaxLongitude,TileSystem.MinLatitude,TileSystem.MinLongitude);
-
+	private static final TileSystem tileSystem = new TileSystemWebMercator(); // used only for the default bounding box
+	protected BoundingBox mBounds = new BoundingBox(tileSystem.getMaxLatitude(), tileSystem.getMaxLongitude(),tileSystem.getMinLatitude(),tileSystem.getMinLongitude());
 
 	// ===========================================================
 	// Constructors

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/simplefastpoint/SimpleFastPointOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/simplefastpoint/SimpleFastPointOverlay.java
@@ -46,7 +46,7 @@ public class SimpleFastPointOverlay extends Overlay {
     private int numLabels;
     private BoundingBox startBoundingBox;
     private Projection startProjection;
-    private BoundingBox prevBoundingBox = new BoundingBox(0, 0, 0, 0);
+    private BoundingBox prevBoundingBox = new BoundingBox();
 
     /**
      * Just a light internal class for storing point data

--- a/osmdroid-android/src/main/java/org/osmdroid/views/util/PathProjection.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/util/PathProjection.java
@@ -6,6 +6,7 @@ import org.osmdroid.util.BoundingBox;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.util.PointL;
 import org.osmdroid.util.TileSystem;
+import org.osmdroid.util.TileSystemWebMercator;
 import org.osmdroid.views.Projection;
 
 import android.graphics.Path;
@@ -14,6 +15,8 @@ import android.graphics.PointF;
 import android.graphics.Rect;
 
 public class PathProjection {
+
+	private static final TileSystem tileSystem = new TileSystemWebMercator();
 
 	public static Path toPixels(Projection projection, final List<? extends GeoPoint> in,
 			final Path reuse) {
@@ -33,7 +36,7 @@ public class PathProjection {
 		for (final GeoPoint gp : in) {
 			final Point underGeopointTileCoords = new Point();
 			final double mapSize = TileSystem.MapSize(projection.getZoomLevel());
-			final PointL mercator = TileSystem.getMercatorFromGeo(
+			final PointL mercator = tileSystem.getMercatorFromGeo(
 					gp.getLatitude(), gp.getLongitude(), mapSize,
 					null, true);
 			underGeopointTileCoords.x = projection.getTileFromMercator(mercator.x);
@@ -48,8 +51,8 @@ public class PathProjection {
 			final PointL lowerLeft = new PointL(
 					projection.getMercatorFromTile(underGeopointTileCoords.x + TileSystem.getTileSize()),
 					projection.getMercatorFromTile(underGeopointTileCoords.y + TileSystem.getTileSize()));
-			final GeoPoint neGeoPoint = TileSystem.getGeoFromMercator(upperRight.x, upperRight.y, mapSize, null, true, true);
-			final GeoPoint swGeoPoint = TileSystem.getGeoFromMercator(lowerLeft.x, lowerLeft.y, mapSize, null, true, true);
+			final GeoPoint neGeoPoint = tileSystem.getGeoFromMercator(upperRight.x, upperRight.y, mapSize, null, true, true);
+			final GeoPoint swGeoPoint = tileSystem.getGeoFromMercator(lowerLeft.x, lowerLeft.y, mapSize, null, true, true);
 			final BoundingBox bb = new BoundingBox(neGeoPoint.getLatitude(),
 					neGeoPoint.getLongitude(), swGeoPoint.getLatitude(),
 					swGeoPoint.getLongitude());

--- a/osmdroid-android/src/main/java/org/osmdroid/views/util/PathProjection.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/util/PathProjection.java
@@ -6,7 +6,6 @@ import org.osmdroid.util.BoundingBox;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.util.PointL;
 import org.osmdroid.util.TileSystem;
-import org.osmdroid.util.TileSystemWebMercator;
 import org.osmdroid.views.Projection;
 
 import android.graphics.Path;
@@ -15,8 +14,6 @@ import android.graphics.PointF;
 import android.graphics.Rect;
 
 public class PathProjection {
-
-	private static final TileSystem tileSystem = new TileSystemWebMercator();
 
 	public static Path toPixels(Projection projection, final List<? extends GeoPoint> in,
 			final Path reuse) {
@@ -32,6 +29,7 @@ public class PathProjection {
 		final Path out = (reuse != null) ? reuse : new Path();
 		out.incReserve(in.size());
 
+	    final TileSystem tileSystem = org.osmdroid.views.MapView.getTileSystem();
 		boolean first = true;
 		for (final GeoPoint gp : in) {
 			final Point underGeopointTileCoords = new Point();

--- a/osmdroid-android/src/test/java/org/osmdroid/util/BoundBoxTest.java
+++ b/osmdroid-android/src/test/java/org/osmdroid/util/BoundBoxTest.java
@@ -13,6 +13,8 @@ import java.util.List;
 
 public class BoundBoxTest {
 
+    private static final TileSystem tileSystem = new TileSystemWebMercator();
+
     @Test
     public void testBoundingBox() throws Exception{
 
@@ -37,16 +39,16 @@ public class BoundBoxTest {
     public void testBoundingBoxMax() throws Exception{
 
         List<IGeoPoint> partialPolyLine = new ArrayList<>();
-        partialPolyLine.add(new GeoPoint(TileSystem.MaxLatitude,180d));
-        partialPolyLine.add(new GeoPoint(TileSystem.MinLatitude,-180d));
+        partialPolyLine.add(new GeoPoint(tileSystem.getMaxLatitude(),180d));
+        partialPolyLine.add(new GeoPoint(tileSystem.getMinLatitude(),-180d));
 
         BoundingBox fromGeoPoints = BoundingBox.fromGeoPoints(partialPolyLine);
         Assert.assertEquals(fromGeoPoints.getCenter().getLatitude(),0d, 0.000001d);
         Assert.assertEquals(fromGeoPoints.getCenter().getLongitude(),0d, 0.000001d);
 
 
-        Assert.assertEquals(fromGeoPoints.getLatNorth(),TileSystem.MaxLatitude, 0.000001d);
-        Assert.assertEquals(fromGeoPoints.getLatSouth(),TileSystem.MinLatitude, 0.000001d);
+        Assert.assertEquals(fromGeoPoints.getLatNorth(),tileSystem.getMaxLatitude(), 0.000001d);
+        Assert.assertEquals(fromGeoPoints.getLatSouth(),tileSystem.getMinLatitude(), 0.000001d);
         Assert.assertEquals(fromGeoPoints.getLonEast(),180d, 0.000001d);
         Assert.assertEquals(fromGeoPoints.getLonWest(),-180d, 0.000001d);
     }

--- a/osmdroid-android/src/test/java/org/osmdroid/util/GeoPointTest.java
+++ b/osmdroid-android/src/test/java/org/osmdroid/util/GeoPointTest.java
@@ -26,6 +26,8 @@ public class GeoPointTest {
 
 	private static Random random = new Random();
 
+	private static final TileSystem tileSystem = new TileSystemWebMercator();
+
 	/**
 	 * Testing that a distance from a point to the same point is 0
 	 * @since 6.0.0
@@ -217,8 +219,8 @@ public class GeoPointTest {
 	 */
 	private double getCleanLongitudeDiff(final double pLongitude1, final double pLongitude2) {
 		double diff = Math.abs(pLongitude1 - pLongitude2);
-		if (diff > TileSystem.MaxLongitude) {
-			diff = TileSystem.MaxLongitude - TileSystem.MinLongitude - diff;
+		if (diff > tileSystem.getMaxLongitude()) {
+			diff = tileSystem.getMaxLongitude() - tileSystem.getMinLongitude() - diff;
 		}
 		return diff;
 	}
@@ -227,13 +229,13 @@ public class GeoPointTest {
 	 * @since 6.0.0
 	 */
 	private double getRandomLongitude() {
-		return TileSystem.getRandomLongitude(random.nextDouble());
+		return tileSystem.getRandomLongitude(random.nextDouble());
 	}
 
 	/**
 	 * @since 6.0.0
 	 */
 	private double getRandomLatitude() {
-		return TileSystem.getRandomLatitude(random.nextDouble(), TileSystem.MinLatitude);
+		return tileSystem.getRandomLatitude(random.nextDouble(), tileSystem.getMinLatitude());
 	}
 }

--- a/osmdroid-android/src/test/java/org/osmdroid/util/ProjectionTest.java
+++ b/osmdroid-android/src/test/java/org/osmdroid/util/ProjectionTest.java
@@ -48,6 +48,7 @@ public class ProjectionTest {
         mMiniMapScreenRect.right = mMiniMapScreenRect.left + mWidth / 4;
         mMiniMapScreenRect.bottom = mMiniMapScreenRect.top + mHeight / 4;
     }
+    private static final TileSystem tileSystem = new TileSystemWebMercator();
 
     /**
      * "If both Projection's scrolls are 0, the geo center is projected to the screen rect center"
@@ -232,11 +233,11 @@ public class ProjectionTest {
     }
 
     private double getRandomLongitude() {
-        return TileSystem.getRandomLongitude(mRandom.nextDouble());
+        return tileSystem.getRandomLongitude(mRandom.nextDouble());
     }
 
     private double getRandomLatitude() {
-        return TileSystem.getRandomLatitude(mRandom.nextDouble(), TileSystem.MinLatitude);
+        return tileSystem.getRandomLatitude(mRandom.nextDouble(), tileSystem.getMinLatitude());
     }
 
     private double getRandom(final double pMin, final double pMax) {
@@ -258,7 +259,8 @@ public class ProjectionTest {
                 pGeoPoint,
                 pOffsetX, pOffsetY,
                 getRandomOrientation(),
-                true, true);
+                true, true,
+                tileSystem);
     }
 
     private Projection getRandomProjection(final double pZoomLevel) {
@@ -281,7 +283,8 @@ public class ProjectionTest {
                     new GeoPoint(0.0, 0.0),
                     0L, 0L,
                     0,
-                    false, false
+                    false, false,
+                    tileSystem
             );
 
             final Point inputPoint = new Point(0, 0);

--- a/osmdroid-android/src/test/java/org/osmdroid/util/TileSystemTest.java
+++ b/osmdroid-android/src/test/java/org/osmdroid/util/TileSystemTest.java
@@ -18,20 +18,21 @@ public class TileSystemTest {
     private static final double latLongDelta = 1E-10;
     private static final int mMinZoomLevel = 0;
     private static final int mMaxZoomLevel = TileSystem.getMaximumZoomLevel();
+    private static final TileSystem tileSystem = new TileSystemWebMercator();
 
     @Test
     public void testGetY01FromLatitude() {
-        checkXY01(0, TileSystem.getY01FromLatitude(TileSystem.MaxLatitude, true));
-        checkXY01(.5, TileSystem.getY01FromLatitude(0, true));
-        checkXY01(1, TileSystem.getY01FromLatitude(TileSystem.MinLatitude, true));
+        checkXY01(0, tileSystem.getY01FromLatitude(tileSystem.getMaxLatitude(), true));
+        checkXY01(.5, tileSystem.getY01FromLatitude(0, true));
+        checkXY01(1, tileSystem.getY01FromLatitude(tileSystem.getMinLatitude(), true));
     }
 
     @Test
     public void testGetX01FromLongitude() {
         final int iterations = 10;
         for (int i = 0 ; i <= iterations ; i ++) {
-            final double longitude = TileSystem.MinLongitude + i * (TileSystem.MaxLongitude - TileSystem.MinLongitude) / iterations;
-            checkXY01(((double)i) / iterations, TileSystem.getX01FromLongitude(longitude, true));
+            final double longitude = tileSystem.getMinLongitude() + i * (tileSystem.getMaxLongitude() - tileSystem.getMinLongitude()) / iterations;
+            checkXY01(((double)i) / iterations, tileSystem.getX01FromLongitude(longitude, true));
         }
     }
 
@@ -40,9 +41,9 @@ public class TileSystemTest {
      */
     @Test
     public void testGetLatitudeFromY01() {
-        checkLatitude(TileSystem.MaxLatitude, TileSystem.getLatitudeFromY01(0, true));
-        checkLatitude(0, TileSystem.getLatitudeFromY01(0.5, true));
-        checkLatitude(TileSystem.MinLatitude, TileSystem.getLatitudeFromY01(1, true));
+        checkLatitude(tileSystem.getMaxLatitude(), tileSystem.getLatitudeFromY01(0, true));
+        checkLatitude(0, tileSystem.getLatitudeFromY01(0.5, true));
+        checkLatitude(tileSystem.getMinLatitude(), tileSystem.getLatitudeFromY01(1, true));
     }
 
     /**
@@ -53,7 +54,7 @@ public class TileSystemTest {
         final int iterations = 100;
         for (int i = 0 ; i <= iterations ; i ++) {
             final double latitude = getRandomLatitude();
-            checkLatitude(latitude, TileSystem.getLatitudeFromY01(TileSystem.getY01FromLatitude(latitude, true), true));
+            checkLatitude(latitude, tileSystem.getLatitudeFromY01(tileSystem.getY01FromLatitude(latitude, true), true));
         }
     }
 
@@ -64,12 +65,12 @@ public class TileSystemTest {
     public void testGetLongitudeFromX01() {
         final int iterations = 10;
         for (int i = 0 ; i <= iterations ; i ++) {
-            final double longitude = TileSystem.MinLongitude + i * (TileSystem.MaxLongitude - TileSystem.MinLongitude) / iterations;
-            checkLongitude(longitude, TileSystem.getLongitudeFromX01(((double)i) / iterations, true));
+            final double longitude = tileSystem.getMinLongitude() + i * (tileSystem.getMaxLongitude() - tileSystem.getMinLongitude()) / iterations;
+            checkLongitude(longitude, tileSystem.getLongitudeFromX01(((double)i) / iterations, true));
         }
-        checkLongitude(TileSystem.MinLongitude, TileSystem.getLongitudeFromX01(0, true));
-        checkLongitude(0, TileSystem.getLongitudeFromX01(0.5, true));
-        checkLongitude(TileSystem.MaxLongitude, TileSystem.getLongitudeFromX01(1, true));
+        checkLongitude(tileSystem.getMinLongitude(), tileSystem.getLongitudeFromX01(0, true));
+        checkLongitude(0, tileSystem.getLongitudeFromX01(0.5, true));
+        checkLongitude(tileSystem.getMaxLongitude(), tileSystem.getLongitudeFromX01(1, true));
     }
 
     /**
@@ -80,7 +81,7 @@ public class TileSystemTest {
         final int iterations = 100;
         for (int i = 0 ; i <= iterations ; i ++) {
             final double longitude = getRandomLongitude();
-            checkLongitude(longitude, TileSystem.getLongitudeFromX01(TileSystem.getX01FromLongitude(longitude, true), true));
+            checkLongitude(longitude, tileSystem.getLongitudeFromX01(tileSystem.getX01FromLongitude(longitude, true), true));
         }
     }
 
@@ -92,17 +93,17 @@ public class TileSystemTest {
     /**
      * @since 6.0.0
      */
-    private void checkLatitude(final double pExpected, final double pActual) {
+    protected void checkLatitude(final double pExpected, final double pActual) {
         Assert.assertEquals(pExpected, pActual, latLongDelta);
-        checkMinMax(pActual, TileSystem.MinLatitude, TileSystem.MaxLatitude);
+        checkMinMax(pActual, tileSystem.getMinLatitude(), tileSystem.getMaxLatitude());
     }
 
     /**
      * @since 6.0.0
      */
-    private void checkLongitude(final double pExpected, final double pActual) {
+    protected void checkLongitude(final double pExpected, final double pActual) {
         Assert.assertEquals(pExpected, pActual, latLongDelta);
-        checkMinMax(pActual, TileSystem.MinLongitude, TileSystem.MaxLongitude);
+        checkMinMax(pActual, tileSystem.getMinLongitude(), tileSystem.getMaxLongitude());
     }
 
     /**
@@ -114,7 +115,7 @@ public class TileSystemTest {
     }
 
     @Test
-    public void testGetBoundingBoxZoom() throws Exception{
+    public void testGetBoundingBoxZoom() {
         final int tileSize = 256;
         final int screenWidth = tileSize * 2;
         final int screenHeight = screenWidth * 2;
@@ -127,16 +128,16 @@ public class TileSystemTest {
             final double east = getRandomLongitude();
             final double west = getRandomLongitude();
             final BoundingBox boundingBox = new BoundingBox(north, east, south, west);
-            final double zoom = TileSystem.getBoundingBoxZoom(boundingBox, screenWidth, screenHeight);
+            final double zoom = tileSystem.getBoundingBoxZoom(boundingBox, screenWidth, screenHeight);
             if (zoom == Double.MIN_VALUE) {
                 Assert.assertTrue(north <= south || east == west);
                 continue;
             }
             final double mapSize = TileSystem.MapSize(zoom);
-            final long left = TileSystem.getMercatorXFromLongitude(west, mapSize, true);
-            final long top = TileSystem.getMercatorYFromLatitude(north, mapSize, true);
-            final long right = TileSystem.getMercatorXFromLongitude(east, mapSize, true);
-            final long bottom = TileSystem.getMercatorYFromLatitude(south, mapSize, true);
+            final long left = tileSystem.getMercatorXFromLongitude(west, mapSize, true);
+            final long top = tileSystem.getMercatorYFromLatitude(north, mapSize, true);
+            final long right = tileSystem.getMercatorXFromLongitude(east, mapSize, true);
+            final long bottom = tileSystem.getMercatorYFromLatitude(south, mapSize, true);
             long width = right - left;
             if (east < west) {
                 width += mapSize;
@@ -192,7 +193,7 @@ public class TileSystemTest {
      */
     @Test
     public void test_LatLongToPixelXY() {
-        final PointL point = TileSystem.getMercatorFromGeo(60, 60, TileSystem.MapSize((double)10), null, true);
+        final PointL point = tileSystem.getMercatorFromGeo(60, 60, TileSystem.MapSize((double)10), null, true);
         Assert.assertEquals(174762, point.x);
         Assert.assertEquals(76126, point.y);
     }
@@ -208,7 +209,7 @@ public class TileSystemTest {
         final int levelOfDetail = 8;
         final double delta = 1E-3;
 
-        final GeoPoint point = TileSystem.getGeoFromMercator(pixelX, pixelY, TileSystem.MapSize((double)levelOfDetail), null, true, true);
+        final GeoPoint point = tileSystem.getGeoFromMercator(pixelX, pixelY, TileSystem.MapSize((double)levelOfDetail), null, true, true);
 
         Assert.assertEquals(-179.752807617187, point.getLongitude(), delta);
         Assert.assertEquals(85.0297584051224, point.getLatitude(), delta);
@@ -245,7 +246,7 @@ public class TileSystemTest {
      * Reference values from: http://msdn.microsoft.com/en-us/library/bb259689.aspx
      */
     @Test
-    public void test_QuadKeyToTileXY() { ;
+    public void test_QuadKeyToTileXY() {
         testPoint(0, 1, TileSystem.QuadKeyToTileXY("2", null));
         testPoint(3, 1, TileSystem.QuadKeyToTileXY("13", null));
         testPoint(3, 5, TileSystem.QuadKeyToTileXY("213", null));
@@ -276,11 +277,11 @@ public class TileSystemTest {
     }
 
     private double getRandomLongitude() {
-        return TileSystem.getRandomLongitude(random.nextDouble());
+        return tileSystem.getRandomLongitude(random.nextDouble());
     }
 
     private double getRandomLatitude() {
-        return TileSystem.getRandomLatitude(random.nextDouble(), TileSystem.MinLatitude);
+        return tileSystem.getRandomLatitude(random.nextDouble(), tileSystem.getMinLatitude());
     }
 
     private void checkSize(final long pWidth, final long pHeight, final int pScreenWidth, final int pScreenHeight) {

--- a/osmdroid-android/src/test/java/org/osmdroid/views/overlay/LinearRingTest.java
+++ b/osmdroid-android/src/test/java/org/osmdroid/views/overlay/LinearRingTest.java
@@ -7,6 +7,7 @@ import junit.framework.Assert;
 import org.junit.Test;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.util.TileSystem;
+import org.osmdroid.util.TileSystemWebMercator;
 
 import java.util.Random;
 
@@ -19,6 +20,7 @@ import java.util.Random;
 public class LinearRingTest {
 
     private final Random mRandom = new Random();
+    private static final TileSystem tileSystem = new TileSystemWebMercator();
 
     @Test
     public void testGetCenter1DLatitudesOnly() {
@@ -78,11 +80,11 @@ public class LinearRingTest {
     }
 
     private int getRandomPositiveLatitude() {
-        return getRandom(0, (int)TileSystem.MaxLatitude);
+        return getRandom(0, (int)tileSystem.getMaxLatitude());
     }
 
     private int getRandomLongitude() {
-        return getRandom(-(int)TileSystem.MaxLongitude, (int)TileSystem.MaxLongitude);
+        return getRandom((int)tileSystem.getMinLongitude(), (int)tileSystem.getMaxLongitude());
     }
 
     private int getRandom(final int min, final int max) {

--- a/osmdroid-geopackage/src/main/java/org/osmdroid/gpkg/tiles/raster/GeoPackageMapTileModuleProvider.java
+++ b/osmdroid-geopackage/src/main/java/org/osmdroid/gpkg/tiles/raster/GeoPackageMapTileModuleProvider.java
@@ -39,7 +39,7 @@ import mil.nga.geopackage.tiles.user.TileDao;
  */
 public class GeoPackageMapTileModuleProvider extends MapTileModuleProviderBase {
 
-    private static final TileSystem tileSystem = new TileSystemWebMercator();
+    private final TileSystem tileSystem = org.osmdroid.views.MapView.getTileSystem();
 
     //TileRetriever retriever;
     protected IFilesystemCache tileWriter = null;

--- a/osmdroid-geopackage/src/main/java/org/osmdroid/gpkg/tiles/raster/GeoPackageMapTileModuleProvider.java
+++ b/osmdroid-geopackage/src/main/java/org/osmdroid/gpkg/tiles/raster/GeoPackageMapTileModuleProvider.java
@@ -15,6 +15,7 @@ import org.osmdroid.tileprovider.tilesource.ITileSource;
 import org.osmdroid.util.BoundingBox;
 import org.osmdroid.util.MapTileIndex;
 import org.osmdroid.util.TileSystem;
+import org.osmdroid.util.TileSystemWebMercator;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -37,6 +38,8 @@ import mil.nga.geopackage.tiles.user.TileDao;
  * Created by alex on 10/29/15.
  */
 public class GeoPackageMapTileModuleProvider extends MapTileModuleProviderBase {
+
+    private static final TileSystem tileSystem = new TileSystemWebMercator();
 
     //TileRetriever retriever;
     protected IFilesystemCache tileWriter = null;
@@ -127,9 +130,9 @@ public class GeoPackageMapTileModuleProvider extends MapTileModuleProviderBase {
 
                 ProjectionTransform transform = tileDao.getProjection().getTransformation(ProjectionConstants.EPSG_WORLD_GEODETIC_SYSTEM);
                 mil.nga.geopackage.BoundingBox boundingBox = transform.transform(tileDao.getBoundingBox());
-                BoundingBox bounds = new BoundingBox(Math.min(TileSystem.MaxLatitude, boundingBox.getMaxLatitude()),
+                BoundingBox bounds = new BoundingBox(Math.min(tileSystem.getMaxLatitude(), boundingBox.getMaxLatitude()),
                     boundingBox.getMaxLongitude(),
-                    Math.max(TileSystem.MinLatitude, boundingBox.getMinLatitude()),
+                    Math.max(tileSystem.getMinLatitude(), boundingBox.getMinLatitude()),
                     boundingBox.getMinLongitude());
 
                 srcs.add(new GeopackageRasterTileSource(databases.get(i), tileTables.get(k), (int)tileDao.getMinZoom(), (int)tileDao.getMaxZoom(), bounds));
@@ -157,9 +160,9 @@ public class GeoPackageMapTileModuleProvider extends MapTileModuleProviderBase {
             ProjectionTransform transform = tileDao.getProjection().getTransformation(ProjectionConstants.EPSG_WORLD_GEODETIC_SYSTEM);
             mil.nga.geopackage.BoundingBox boundingBox = transform.transform(tileDao.getBoundingBox());
 
-            BoundingBox bounds = new BoundingBox(Math.min(TileSystem.MaxLatitude, boundingBox.getMaxLatitude()),
+            BoundingBox bounds = new BoundingBox(Math.min(tileSystem.getMaxLatitude(), boundingBox.getMaxLatitude()),
                 boundingBox.getMaxLongitude(),
-                Math.max(TileSystem.MinLatitude, boundingBox.getMinLatitude()),
+                Math.max(tileSystem.getMinLatitude(), boundingBox.getMinLatitude()),
                 boundingBox.getMinLongitude());
             srcs.add(new GeopackageRasterTileSource(database, tileTables.get(k), (int)tileDao.getMinZoom(), (int)tileDao.getMaxZoom(), bounds));
 

--- a/osmdroid-wms/src/main/java/org/osmdroid/wms/DomParserWms111.java
+++ b/osmdroid-wms/src/main/java/org/osmdroid/wms/DomParserWms111.java
@@ -4,7 +4,6 @@ import android.util.Log;
 
 import org.osmdroid.util.BoundingBox;
 import org.osmdroid.util.TileSystem;
-import org.osmdroid.util.TileSystemWebMercator;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
@@ -28,8 +27,6 @@ import java.util.List;
 
 public class DomParserWms111 {
     static final String TAG = "osmdroidwms";
-
-    private static final TileSystem tileSystem = new TileSystemWebMercator();
 
     public static WMSEndpoint parse(Element element) throws Exception {
         //  WMTMSCapabilities ret = new WMTMSCapabilities();
@@ -157,6 +154,7 @@ public class DomParserWms111 {
 
     //e is "Layer"
     private static Collection<? extends WMSLayer> parseLayers(Node element) {
+        final TileSystem tileSystem = org.osmdroid.views.MapView.getTileSystem();
         List<WMSLayer> rets = new ArrayList<>();
         WMSLayer ret = new WMSLayer();
 

--- a/osmdroid-wms/src/main/java/org/osmdroid/wms/DomParserWms111.java
+++ b/osmdroid-wms/src/main/java/org/osmdroid/wms/DomParserWms111.java
@@ -4,6 +4,7 @@ import android.util.Log;
 
 import org.osmdroid.util.BoundingBox;
 import org.osmdroid.util.TileSystem;
+import org.osmdroid.util.TileSystemWebMercator;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
@@ -27,6 +28,8 @@ import java.util.List;
 
 public class DomParserWms111 {
     static final String TAG = "osmdroidwms";
+
+    private static final TileSystem tileSystem = new TileSystemWebMercator();
 
     public static WMSEndpoint parse(Element element) throws Exception {
         //  WMTMSCapabilities ret = new WMTMSCapabilities();
@@ -177,12 +180,12 @@ public class DomParserWms111 {
             } else if (name.contains("LatLonBoundingBox")) {
                 //TODO need some handling for crs here
                 south = (Double.parseDouble(e.getAttributes().getNamedItem("miny").getNodeValue()));
-                if (south < TileSystem.MinLatitude)
-                    south = TileSystem.MinLatitude;
+                if (south < tileSystem.getMinLatitude())
+                    south = tileSystem.getMinLatitude();
                 north = (Double.parseDouble(e.getAttributes().getNamedItem("maxy").getNodeValue()));
 
-                if (north > TileSystem.MaxLatitude)
-                    north = TileSystem.MaxLatitude;
+                if (north > tileSystem.getMaxLatitude())
+                    north = tileSystem.getMaxLatitude();
                 west = (Double.parseDouble(e.getAttributes().getNamedItem("maxx").getNodeValue()));
                 east = (Double.parseDouble(e.getAttributes().getNamedItem("minx").getNodeValue()));
                 ret.setBbox(new BoundingBox(north, east, south, west));


### PR DESCRIPTION
New class:
* `TileSystemWebMercator`: the current implementation of a tile system in a Web Mercator projection

Impacted classes:
* `BookmarkSample`: now uses getters for min/max latitude/longitude
* `BoundBoxTest`: now uses getters for min/max latitude/longitude
* `BoundingBox`: now uses getters for min/max latitude/longitude
* `DomParserWms111`: now uses getters for min/max latitude/longitude
* `GeoPackageMapTileModuleProvider`: now uses getters for min/max latitude/longitude
* `GeoPointTest`: now uses getters for min/max latitude/longitude and other non static `TileSystem` methods
* `IconPlottingOverlay`: now uses getters for min/max latitude/longitude
* `LinearRing`: impacted the `getCenter` method
* `LinearRingTest`: now uses getters for min/max latitude/longitude
* `MapController`: now uses getters for min/max latitude/longitude
* `MapView`: created a `TileSystem` member with getter and setter, and a default `new TileSystemWebMercator()` value
* `MilStdPointPlottingOverlay`: now uses getters for min/max latitude/longitude
* `OpenStreetMapViewTest`: now uses getters for min/max latitude/longitude and other non static `TileSystem` methods
* `Overlay`: now uses getters for min/max latitude/longitude
* `PathProjection`: now uses non static `TileSystem` methods
* `Projection`: added a `TileSystem` in the constructor and as a member; now uses non static `TileSystem` methods
* `ProjectionTest`: impacted the new `TileSystem` parameter in the `Projection` constructor; now uses non static `TileSystem` methods
* `SampleAnimateTo`: now uses non static `TileSystem` methods
* `SampleAssetsOnlyRepetitionModes`: now uses getters for min/max latitude/longitude
* `SampleZoomToBounding`: now uses getters for min/max latitude/longitude and other non static `TileSystem` methods
* `microsoft.mappoint.TileSystem`: now uses non static `TileSystem` methods
* `org.osmdroid.util.TileSystem`: made it abstract, with 4 lat/lon to/from X01/Y01 methods and 4 min/max lat/lon getters; deprecated the min/max lat/lon members; removed the `static` keyword as much as possible in order to make the class extendable; renamed method `getX01FromLongitudeWithoutWrap` as `getX01FromLongitude` (same for `getY01FromLatitude`)
* `TileSystemTest`: now uses non static `TileSystem` methods of a `TileSystemWebMercator` instance