### PR TITLE
Feature/#1058

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,25 +50,25 @@ env:
     
     matrix:
     - API=10 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default
-    #- API=10 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
-    #- API=14 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default     # emulator consistently times out
-    - API=15 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default
-    #- API=15 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
-    - API=16 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default
-    - API=17 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default
-    #- API=17 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
-    - API=18 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default
-    #- API=18 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
+    #- API=10 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis     # currently not needed
+    #- API=14 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default         # emulator consistently times out
+    #- API=15 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default         # https://github.com/osmdroid/osmdroid/issues/1066
+    #- API=15 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis     # currently not needed
+    #- API=16 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default         # https://github.com/osmdroid/osmdroid/issues/1065
+    #- API=17 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default         # https://github.com/osmdroid/osmdroid/issues/1065
+    #- API=17 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis     # currently not needed
+    #- API=18 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default         # https://github.com/osmdroid/osmdroid/issues/1065
+    #- API=18 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis     # currently not needed
     - API=19 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default
     - API=21 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default
-    #- API=21 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
-    - API=22 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default
-    #- API=22 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
-    #- API=23 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default      # sdkmanager --list reports this to be available, but image is not found during build
-    - API=23 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
-    - API=24 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default
-    #- API=24 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis  # emulator consistently times out
-    #- API=25 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis  # no addons available, so can't be used
+    #- API=21 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis     # currently not needed
+    #- API=22 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default         # com.android.ddmlib.InstallException: Failed to finalize session : INSTALL_FAILED_DEXOPT: Package couldn't be installed in /data/app/org.osmdroid-2: scanPackageLI
+    #- API=22 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis     # currently not needed
+    #- API=23 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default         # sdkmanager --list reports this to be available, but image is not found during build
+    #- API=23 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis     # Unable to install /home/travis/build/cbalster/osmdroid/OpenStreetMapViewer/build/outputs/apk/OpenStreetMapViewer-6.0.2-SNAPSHOT-debug.apk com.android.ddmlib.InstallException: Failed to establish session
+    #- API=24 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default         # "The command "adb shell ls /" failed and exited with 1 during." see line 108
+    #- API=24 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis     # emulator consistently times out
+    #- API=25 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis     # no addons available, so can't be used
 
 before_install:
   # create and start emulators; automatically downloads required platform and - if necessary - the google api addons

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,49 +1,29 @@
 language: android
-jdk: openjdk7
+jdk: openjdk8
 android:
   components:
-    # The BuildTools version used by your project
     - tools
     - platform-tools
-    - build-tools-23.0.2 # 23.0.2 was not available on build
-    - build-tools-23.0.1
-    - build-tools-23.0.3
-    # The SDK version used to compile your project
-    - android-24
-    - android-23
-    - android-22
-    - android-21
-    - android-19
-    - android-18
-    - android-15
-    - android-10
-    - android-8
-    - addon-google_apis-google-10
-    - addon-google_apis-google-15
-    - addon-google_apis-google-18
-    - addon-google_apis-google-19
-    - addon-google_apis-google-21
-    - addon-google_apis-google-22
-    - addon-google_apis-google-23
-    - addon-google_apis-google-8
-    - sys-img-armeabi-v7a-google_apis-23
+    - tools
 
-    # Additional components
-    - extra-google-google_play_services
-    - extra-google-m2repository
-    - extra-android-m2repository
-    - addon-google_apis-google-19
-    - sys-img-armeabi-android-8
-    - sys-img-armeabi-android-10
-    - sys-img-armeabi-android-15
-    - sys-img-armeabi-android-19
-    - sys-img-armeabi-android-21
-    - sys-img-armeabi-v7a-android-10
-    - sys-img-armeabi-v7a-google_apis-19
-    - sys-img-armeabi-v7a-google_apis-21
-    - sys-img-armeabi-v7a-google_apis-15
-    - sys-img-armeabi-v7a-google_apis-23
+    # The BuildTools version used by your project
+    - build-tools-23.0.3
+
+    # The SDK version used to compile your project
+    # 
+    # "addon-google_apis-google-*" is only required when google apis are used
+    #
+    # Note: Don't add the platforms or addons required for the emulators here.
+    #       Those are automatically downloaded in "before_install" on a per worker basis.
+    #
+    
+    - android-23
     - addon-google_apis-google-23
