### PR TITLE
osmdroid-third-party: build.gradle workaround about google play-services

### DIFF
--- a/GoogleWrapperSample/build.gradle
+++ b/GoogleWrapperSample/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     testCompile "junit:junit:${project.property('junit.version')}"
     compile 'com.android.support:appcompat-v7:23.+'
     //this covers google maps v2 apis
-    compile 'com.google.android.gms:play-services:8.+'
+    //compile 'com.google.android.gms:play-services:8.+'
 
     compile 'com.google.android.gms:play-services-maps:8.+'
 

--- a/osmdroid-third-party/build.gradle
+++ b/osmdroid-third-party/build.gradle
@@ -17,6 +17,6 @@ dependencies {
     compile project(':osmdroid-android')
     //compile(group: 'org.apache.james', name: 'apache-mime4j', version: '0.6') {}
 
-    compile 'com.google.android.gms:play-services:8.+'
+//    compile 'com.google.android.gms:play-services:8.+'
     compile 'com.google.android.gms:play-services-maps:8.+'
 }


### PR DESCRIPTION
> A problem occurred configuring project ':GoogleWrapperSample'.
A problem occurred configuring project ':osmdroid-third-party'.
Could not find play-services.jar (com.google.android.gms:play-services:8.4.0).
Searched in the following locations:
https://jcenter.bintray.com/com/google/android/gms/play-services/8.4.0/play-services-8.4.0.jar

Impacted file:
* `build.gradle`: removed the line about play-services