### PR TITLE
bug/#1076 - rolling back to MapView in xml

### DIFF
--- a/OpenStreetMapViewer/src/main/res/layout/sample_cachemgr.xml
+++ b/OpenStreetMapViewer/src/main/res/layout/sample_cachemgr.xml
@@ -4,11 +4,10 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent" >
 
-    <LinearLayout
+    <org.osmdroid.views.MapView
         android:id="@+id/mapview"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="horizontal" />
+        android:layout_height="match_parent"/>
 
     <Button android:id="@+id/btnCache"
         android:layout_width="fill_parent"


### PR DESCRIPTION
Impacted file:
* `sample_cachemgr.xml`: rolled back to `MapView` instead of the recent `LinearLayout` change, as the corresponding code didn't take the same path and that caused an ANR (casting a `LinearLayout` as a `MapView`)