+    
+    # Additional components - currently not required
+    #- extra-google-m2repository #contains constraintlayout
+    #- extra-android-m2repository
+    #- extra-google-google_play_services
 
 sudo: required
 
@@ -54,30 +34,56 @@ env:
     #minutes (2 minutes by default), prevents CommandShellUnresponsiveExceptions
     - ADB_INSTALL_TIMEOUT=14
 
+    # setup of emulators this will be tested on
+    #
+    # API:         Desired API level of the emulator
+    # ANDROID_ABI: Currently either "armeabi" (only needed for API8) or "armeabi-v7a"
+    # ANDROID_TAG: Either "default" or "google_apis" if play services are used
+    #
+    # Below list was generated in June 2018. To get an up to date list of available options run "sdkmanager --list"
+    #
+    # Note: Currently (June 2018) there are no arm images for API > 25 provided by google.
+    #       This is unlikely to change in the future due to the new emulator supporting
+    #       (and requiring!) hardware acceleration for x86.
+    #       Unfortunately Travis has no solution yet for providing KVM on the worker machines
+    #       so running API25 and up emulators is not possible right now.
+    
     matrix:
-    #note when changing these, updating the gradle build file for the GoogleWrapper project
-    # first env var is just for display purposes
-    - API=8g ANDROID_TARGET=11  ANDROID_ABI=armeabi
-    - API=8 ANDROID_TARGET=1  ANDROID_ABI=armeabi
-    - API=10 ANDROID_TARGET=2  ANDROID_ABI=armeabi
-    # - API=19 ANDROID_TARGET=5  ANDROID_ABI=google_apis/armeabi-v7a
-    # (above) stopped working sept 2017 unknown reason
-    # - API=15 ANDROID_TARGET=3  ANDROID_ABI=google_apis/armeabi-v7a
-    # (above) stopped working sept 2017 unknown reason
-    # - API=10g ANDROID_TARGET=12  ANDROID_ABI=armeabi
-    # (above) stopped working sept 2017 unknown reason, the emulator says google services aren't installed
-    # - API=15g ANDROID_TARGET=13  ANDROID_ABI=armeabi-v7a
-    # (above) stopped working sept 2017 unknown reason
+    - API=10 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default
+    - API=10 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
+    #- API=14 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default     # emulator consistently times out
+    - API=15 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default
+    - API=15 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
+    - API=16 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default
+    - API=17 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default
+    - API=17 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
+    - API=18 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default
+    - API=18 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
+    - API=19 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default
+    - API=21 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default
+    - API=21 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
+    - API=22 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default
+    - API=22 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
+    #- API=23 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default      # sdkmanager --list reports this to be available, but image is not found during build
+    - API=23 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
+    - API=24 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default
+    #- API=24 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis  # emulator consistently times out
+    #- API=25 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis  # no addons available, so can't be used
 
 before_install:
