### PR TITLE
feature/#1104 - more explicit Marker.setIcon methods and anchor setting fix

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/IISTrackerBase.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/IISTrackerBase.java
@@ -64,7 +64,7 @@ public abstract class IISTrackerBase extends SampleGridlines {
 
         marker = new Marker(mMapView);
         marker.setImage(image);
-        marker.setIcon(icon);
+        marker.setDrawableIcon(icon);
         marker.setTitle("International Space Station");
 
 
@@ -110,7 +110,7 @@ public abstract class IISTrackerBase extends SampleGridlines {
 
                                         marker = new Marker(mMapView);
                                         marker.setImage(image);
-                                        marker.setIcon(icon);
+                                        marker.setDrawableIcon(icon);
                                         marker.setTitle("International Space Station");
                                         marker.setPosition(location);
                                         mMapView.getController().setCenter(location);

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleMarker.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleMarker.java
@@ -33,7 +33,7 @@ public class SampleMarker extends BaseSampleFragment {
         Marker startMarker = new Marker(mMapView);
         startMarker.setPosition(startPoint);
         startMarker.setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM);
-        startMarker.setIcon(getResources().getDrawable(R.drawable.icon));
+        startMarker.setDrawableIcon(getResources().getDrawable(R.drawable.icon));
         startMarker.setTitle("White House");
         startMarker.setSnippet("The White House is the official residence and principal workplace of the President of the United States.");
         startMarker.setSubDescription("1600 Pennsylvania Ave NW, Washington, DC 20500");
@@ -43,7 +43,7 @@ public class SampleMarker extends BaseSampleFragment {
         startMarker = new Marker(mMapView);
         startMarker.setPosition(startPoint);
         startMarker.setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM);
-        startMarker.setIcon(getResources().getDrawable(R.drawable.icon));
+        startMarker.setDrawableIcon(getResources().getDrawable(R.drawable.icon));
         startMarker.setTitle("Pentagon");
         startMarker.setSnippet("The Pentagon.");
         startMarker.setSubDescription("The Pentagon is the headquarters of the United States Department of Defense.");
@@ -62,7 +62,7 @@ public class SampleMarker extends BaseSampleFragment {
         startMarker = new Marker(mMapView);
         startMarker.setPosition(startPoint);
         startMarker.setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM);
-        startMarker.setIcon(getResources().getDrawable(R.drawable.icon));
+        startMarker.setDrawableIcon(getResources().getDrawable(R.drawable.icon));
         startMarker.setTitle("Washington Monument");
         startMarker.setSnippet("Washington Monument.");
         startMarker.setSubDescription("Washington Monument.");

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleMilitaryIconsMarker.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleMilitaryIconsMarker.java
@@ -139,7 +139,7 @@ public class SampleMilitaryIconsMarker extends BaseSampleFragment {
                }
                m.setSnippet("A random point");
                m.setSubDescription("location: " + random_lat + "," + random_lon);
-               m.setIcon(icons.get(index));
+               m.setDrawableIcon(icons.get(index));
                mMapView.getOverlayManager().add(m);
           }
 

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleOsmPath.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleOsmPath.java
@@ -116,7 +116,7 @@ public class SampleOsmPath extends BaseSampleFragment implements MapListener {
 		marker.setPosition(new GeoPoint(((40.796788-40.768094)/2)+40.768094,
 				((-73.949232- -73.981762)/2) +  -73.981762));
 		marker.setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM);
-		marker.setIcon(getResources().getDrawable(R.drawable.sfgpuci));
+		marker.setDrawableIcon(getResources().getDrawable(R.drawable.sfgpuci));
 		marker.setTitle("Start point");
 		marker.setDraggable(true);
 		mMapView.getOverlays().add(marker);

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/drawing/IconPlottingOverlay.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/drawing/IconPlottingOverlay.java
@@ -60,7 +60,7 @@ public class IconPlottingOverlay extends Overlay {
 
             Marker m = new Marker(mapView);
             m.setPosition(pt);
-            m.setIcon(markerIcon);
+            m.setDrawableIcon(markerIcon);
             m.setImage(markerIcon);
             m.setTitle("A demo title");
             m.setSubDescription("A demo sub description\n" + pt.getLatitude() + "," + pt.getLongitude());

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/layers/LayerManager.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/layers/LayerManager.java
@@ -134,7 +134,7 @@ public class LayerManager extends BaseSampleFragment {
         Marker startMarker = new Marker(mMapView);
         startMarker.setPosition(startPoint);
         startMarker.setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM);
-        startMarker.setIcon(getResources().getDrawable(R.drawable.icon));
+        startMarker.setDrawableIcon(getResources().getDrawable(R.drawable.icon));
         startMarker.setTitle("White House");
         startMarker.setSnippet("The White House is the official residence and principal workplace of the President of the United States.");
         startMarker.setSubDescription("1600 Pennsylvania Ave NW, Washington, DC 20500");
@@ -144,7 +144,7 @@ public class LayerManager extends BaseSampleFragment {
         startMarker = new Marker(mMapView);
         startMarker.setPosition(startPoint);
         startMarker.setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM);
-        startMarker.setIcon(getResources().getDrawable(R.drawable.icon));
+        startMarker.setDrawableIcon(getResources().getDrawable(R.drawable.icon));
         startMarker.setTitle("Pentagon");
         startMarker.setSnippet("The Pentagon.");
         startMarker.setSubDescription("The Pentagon is the headquarters of the United States Department of Defense.");
@@ -163,7 +163,7 @@ public class LayerManager extends BaseSampleFragment {
         startMarker = new Marker(mMapView);
         startMarker.setPosition(startPoint);
         startMarker.setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM);
-        startMarker.setIcon(getResources().getDrawable(R.drawable.icon));
+        startMarker.setDrawableIcon(getResources().getDrawable(R.drawable.icon));
         startMarker.setTitle("Washington Monument");
         startMarker.setSnippet("Washington Monument.");
         startMarker.setSubDescription("Washington Monument.");

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/location/SampleCustomMyLocation.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/location/SampleCustomMyLocation.java
@@ -36,7 +36,7 @@ public class SampleCustomMyLocation extends BaseSampleFragment implements Locati
     public void addOverlays() {
         super.addOverlays();
         myLocation = new Marker(mMapView);
-        myLocation.setIcon(getResources().getDrawable(org.osmdroid.R.drawable.icon));
+        myLocation.setDrawableIcon(getResources().getDrawable(org.osmdroid.R.drawable.icon));
         myLocation.setImage(getResources().getDrawable(org.osmdroid.R.drawable.icon));
 
 

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/milstd2525/MilStdMultipointOverlay.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/milstd2525/MilStdMultipointOverlay.java
@@ -238,15 +238,13 @@ public class MilStdMultipointOverlay extends Overlay {
                     }
                 } else {
                     //not a line or a polygon
-
-                    Marker.ENABLE_TEXT_LABELS_WHEN_NO_IMAGE = true;
                     Marker m = new Marker(map);
                     m.setTextLabelBackgroundColor(Color.WHITE.toInt());
                     m.setTextLabelFontSize(14);
                     m.setTextLabelForegroundColor(Color.BLACK.toInt());
                     m.setTitle(info.getModifierString());
                     m.setRotation((float) info.getModifierStringAngle());
-                    m.setIcon(null);
+                    m.setTitleIcon();
                     m.setPosition(new GeoPoint(info.getModifierStringPosition().getY(), info.getModifierStringPosition().getX()));
                     lastOverlay.getItems().add(m);
                 }

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/milstd2525/MilStdPointPlottingOverlay.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/milstd2525/MilStdPointPlottingOverlay.java
@@ -77,7 +77,7 @@ public class MilStdPointPlottingOverlay extends Overlay {
                 if (ii != null && ii.getImage() != null) {
                     BitmapDrawable d = new BitmapDrawable(ii.getImage());
                     m.setImage(d);
-                    m.setIcon(d);
+                    m.setDrawableIcon(d);
 
                     int centerX = ii.getCenterPoint().x;    //pixel center position
                     //calculate what percentage of the center this value is

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/milstd2525/Plotter.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/milstd2525/Plotter.java
@@ -299,7 +299,7 @@ public class Plotter extends SampleGridlines implements View.OnClickListener, Te
                 }
                 Drawable d = new BitmapDrawable(ii.getImage());
                 m.setImage(d);
-                m.setIcon(d);
+                m.setDrawableIcon(d);
                 int centerX = ii.getCenterPoint().x;    //pixel center position
                 //calculate what percentage of the center this value is
                 float realCenterX = (float) centerX / (float) ii.getImage().getWidth();

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Marker.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Marker.java
@@ -11,7 +11,6 @@ import android.graphics.Rect;
 import android.graphics.Typeface;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
-import android.os.Build;
 import android.view.MotionEvent;
 import android.util.TypedValue;
 
@@ -57,6 +56,7 @@ public class Marker extends OverlayWithIW {
 	 * that sets the image icon of a  marker to a text label if no image url was provided. It's also
 	 * used in a few other cases, such as placing a generic text label on the map
 	 */
+	@Deprecated
 	public static boolean ENABLE_TEXT_LABELS_WHEN_NO_IMAGE=false;
 
 	/* attributes for text labels, used for osmdroid gridlines */
@@ -67,6 +67,7 @@ public class Marker extends OverlayWithIW {
 	 * enables per Marker instance overrides for this setting
 	 * @since 6.0.0
 	 */
+	@Deprecated
 	protected boolean mEnableTextLabelsWhenNoImage=false;
 
 	/*attributes for standard features:*/
@@ -121,7 +122,7 @@ public class Marker extends OverlayWithIW {
 			mDefaultIcon = resourceProxy.getResources().getDrawable(R.drawable.marker_default);
 		mIcon = mDefaultIcon;
 		//set the offset
-		setAnchor(0.5f, 1.0f);
+		setAnchor(ANCHOR_CENTER, ANCHOR_BOTTOM);
 		if (mDefaultInfoWindow == null || mDefaultInfoWindow.getMapView() != mapView){
 			//build default bubble, that will be shared between all markers using the default one:
 			//(using the default layout included in the aar library)
@@ -135,43 +136,64 @@ public class Marker extends OverlayWithIW {
 	 *
 	 * Also use care and appropriately set the anchor point of the image. For the default
 	 * icon, it's the tip of the teardrop, other it will default to the center of the image.
-	 * @param icon if null, the default osmdroid marker is used. 
+	 * @param icon if null, the default osmdroid marker is used.
+	 * @deprecated Use {@link #setDrawableIcon(Drawable)}, {@link #setTitleIcon()},
+	 * {@link #setTextIcon(String)} or {@link #setDefaultIcon()} instead
 	 */
+	@Deprecated
 	public void setIcon(final Drawable icon){
 		if ((ENABLE_TEXT_LABELS_WHEN_NO_IMAGE || mEnableTextLabelsWhenNoImage) && icon==null && this.mTitle!=null && this.mTitle.length() > 0) {
-			Paint background = new Paint();
-			background.setColor(mTextLabelBackgroundColor);
-
-			Paint p = new Paint();
-			p.setTextSize(mTextLabelFontSize);
-			p.setColor(mTextLabelForegroundColor);
-
-			p.setAntiAlias(true);
-			p.setTypeface(Typeface.DEFAULT_BOLD);
-			p.setTextAlign(Paint.Align.LEFT);
-			int width=(int)(p.measureText(getTitle()) + 0.5f);
-			float baseline=(int)(-p.ascent() + 0.5f);
-			int height=(int) (baseline +p.descent() + 0.5f);
-			Bitmap image = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
-			Canvas c = new Canvas(image);
-			c.drawPaint(background);
-			c.drawText(getTitle(),0,baseline,p);
-
-			mIcon=new BitmapDrawable(mResources,image);
-			//set the offset
-			setAnchor(0.5f, 0.5f);
-		} else if (!mEnableTextLabelsWhenNoImage && !ENABLE_TEXT_LABELS_WHEN_NO_IMAGE && icon!=null) {
-			this.mIcon = icon;
-			//set the offset
-			setAnchor(0.5f, 0.5f);
+			setTitleIcon();
 		} else if (icon!=null) {
 			mIcon=icon;
 		} else {
-			//there's still an edge case here, title label not defined, icon is null and textlabel is enabled
-			mIcon = mDefaultIcon;
-			//set the offset
-			setAnchor(0.5f, 1.0f);
+			setDefaultIcon();
 		}
+	}
+
+	/**
+	 * @since 6.1.0
+	 */
+	public void setTitleIcon() {
+		setTextIcon(mTitle);
+	}
+
+	/**
+	 * @since 6.1.0
+	 */
+	public void setTextIcon(final String pText) {
+		final Paint background = new Paint();
+		background.setColor(mTextLabelBackgroundColor);
+		final Paint p = new Paint();
+		p.setTextSize(mTextLabelFontSize);
+		p.setColor(mTextLabelForegroundColor);
+		p.setAntiAlias(true);
+		p.setTypeface(Typeface.DEFAULT_BOLD);
+		p.setTextAlign(Paint.Align.LEFT);
+		final int width = (int) (p.measureText(getTitle()) + 0.5f);
+		final float baseline = (int) (-p.ascent() + 0.5f);
+		final int height = (int) (baseline + p.descent() + 0.5f);
+		final Bitmap image = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+		final Canvas c = new Canvas(image);
+		c.drawPaint(background);
+		c.drawText(getTitle(), 0, baseline, p);
+		mIcon = new BitmapDrawable(mResources, image);
+		setAnchor(ANCHOR_CENTER, ANCHOR_CENTER);
+	}
+
+	/**
+	 * @since 6.1.0
+	 */
+	public void setDrawableIcon(final Drawable pIcon) {
+		mIcon = pIcon;
+	}
+
+	/**
+	 * @since 6.1.0
+	 */
+	public void setDefaultIcon() {
+		mIcon = mDefaultIcon;
+		setAnchor(ANCHOR_CENTER, ANCHOR_BOTTOM);
 	}
 
 	/**
@@ -269,6 +291,7 @@ public class Marker extends OverlayWithIW {
 	 * @since 6.0.0
 	 * @return
 	 */
+	@Deprecated
 	public boolean isEnableTextLabelsWhenNoImage() {
 		return mEnableTextLabelsWhenNoImage;
 	}
@@ -277,6 +300,7 @@ public class Marker extends OverlayWithIW {
 	 * @since 6.0.0
 	 * @param mEnableTextLabelsWhenNoImage
 	 */
+	@Deprecated
 	public void setEnableTextLabelsWhenNoImage(boolean mEnableTextLabelsWhenNoImage) {
 		this.mEnableTextLabelsWhenNoImage = mEnableTextLabelsWhenNoImage;
 	}

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/gridlines/LatLonGridlineOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/gridlines/LatLonGridlineOverlay.java
@@ -50,9 +50,6 @@ public class LatLonGridlineOverlay {
         BoundingBox box = mapView.getBoundingBox();
         int zoom = mapView.getZoomLevel();
 
-        Marker.ENABLE_TEXT_LABELS_WHEN_NO_IMAGE = true;
-
-
         if (DEBUG) {
             System.out.println("######### getLatLonGrid ");
         }
@@ -159,7 +156,7 @@ public class LatLonGridlineOverlay {
                     m.setTitle(df.format(i) + "S");
                 }
                 //must set the icon last
-                m.setIcon(null);
+                m.setTitleIcon();
                 m.setPosition(new GeoPoint(i, west + incrementor));
                 gridlines.add(m);
             }
@@ -195,7 +192,7 @@ public class LatLonGridlineOverlay {
                     m.setTitle(df.format(i) + "W");
                 }
                 //must set the icon last
-                m.setIcon(null);
+                m.setTitleIcon();
                 m.setPosition(new GeoPoint(south + (incrementor), i));
                 gridlines.add(m);
             }
@@ -250,7 +247,7 @@ public class LatLonGridlineOverlay {
                         m.setTitle(df.format(i) + "W");
                     }
                     //must set the icon last
-                    m.setIcon(null);
+                    m.setTitleIcon();
                     m.setPosition(new GeoPoint(south + (incrementor), i));
                     gridlines.add(m);
                 }
@@ -268,7 +265,7 @@ public class LatLonGridlineOverlay {
                         m.setTitle(df.format(i) + "W");
                     }
                     //must set the icon last in order for the text label to show
-                    m.setIcon(null);
+                    m.setTitleIcon();
                     m.setPosition(new GeoPoint(south + (incrementor), i));
                     gridlines.add(m);
                 }

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/gridlines/LatLonGridlineOverlay2.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/gridlines/LatLonGridlineOverlay2.java
@@ -92,7 +92,6 @@ public class LatLonGridlineOverlay2 extends Overlay {
     }
 
     protected void applyMarkerAttributes(Marker m) {
-        m.setEnableTextLabelsWhenNoImage(true);
         m.setTextLabelBackgroundColor(mFontBackgroundColor);
         m.setTextLabelFontSize(mFontSizeDp);
         m.setTextLabelForegroundColor(mFontColor);
@@ -197,7 +196,7 @@ public class LatLonGridlineOverlay2 extends Overlay {
                     m.setTitle(mDecimalFormatter.format(i) + "S");
                 }
                 //must set the icon last
-                m.setIcon(null);
+                m.setTitleIcon();
                 m.setPosition(new GeoPoint(i, west + incrementor));
                 gridlines.add(m);
             }
@@ -231,7 +230,7 @@ public class LatLonGridlineOverlay2 extends Overlay {
                     m.setTitle(mDecimalFormatter.format(i) + "W");
                 }
                 //must set the icon last
-                m.setIcon(null);
+                m.setTitleIcon();
                 m.setPosition(new GeoPoint(south + (incrementor), i));
                 gridlines.add(m);
             }
@@ -276,7 +275,7 @@ public class LatLonGridlineOverlay2 extends Overlay {
                         m.setTitle(mDecimalFormatter.format(i) + "W");
                     }
                     //must set the icon last
-                    m.setIcon(null);
+                    m.setTitleIcon();
                     m.setPosition(new GeoPoint(south + (incrementor), i));
                     gridlines.add(m);
                 }
@@ -294,7 +293,7 @@ public class LatLonGridlineOverlay2 extends Overlay {
                         m.setTitle(mDecimalFormatter.format(i) + "W");
                     }
                     //must set the icon last in order for the text label to show
-                    m.setIcon(null);
+                    m.setTitleIcon();
                     m.setPosition(new GeoPoint(south + (incrementor), i));
                     gridlines.add(m);
                 }

--- a/osmdroid-geopackage/src/main/java/org/osmdroid/gpkg/overlay/OsmMapShapeConverter.java
+++ b/osmdroid-geopackage/src/main/java/org/osmdroid/gpkg/overlay/OsmMapShapeConverter.java
@@ -689,7 +689,7 @@ public class OsmMapShapeConverter {
         m.setPosition(latLng);
         if (options!=null) {
             if (options.getIcon()!=null){
-                m.setIcon(options.getIcon());
+                m.setDrawableIcon(options.getIcon());
             }
             m.setAlpha(options.getAlpha());
             m.setTitle(options.getTitle());


### PR DESCRIPTION
Impacted classes:
* `Marker`: deprecated static member `ENABLE_TEXT_LABELS_WHEN_NO_IMAGE`, member `mEnableTextLabelsWhenNoImage` and method `setIcon`; created methods `setTitleIcon`, `setTextIcon`, `setDrawableIcon` and `setDefaultIcon` that have more explicit names; fixed unexpected anchor setting; gently refactored
* `IconPlottingOverlay`, `IISTrackerBase`, `LatLonGridlineOverlay`, `LatLonGridlineOverlay2`, `LayerManager`, `MilStdMultipointOverlay`, `MilStdPointPlottingOverlay`, `OsmMapShapeConverter`, `Plotter`, `SampleCustomMyLocation`, `SampleMarker`, `SampleMilitaryIconsMarker`, `SampleOsmPath`: used `setTitleIcon` and `setDrawableIcon` instead of deprecated method `setIcon`; removed calls to `ENABLE_TEXT_LABELS_WHEN_NO_IMAGE` and `mEnableTextLabelsWhenNoImage`