### PR TITLE
bug/#1106 - extended "downgraded mode" to zoom range checks

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/tilesources/SampleLieFi.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/tilesources/SampleLieFi.java
@@ -137,10 +137,10 @@ public class SampleLieFi extends BaseSampleFragment {
         }
 
         /**
-         * @since 6.0
+         * @since 6.0.3
          */
         @Override
-        protected boolean isDowngradedMode() {
+        protected boolean isDowngradedMode(final long pMapTileIndex) {
             return (mNetworkAvailabilityCheck != null && !mNetworkAvailabilityCheck.getNetworkAvailable())
                     || !useDataConnection();
         }

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderArray.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderArray.java
@@ -103,8 +103,17 @@ public class MapTileProviderArray extends MapTileProviderBase implements MapTile
 
 	/**
 	 * @since 6.0
+	 * @deprecated Not used anymore. Use {@link #isDowngradedMode(long)} instead
 	 */
+	@Deprecated
 	protected boolean isDowngradedMode() {
+		return false;
+	}
+
+	/**
+	 * @since 6.0.3
+	 */
+	protected boolean isDowngradedMode(final long pMapTileIndex) {
 		return false;
 	}
 
@@ -115,7 +124,7 @@ public class MapTileProviderArray extends MapTileProviderBase implements MapTile
 			if (ExpirableBitmapDrawable.getState(tile) == ExpirableBitmapDrawable.UP_TO_DATE) {
 				return tile; // best scenario ever
 			}
-			if (isDowngradedMode()) {
+			if (isDowngradedMode(pMapTileIndex)) {
 				return tile; // best we can, considering
 			}
 		}


### PR DESCRIPTION
Impacted classes:
* `MapTileProviderArray`: deprecated method `isDowngradedMode()`; replaced it with method `isDowngradedMode(long pMapTileIndex)` that is able to take into account the zoom, x and y ranges of the providers
* `MapTileProviderBasic`: removed deprecated method `isDowngradedMode()`; replaced it with method `isDowngradedMode(long pMapTileIndex)` that takes into account the zoom range of the online providers
* `SampleLieFi`: replaced method `isDowngradedMode()` with `isDowngradedMode(long pMapTileIndex)`