-  # create and start emulators
-  - export ANDROID_SDK_ROOT=/usr/local/android-sdk/
-  - android list targets
-  - echo android create avd --force -n test$ANDROID_TARGET -t $ANDROID_TARGET --abi $ANDROID_ABI --sdcard 200M
-  - echo no | android create avd --force -n test$ANDROID_TARGET -t $ANDROID_TARGET --abi $ANDROID_ABI --sdcard 200M
-  - emulator -memory 1536 -avd test$ANDROID_TARGET -no-skin -no-audio -no-window &
-  - android-wait-for-emulator
-  - adb shell input keyevent 82 &
+  # create and start emulators; automatically downloads required platform and - if necessary - the google api addons
+  - echo yes | sdkmanager "tools" "platforms;android-$API"
+  - if [ $ANDROID_TAG == "google_apis" ]; then echo yes | sdkmanager "add-ons;addon-google_apis-google-$API"; fi
+  - echo yes | sdkmanager "system-images;android-$API;$ANDROID_TAG;$ANDROID_ABI"
+  - avdmanager list
+  - echo avdmanager create avd -f -n test-api$API -k "system-images;android-$API;$ANDROID_TAG;$ANDROID_ABI" -c 200M
+  - echo no | avdmanager create avd -f -n test-api$API -k "system-images;android-$API;$ANDROID_TAG;$ANDROID_ABI" -c 200M
+  - $ANDROID_HOME/emulator/emulator -memory 1536 -avd test-api$API -no-window -no-audio&
+  
+install:
+  # run build while emulator is starting up
+  - ./gradlew -version
+  - ./gradlew clean assemble assembleAndroidTest
 
 # mvn sdk deploy
 before_script:
@@ -93,6 +99,9 @@ before_script:
 
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
+  
+  # output date/time set on emulator for diagnostics
+  - adb shell date
 
   #setup for maps forge adapter
   #- wget http://download.mapsforge.org/maps/world/world.map
@@ -107,11 +116,12 @@ before_script:
   - adb push testzoom4.sqlite /sdcard/osmdroid/testzoom4.sqlite
   - adb push testzoom4.zip /sdcard/osmdroid/testzoom4.zip
   - adb push testzoom4.gemf /sdcard/osmdroid/testzoom4.gemf
+  
   #maybe one day it will be added to the repo- adb push ERDC_Whitehorse_GeoPackage.gpkg /sdcard/osmdroid/ERDC_Whitehorse_GeoPackage.gpkg
   #- adb push resources/usgsbase.gemf /sdcard/osmdroid/usgsbase.gemf
   #- adb push resources/usgstopo.sqlite /sdcard/osmdroid/usgstopo.sqlite
   #- adb push resources/usgssat.zip /sdcard/osmdroid/usgssat.zip
-
+  
 #build
 script:
   #build using maven with integration tests
@@ -122,12 +132,9 @@ script:
   #- mvn install -fn -B -U -Pdist
   #- mvn install -Pdist
   #- mvn android:undeploy
-  #build using gradle
-  # travis_wait 30 https://docs.travis-ci.com/user/common-build-problems/#My-builds-are-timing-out
-  - ./gradlew -version
-  - echo $JAVA_HOME
-  - export JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64
-  - travis_wait 60 ./gradlew clean install connectedCheck
+
+  #run tests 
+  - travis_wait 60 ./gradlew check connectedCheck
   # fun fact, maven runs android tests concurrently for all connected devices, gradle does not
   # since we're using build matrix, each build target compiles the source, fires up it's specific vm, runs the tests, then exits.
   # --stacktrace

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ android:
     #
     
     - android-23
-    - addon-google_apis-google-23
+    #- addon-google_apis-google-23
     
     # Additional components - currently not required
     #- extra-google-m2repository #contains constraintlayout
@@ -50,20 +50,20 @@ env:
     
     matrix:
     - API=10 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default
-    - API=10 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
+    #- API=10 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
     #- API=14 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default     # emulator consistently times out
     - API=15 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default
-    - API=15 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
+    #- API=15 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
     - API=16 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default
     - API=17 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default
-    - API=17 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
+    #- API=17 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
     - API=18 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default
-    - API=18 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
+    #- API=18 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
     - API=19 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default
     - API=21 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default
-    - API=21 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
+    #- API=21 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
     - API=22 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default
-    - API=22 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
+    #- API=22 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
     #- API=23 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default      # sdkmanager --list reports this to be available, but image is not found during build
     - API=23 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
     - API=24 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default

