### PR TITLE
bug/#1012 Add synchronization in MapTileCache.remove

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileCache.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileCache.java
@@ -178,7 +178,10 @@ public class MapTileCache {
 	 * Was in LRUMapTileCache
 	 */
 	public void remove(final long pMapTileIndex) {
-		final Drawable drawable = mCachedTiles.remove(pMapTileIndex);
+		final Drawable drawable;
+		synchronized (mCachedTiles) {
+			drawable = mCachedTiles.remove(pMapTileIndex);
+		}
 		if (getTileRemovedListener() != null)
 			getTileRemovedListener().onTileRemoved(pMapTileIndex);
 		BitmapPool.getInstance().asyncRecycle(drawable);


### PR DESCRIPTION
Fix a race in `MapTileCache` (#1012).

This synchronizes a call to `mCachedTiles.remove`, the same way other calls are guarded.

As discussed on: https://github.com/osmdroid/osmdroid/issues/1012#issuecomment-391466140