### PR TITLE
bug/#690 - secondary tile overlay does not refresh when tiles download

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samples/SampleWithTilesOverlayAndCustomTileSource.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samples/SampleWithTilesOverlayAndCustomTileSource.java
@@ -46,14 +46,15 @@ public class SampleWithTilesOverlayAndCustomTileSource extends Activity {
 		mMapView.setBuiltInZoomControls(true);
 
 		// zoom to the netherlands
-		mMapView.getController().setZoom(7);
-		mMapView.getController().setCenter(new GeoPoint(51500000, 5400000));
+		mMapView.getController().setZoom(7.);
+		mMapView.getController().setCenter(new GeoPoint(51.5, 5.4));
 
 		// Add tiles layer with custom tile source
 		final MapTileProviderBasic tileProvider = new MapTileProviderBasic(getApplicationContext());
 		final ITileSource tileSource = new XYTileSource("FietsRegionaal",  3, 18, 256, ".png",
 				new String[] { "http://overlay.openstreetmap.nl/openfietskaart-rcn/" });
 		tileProvider.setTileSource(tileSource);
+		tileProvider.setTileRequestCompleteHandler(mMapView.getTileRequestCompleteHandler());
 		final TilesOverlay tilesOverlay = new TilesOverlay(tileProvider, this.getBaseContext());
 		tilesOverlay.setLoadingBackgroundColor(Color.TRANSPARENT);
 		mMapView.getOverlays().add(tilesOverlay);


### PR DESCRIPTION
I explained how to make things work in my comments of issue #690, and I fixed the demo.

Impacted class:
* `SampleWithTilesOverlayAndCustomTileSource`: added an explicit call to `setTileRequestCompleteHandler`