### PR TITLE
bug/#1040 - explicit call to invalidate after animation

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapController.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapController.java
@@ -431,6 +431,7 @@ public class MapController implements IMapController, OnFirstLayoutListener {
             mZoomOutAnimationOld.reset();
             setZoom(mTargetZoomLevel);
         }
+        mMapView.invalidate();
     }
 
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)


### PR DESCRIPTION
Thank you @InI4 for this bug fix suggestion.

Impacted classes:
* `MapController`: added an explicit call to `invalidate` after animation, in method `onAnimationEnd`