--- a/GoogleWrapperSample/build.gradle
+++ b/GoogleWrapperSample/build.gradle
@@ -10,8 +10,8 @@ apply plugin: 'com.android.application'
 apply from: "https://raw.githubusercontent.com/gradle-fury/gradle-fury/v1.1.4/gradle/android-support.gradle"
 
 android {
-    compileSdkVersion 'Google Inc.:Google APIs:23'
-    buildToolsVersion "23.0.3"
+    buildToolsVersion "${project.property('android.buildToolsVersion')}"
+    compileSdkVersion "Google Inc.:Google APIs:${project.property('android.targetSdkVersion')}"
 
     defaultConfig {
         applicationId "org.osmdroid.google.sample"
@@ -27,22 +27,21 @@ android {
 
 dependencies {
     testCompile "junit:junit:${project.property('junit.version')}"
-    compile 'com.android.support:appcompat-v7:23.+'
+
+    compile "com.android.support:appcompat-v7:${project.property('android-support.version')}"
     //this covers google maps v2 apis
     //compile 'com.google.android.gms:play-services:8.+'
 
     compile 'com.google.android.gms:play-services-maps:8.+'
 
-    compile 'com.android.support:support-v4:23+'
-    compile 'com.android.support:appcompat-v7:23.1.1'
+    compile "com.android.support:support-v4:${project.property('android-support.version')}"
+    compile "com.android.support:appcompat-v7:${project.property('android-support.version')}"
     compile project(':osmdroid-android')
     compile project(':osmdroid-third-party')
 
-    androidTestCompile 'com.android.support:support-annotations:23+'
     androidTestCompile 'com.android.support.test:runner:0.4.+'
     androidTestCompile 'com.android.support.test:rules:0.4.+'
-
-
+    androidTestCompile "com.android.support:support-annotations:${project.property('android-support.version')}"
 }
 
 project.gradle.taskGraph.whenReady {

--- a/GoogleWrapperSample/build.gradle
+++ b/GoogleWrapperSample/build.gradle
@@ -46,20 +46,20 @@ dependencies {
 
 project.gradle.taskGraph.whenReady {
     //this is just for Travis CI builds, since this package needs at least api 9 with google apis
-    //ignore the following build targets 1,2,3,7, 12
-    if (System.getenv("API")!=null) {
-        String apistring = System.getenv("API");
-        if (apistring.contains("g")) {
-            int api = Integer.parseInt(System.getenv("API").replace("g", "").trim());
+    if (System.getenv("API") != null && System.getenv("ANDROID_TAG") != null) {
+        String apistring = System.getenv("API")
+        String tag = System.getenv("ANDROID_TAG")
+        if (tag.contains("google_apis")) {
+            int api = Integer.parseInt(apistring.trim())
             if (api < 9) {
-                println "Skipping GoogleWrapperSample instrumentation test since the API level doesn't match this project"
-                installDebug { actions = []; }
-                connectedDebugAndroidTest { actions = []; }
+                println "Skipping GoogleWrapperSample instrumentation test since system image API level is < 9"
+                installDebug { actions = [] }
+                connectedDebugAndroidTest { actions = [] }
             }
         } else {
-            println "Skipping GoogleWrapperSample instrumentation test since the API level doesn't match this project"
-            installDebug { actions = []; }
-            connectedDebugAndroidTest { actions = []; }
+            println "Skipping GoogleWrapperSample instrumentation test since system image doesn't have google APIs"
+            installDebug { actions = [] }
+            connectedDebugAndroidTest { actions = [] }
         }
     }
 

--- a/OpenStreetMapViewer/build.gradle
+++ b/OpenStreetMapViewer/build.gradle
@@ -27,7 +27,7 @@ android {
 
 
 dependencies {
-    compile 'com.android.support:support-v4:23+'
+    compile "com.android.support:support-v4:${project.property('android-support.version')}"
     compile project(':osmdroid-android')
     compile project(':osmdroid-geopackage')
     compile project(':osmdroid-mapsforge')
@@ -37,10 +37,10 @@ dependencies {
 
     compile 'com.github.angads25:filepicker:1.1.1'
 
-    compile 'com.android.support:design:23.+' //needed for UI menuing
-    compile 'com.android.support:cardview-v7:23.+'  //needed for samples only
-    compile 'com.android.support:recyclerview-v7:23.+' //needed for samples only
-    compile 'com.android.support:appcompat-v7:23.+' //needed for UI menuing
+    compile "com.android.support:design:${project.property('android-support.version')}" //needed for UI menuing
+    compile "com.android.support:cardview-v7:${project.property('android-support.version')}"  //needed for samples only
+    compile "com.android.support:recyclerview-v7:${project.property('android-support.version')}" //needed for samples only
+    compile "com.android.support:appcompat-v7:${project.property('android-support.version')}" //needed for UI menuing
     //crash logging
     compile 'ch.acra:acra:4.7.0'
 
@@ -50,9 +50,9 @@ dependencies {
     testCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.4-beta2'
 
     //on device testing
-    androidTestCompile 'com.android.support:support-annotations:23+'
     androidTestCompile 'com.android.support.test:runner:0.4.+'
     androidTestCompile 'com.android.support.test:rules:0.4.+'
+    androidTestCompile "com.android.support:support-annotations:${project.property('android-support.version')}"
 }
 
 

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/bugtestfragments/Bug512CacheManagerWp.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/bugtestfragments/Bug512CacheManagerWp.java
@@ -1,12 +1,12 @@
 package org.osmdroid.bugtestfragments;
 
-import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
+import android.widget.LinearLayout;
 
 import junit.framework.Assert;
 
@@ -16,7 +16,6 @@ import org.osmdroid.samplefragments.BaseSampleFragment;
 import org.osmdroid.tileprovider.MapTileProviderBasic;
 import org.osmdroid.tileprovider.cachemanager.CacheManager;
 import org.osmdroid.tileprovider.tilesource.OnlineTileSourceBase;
-import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
 import org.osmdroid.tileprovider.tilesource.XYTileSource;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.MapView;
@@ -42,27 +41,27 @@ public class Bug512CacheManagerWp extends BaseSampleFragment implements CacheMan
 
         View root = inflater.inflate(R.layout.sample_cachemgr, container,false);
 
-        mMapView = (MapView) root.findViewById(R.id.mapview);
         btnCache = (Button) root.findViewById(R.id.btnCache);
         btnCache.setOnClickListener(this);
         btnCache.setText("Run job (watch logcat output)");
 
-        OnlineTileSourceBase onlineTileSourceBase = TileSourceFactory.MAPNIK;
-
         // Workaround for failing unit test due to issues with https connections on API < 9
         // https://github.com/osmdroid/osmdroid/issues/1048
         // https://github.com/osmdroid/osmdroid/issues/1051
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.GINGERBREAD) {
-            onlineTileSourceBase = new XYTileSource("Mapnik",
+        // Also works around an issue with some emulator image that do not update their time/date
+        // correctly and stay on 0 unix time. This causes SSLExceptions due to the validity of the
+        // certificates.
+        OnlineTileSourceBase onlineTileSourceBase = new XYTileSource("Mapnik",
                     0, 19, 256, ".png",
                     new String[]{
                             "http://a.tile.openstreetmap.org/",
                             "http://b.tile.openstreetmap.org/",
                             "http://c.tile.openstreetmap.org/"}, "© OpenStreetMap contributors");
-        }
 
-        mMapView.setTileProvider(new MapTileProviderBasic(
+        mMapView = new MapView(getActivity(), new MapTileProviderBasic(
                 getActivity().getApplicationContext(), onlineTileSourceBase));
+
+        ((LinearLayout) root.findViewById(R.id.mapview)).addView(mMapView);
 
         return root;
     }

--- a/OpenStreetMapViewer/src/main/res/layout/sample_cachemgr.xml
+++ b/OpenStreetMapViewer/src/main/res/layout/sample_cachemgr.xml
@@ -4,10 +4,11 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent" >
 
-    <org.osmdroid.views.MapView
+    <LinearLayout
         android:id="@+id/mapview"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="match_parent"
+        android:orientation="horizontal" />
 
     <Button android:id="@+id/btnCache"
         android:layout_width="fill_parent"

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ org.gradle.configureondemand true
 # "Specifies the jvmargs used for the daemon process.  The setting is particularly useful for
 #  tweaking memory settings.  At the moment, the default settings are pretty generous with regards
 #  to memory."
-org.gradle.jvmargs=-Xms256m -Xmx1024m -XX:MaxPermSize=256m
+org.gradle.jvmargs=-Xms256m -Xmx2048m -XX:MaxPermSize=256m
 
 
 # Dependency version configurations ----------------------------------------------------------------

--- a/osmdroid-android-it/src/main/java/org/osmdroid/views/util/OpenStreetMapTileProviderDirectTest.java
+++ b/osmdroid-android-it/src/main/java/org/osmdroid/views/util/OpenStreetMapTileProviderDirectTest.java
@@ -29,7 +29,6 @@ import android.graphics.Paint;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
-import android.os.Environment;
 import android.os.RemoteException;
 import android.test.AndroidTestCase;
 
@@ -70,9 +69,8 @@ public class OpenStreetMapTileProviderDirectTest extends AndroidTestCase {
 		if (Build.VERSION.SDK_INT >=23)
 			return;
 
-		//this can fail if storage permissions isn't available.
 		// create a bitmap, draw something on it, write it to a file and put it in the cache
-		String path = Environment.getExternalStorageDirectory().getAbsolutePath() + File.separator + "osmdroid" + File.separator;
+		String path = getContext().getFilesDir().getAbsolutePath() + File.separator + "osmdroid" + File.separator;
 
 		File temp= new File(path);
 		if (!temp.exists())
@@ -90,7 +88,7 @@ public class OpenStreetMapTileProviderDirectTest extends AndroidTestCase {
 		try {
 			f.createNewFile();
 			final FileOutputStream fos = new FileOutputStream(path);
-			bitmap1.compress(CompressFormat.JPEG, 100, fos);
+			bitmap1.compress(CompressFormat.PNG, 100, fos);
 			fos.close();
 		}catch (Exception ex){
 			ex.printStackTrace();

--- a/osmdroid-simple-map/build.gradle
+++ b/osmdroid-simple-map/build.gradle
@@ -12,7 +12,7 @@ android {
 
 
 dependencies {
-    compile 'com.android.support:support-v4:23+'
+    compile "com.android.support:support-v4:${project.property('android-support.version')}"
     compile project(':osmdroid-android')
 
 }

--- a/osmdroid-third-party/build.gradle
+++ b/osmdroid-third-party/build.gradle
@@ -9,8 +9,8 @@ description = 'DEPRECATED osmdroid 3rd party libraries and examples. May use non
 apply plugin: 'com.android.library'
 apply from: "https://raw.githubusercontent.com/gradle-fury/gradle-fury/v1.1.4/gradle/android-support.gradle"
 android {
-    compileSdkVersion "Google Inc.:Google APIs:23"
-    buildToolsVersion "23.0.3"
+    compileSdkVersion "Google Inc.:Google APIs:${project.property('android.targetSdkVersion')}"
+    buildToolsVersion "${project.property('android.buildToolsVersion')}"
     defaultConfig {
         minSdkVersion 9
     }


### PR DESCRIPTION
closes #1058, closes #1061 

Sorry for the rather broad PR.
Basically this is a big overhaul of the travis buildscript + some minor fixes for existing tests.
Key points: Build times down to ~15 mins and working newer test targets (10, 19, 21). Others can be enabled when a couple of issues are worked out (see comments behind configs in `travis.yml` and issues #1065 and #1066 ).
I had to drop the API8 test target though, since it is no longer available on google servers.

For details see the individual commit messages.
