### PR TITLE
Removed the systematic and problematic "is SD card available?" check

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileFileArchiveProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileFileArchiveProvider.java
@@ -174,10 +174,6 @@ public class MapTileFileArchiveProvider extends MapTileFileStorageProviderBase {
 	private void findArchiveFiles() {
 		clearArcives();
 
-		if (!isSdCardAvailable()) {
-			return;
-		}
-
           // path should be optionally configurable
           File cachePaths = Configuration.getInstance().getOsmdroidBasePath();
           final File[] files = cachePaths.listFiles();
@@ -221,14 +217,6 @@ public class MapTileFileArchiveProvider extends MapTileFileStorageProviderBase {
 			Drawable returnValue=null;
 			ITileSource tileSource = mTileSource.get();
 			if (tileSource == null) {
-				return null;
-			}
-
-			// if there's no sdcard then don't do anything
-			if (!isSdCardAvailable()) {
-				if (Configuration.getInstance().isDebugMode()) {
-					Log.d(IMapView.LOGTAG,"No sdcard - do nothing for tile: " + MapTileIndex.toString(pMapTileIndex));
-				}
 				return null;
 			}
 

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileFileStorageProviderBase.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileFileStorageProviderBase.java
@@ -6,14 +6,8 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.os.Environment;
-import android.util.Log;
-import org.osmdroid.api.IMapView;
 
 public abstract class MapTileFileStorageProviderBase extends MapTileModuleProviderBase {
-
-	/** whether the sdcard is mounted read/write */
-	static private boolean mSdCardAvailable = true;
 
 	private final IRegisterReceiver mRegisterReceiver;
 	private MyBroadcastReceiver mBroadcastReceiver;
@@ -21,8 +15,6 @@ public abstract class MapTileFileStorageProviderBase extends MapTileModuleProvid
 	public MapTileFileStorageProviderBase(final IRegisterReceiver pRegisterReceiver,
 			final int pThreadPoolSize, final int pPendingQueueSize) {
 		super(pThreadPoolSize, pPendingQueueSize);
-
-		checkSdCard();
 
 		mRegisterReceiver = pRegisterReceiver;
 		mBroadcastReceiver = new MyBroadcastReceiver();
@@ -32,17 +24,6 @@ public abstract class MapTileFileStorageProviderBase extends MapTileModuleProvid
 		mediaFilter.addAction(Intent.ACTION_MEDIA_UNMOUNTED);
 		mediaFilter.addDataScheme("file");
 		pRegisterReceiver.registerReceiver(mBroadcastReceiver, mediaFilter);
-	}
-
-	private void checkSdCard() {
-		final String state = Environment.getExternalStorageState();
-          Log.i(IMapView.LOGTAG,"sdcard state: " + state);
-		mSdCardAvailable = Environment.MEDIA_MOUNTED.equals(state);
-	}
-
-	/** whether the sdcard is mounted read/write */
-	public static boolean isSdCardAvailable() {
-		return mSdCardAvailable;
 	}
 
 	@Override
@@ -72,8 +53,6 @@ public abstract class MapTileFileStorageProviderBase extends MapTileModuleProvid
 		public void onReceive(final Context aContext, final Intent aIntent) {
 
 			final String action = aIntent.getAction();
-
-			checkSdCard();
 
 			if (Intent.ACTION_MEDIA_MOUNTED.equals(action)) {
 				onMediaMounted();

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileFilesystemProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileFilesystemProvider.java
@@ -130,14 +130,6 @@ public class MapTileFilesystemProvider extends MapTileFileStorageProviderBase {
 				return null;
 			}
 
-			// if there's no sdcard then don't do anything
-			if (!isSdCardAvailable()) {
-				if (Configuration.getInstance().isDebugMode()) {
-                         Log.d(IMapView.LOGTAG,"No sdcard - do nothing for tile: " + MapTileIndex.toString(pMapTileIndex));
-				}
-				Counters.fileCacheMiss++;
-				return null;
-			}
 			try {
 				final Drawable result = mWriter.loadTile(tileSource, pMapTileIndex);
 				if (result == null) {

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileSqlCacheProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileSqlCacheProvider.java
@@ -158,14 +158,6 @@ public class MapTileSqlCacheProvider  extends MapTileFileStorageProviderBase{
                 return null;
             }
 
-            // if there's no sdcard then don't do anything
-            if (!isSdCardAvailable()) {
-                if (Configuration.getInstance().isDebugMode()) {
-                    Log.d(IMapView.LOGTAG,"No sdcard - do nothing for tile: " + MapTileIndex.toString(pMapTileIndex));
-                }
-                Counters.fileCacheMiss++;
-                return null;
-            }
             if (mWriter!=null) {
                 try {
                     final Drawable result = mWriter.loadTile(tileSource, pMapTileIndex);


### PR DESCRIPTION
If ever a map tile provider deserves to fail because it needs the SD card and the SD card is not available, it will fail anyway.
And if it doesn't need the SD card, it won't be prevented from working correctly anymore by this "is SD card available?" check.

Impacted classes:
* `MapTileFileArchiveProvider`: removed calls to `isSdCardAvailable`
* `MapTileFileStorageProviderBase`: removed static member `mSdCardAvailable` and methods `checkSdCard` and `isSdCardAvailable`
* `MapTileFilesystemProvider`: removed call to `isSdCardAvailable`
* `MapTileSqlCacheProvider`: removed call to `isSdCardAvailable`