### PR TITLE
bug/#1030 - fixed NPE causing ANR

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/BaseSampleFragment.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/BaseSampleFragment.java
@@ -80,14 +80,18 @@ public abstract class BaseSampleFragment extends Fragment {
 
 	@Override
 	public void onPause(){
+        if (mMapView != null) {
+            mMapView.onPause();
+        }
 		super.onPause();
-		mMapView.onPause();
 	}
 
 	@Override
 	public void onResume(){
 		super.onResume();
-		mMapView.onResume();
+		if (mMapView != null) {
+            mMapView.onResume();
+        }
 	}
 
     @Override


### PR DESCRIPTION
When using concepts like `ViewPager`, the fragments are somehow accessed even when they are not fully created.
In the case of `BaseSampleFragment`, that means that we needed to handle the case when the `MapView` was not created when `onResume` or `onPause` were called.

````java
@Override
public void onPause(){
	if (mMapView != null) { // added
		mMapView.onPause();
	} // added
	super.onPause();
}

@Override
public void onResume(){
	super.onResume();
	if (mMapView != null) { // added
		mMapView.onResume();
	} // added
}
````