### PR TITLE
#1065 Fix handling of reusable bitmaps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,10 +54,10 @@ env:
     #- API=14 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default         # emulator consistently times out
     #- API=15 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default         # https://github.com/osmdroid/osmdroid/issues/1066
     #- API=15 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis     # currently not needed
-    #- API=16 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default         # https://github.com/osmdroid/osmdroid/issues/1065
-    #- API=17 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default         # https://github.com/osmdroid/osmdroid/issues/1065
+    - API=16 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default         # https://github.com/osmdroid/osmdroid/issues/1065
+    - API=17 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default         # https://github.com/osmdroid/osmdroid/issues/1065
     #- API=17 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis     # currently not needed
-    #- API=18 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default         # https://github.com/osmdroid/osmdroid/issues/1065
+    - API=18 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default         # https://github.com/osmdroid/osmdroid/issues/1065
     #- API=18 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis     # currently not needed
     - API=19 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default
     - API=21 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default

--- a/osmdroid-android-it/src/main/java/org/osmdroid/views/util/OpenStreetMapTileProviderDirectTest.java
+++ b/osmdroid-android-it/src/main/java/org/osmdroid/views/util/OpenStreetMapTileProviderDirectTest.java
@@ -80,7 +80,10 @@ public class OpenStreetMapTileProviderDirectTest extends AndroidTestCase {
 		File f = new File(path);
 		if (f.exists())
 			f.delete();
-		final Bitmap bitmap1 = Bitmap.createBitmap(60, 30, Config.ARGB_8888);
+		final Bitmap bitmap1 = Bitmap.createBitmap(
+				TileSourceFactory.MAPNIK.getTileSizePixels(),
+				TileSourceFactory.MAPNIK.getTileSizePixels(),
+				Config.ARGB_8888);
 		bitmap1.eraseColor(Color.YELLOW);
 		final Canvas canvas = new Canvas(bitmap1);
 

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/BitmapPool.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/BitmapPool.java
@@ -116,7 +116,7 @@ public class BitmapPool {
 		if (pDrawable == null) {
 			return;
 		}
-		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.GINGERBREAD) {
+		if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.GINGERBREAD_MR1) {
 			if (pDrawable instanceof BitmapDrawable) {
 				final Bitmap bitmap = ((BitmapDrawable) pDrawable).getBitmap();
 				if (bitmap != null) {

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/BitmapPool.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/BitmapPool.java
@@ -9,7 +9,9 @@ import android.graphics.BitmapFactory;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
+import android.util.Log;
 
+import org.osmdroid.api.IMapView;
 import org.osmdroid.tileprovider.modules.ConfigurablePriorityThreadFactory;
 
 public class BitmapPool {
@@ -30,10 +32,13 @@ public class BitmapPool {
 
 	public void returnDrawableToPool(ReusableBitmapDrawable drawable) {
 		Bitmap b = drawable.tryRecycle();
-		if (b != null && b.isMutable())
+		if (b != null && !b.isRecycled() && b.isMutable() && b.getConfig() != null) {
 			synchronized (mPool) {
 				mPool.addLast(b);
 			}
+		} else if (b != null) {
+			Log.d(IMapView.LOGTAG, "Rejected bitmap from being added to BitmapPool.");
+		}
 	}
 
 	public void applyReusableOptions(final BitmapFactory.Options aBitmapOptions) {

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/BitmapPool.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/BitmapPool.java
@@ -41,14 +41,37 @@ public class BitmapPool {
 		}
 	}
 
+	/**
+	 * @deprecated As of 6.0.2, use
+	 *             {@link #applyReusableOptions(BitmapFactory.Options, int, int)} instead.
+	 */
+	@Deprecated
 	public void applyReusableOptions(final BitmapFactory.Options aBitmapOptions) {
+		// We can not guarantee a bitmap can be reused without knowing the dimensions, so always
+		// return null in inBitmap
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-			aBitmapOptions.inBitmap = obtainBitmapFromPool();
+			aBitmapOptions.inBitmap = null;
 			aBitmapOptions.inSampleSize = 1;
 			aBitmapOptions.inMutable = true;
 		}
 	}
 
+	public void applyReusableOptions(final BitmapFactory.Options aBitmapOptions, final int width, final int height) {
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+			// This could be optimized for KK and up, as from there on the only requirement is that
+			// the reused bitmap's allocatedbytes are >= the size of new one. Since the pool is
+			// almost only used for tiles of the same dimensions, the gains will probably be small.
+			aBitmapOptions.inBitmap = obtainSizedBitmapFromPool(width, height);
+			aBitmapOptions.inSampleSize = 1;
+			aBitmapOptions.inMutable = true;
+		}
+	}
+
+	/**
+	 * @deprecated As of 6.0.2, use
+	 *             {@link #obtainSizedBitmapFromPool(int, int)} instead.
+	 */
+	@Deprecated
 	public Bitmap obtainBitmapFromPool() {
 		synchronized (mPool) {
 			if (mPool.isEmpty()) {

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/BitmapTileSourceBase.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/BitmapTileSourceBase.java
@@ -112,7 +112,8 @@ public abstract class BitmapTileSourceBase implements ITileSource {
 			// default implementation will load the file as a bitmap and create
 			// a BitmapDrawable from it
 			BitmapFactory.Options bitmapOptions = new BitmapFactory.Options();
-			BitmapPool.getInstance().applyReusableOptions(bitmapOptions);
+			BitmapPool.getInstance().applyReusableOptions(
+					bitmapOptions, mTileSizePixels, mTileSizePixels);
 			final Bitmap bitmap;
 			//fix for API 15 see https://github.com/osmdroid/osmdroid/issues/227
 			if (Build.VERSION.SDK_INT == Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1)
@@ -166,7 +167,8 @@ public abstract class BitmapTileSourceBase implements ITileSource {
 			// default implementation will load the file as a bitmap and create
 			// a BitmapDrawable from it
 			BitmapFactory.Options bitmapOptions = new BitmapFactory.Options();
-			BitmapPool.getInstance().applyReusableOptions(bitmapOptions);
+			BitmapPool.getInstance().applyReusableOptions(
+					bitmapOptions, mTileSizePixels, mTileSizePixels);
 			final Bitmap bitmap = BitmapFactory.decodeStream(aFileInputStream, null, bitmapOptions);
 			if (bitmap != null) {
 				return new ReusableBitmapDrawable(bitmap);


### PR DESCRIPTION
closes #1065 

So the problem was that on 10 < API < 19 the BitmapPool returned bitmaps for reuse without checking if size is identical, which is a hard requirement before API 19. This was unlikely to show up in production apps since most bitmaps are tiles which have identical sizes anyway.

With this change, we have to trust that the tilesize in the different `ITileSource`s is correct. Determining the size from the file or inputstream would add significant overhead.
