### PR TITLE
bug/#1074 - cleaner memory management (from static to instance variables)

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
@@ -155,6 +155,11 @@ public class MapView extends ViewGroup implements IMapView,
 
 	private boolean mZoomRounding;
 
+	/**
+	 * @since 6.0.3
+	 */
+	private final MapViewRepository mRepository = new MapViewRepository(this);
+
     public interface OnFirstLayoutListener {
 		/**
 		 * this generally means that the map is ready to go
@@ -997,6 +1002,7 @@ public class MapView extends ViewGroup implements IMapView,
 		if (mProjection!=null)
 			mProjection.detach();
 		mProjection=null;
+		mRepository.onDetach();
 	}
 
 	@Override
@@ -1761,5 +1767,12 @@ public class MapView extends ViewGroup implements IMapView,
 	 */
 	public static void setTileSystem(final TileSystem pTileSystem) {
 		mTileSystem = pTileSystem;
+	}
+
+	/**
+	 * @since 6.0.3
+	 */
+	public MapViewRepository getRepository() {
+		return mRepository;
 	}
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapViewRepository.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapViewRepository.java
@@ -1,0 +1,75 @@
+package org.osmdroid.views;
+
+import android.graphics.drawable.Drawable;
+
+import org.osmdroid.library.R;
+import org.osmdroid.views.overlay.infowindow.BasicInfoWindow;
+import org.osmdroid.views.overlay.infowindow.InfoWindow;
+import org.osmdroid.views.overlay.infowindow.MarkerInfoWindow;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Repository for a MapView
+ * Designed for "singleton-like" objects that need a clean detach
+ * @since 6.0.3
+ * @author Fabrice Fontaine
+ */
+public class MapViewRepository {
+
+    private MapView mMapView;
+    private MarkerInfoWindow mDefaultMarkerInfoWindow;
+    private BasicInfoWindow mDefaultPolylineInfoWindow;
+    private BasicInfoWindow mDefaultPolygonInfoWindow;
+    private Drawable mDefaultMarkerIcon;
+    private final Set<InfoWindow> mInfoWindowList = new HashSet<>();
+
+    public MapViewRepository(final MapView pMapView) {
+        mMapView = pMapView;
+    }
+
+    public void add(final InfoWindow pInfoWindow) {
+        mInfoWindowList.add(pInfoWindow);
+    }
+
+    public void onDetach() {
+        for(final InfoWindow infoWindow : mInfoWindowList) {
+            infoWindow.onDetach();
+        }
+        mInfoWindowList.clear();
+        mMapView = null;
+        mDefaultMarkerInfoWindow = null;
+        mDefaultPolylineInfoWindow = null;
+        mDefaultPolygonInfoWindow = null;
+        mDefaultMarkerIcon = null;
+    }
+
+    public MarkerInfoWindow getDefaultMarkerInfoWindow() {
+        if (mDefaultMarkerInfoWindow == null) {
+            mDefaultMarkerInfoWindow = new MarkerInfoWindow(R.layout.bonuspack_bubble, mMapView);
+        }
+        return mDefaultMarkerInfoWindow;
+    }
+
+    public BasicInfoWindow getDefaultPolylineInfoWindow() {
+        if (mDefaultPolylineInfoWindow == null) {
+            mDefaultPolylineInfoWindow = new BasicInfoWindow(R.layout.bonuspack_bubble, mMapView);
+        }
+        return mDefaultPolylineInfoWindow;
+    }
+
+    public BasicInfoWindow getDefaultPolygonInfoWindow() {
+        if (mDefaultPolygonInfoWindow == null) {
+            mDefaultPolygonInfoWindow = new BasicInfoWindow(R.layout.bonuspack_bubble, mMapView);
+        }
+        return mDefaultPolygonInfoWindow;
+    }
+
+    public Drawable getDefaultMarkerIcon() {
+        if (mDefaultMarkerIcon == null) {
+            mDefaultMarkerIcon = mMapView.getContext().getResources().getDrawable(R.drawable.marker_default);
+        }
+        return mDefaultMarkerIcon;
+    }
+}

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polygon.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polygon.java
@@ -1,6 +1,5 @@
 package org.osmdroid.views.overlay;
 
-import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
@@ -10,15 +9,12 @@ import android.graphics.Region;
 import android.view.MotionEvent;
 
 import org.osmdroid.api.IGeoPoint;
-import org.osmdroid.library.R;
 import org.osmdroid.util.BoundingBox;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.util.PointL;
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.Projection;
-import org.osmdroid.views.overlay.infowindow.BasicInfoWindow;
 import org.osmdroid.views.overlay.infowindow.InfoWindow;
-import org.osmdroid.views.overlay.infowindow.MarkerInfoWindow;
 import org.osmdroid.views.overlay.milestones.MilestoneManager;
 
 import java.util.ArrayList;
@@ -43,7 +39,6 @@ public class Polygon extends OverlayWithIW {
 	private final Path mPath = new Path(); //Path drawn is kept for click detection
 	private LinearRing mOutline = new LinearRing(mPath);
 	private ArrayList<LinearRing> mHoles = new ArrayList<>();
-	protected static InfoWindow mDefaultInfoWindow = null;
 	protected OnClickListener mOnClickListener;
 	/** Paint settings. */
 	private Paint mFillPaint;
@@ -61,11 +56,8 @@ public class Polygon extends OverlayWithIW {
 
 	public Polygon(MapView mapView) {
 		if (mapView != null) {
-			if (mDefaultInfoWindow == null || mDefaultInfoWindow.getMapView() != mapView) {
-				mDefaultInfoWindow = new BasicInfoWindow(R.layout.bonuspack_bubble, mapView);
-			}
+			setInfoWindow(mapView.getRepository().getDefaultPolygonInfoWindow());
 		}
-		setInfoWindow(mDefaultInfoWindow);
 		mFillPaint = new Paint();
 		mFillPaint.setColor(Color.TRANSPARENT);
 		mFillPaint.setStyle(Paint.Style.FILL);
@@ -153,9 +145,6 @@ public class Polygon extends OverlayWithIW {
 		if (mInfoWindow != null){
 			if (mInfoWindow.getRelatedObject()==this)
 				mInfoWindow.setRelatedObject(null);
-			if (mInfoWindow != mDefaultInfoWindow) {
-				mInfoWindow.onDetach();
-			}
 		}
 		mInfoWindow = infoWindow;
 	}

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polyline.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polyline.java
@@ -5,15 +5,12 @@ import android.graphics.Color;
 import android.graphics.Paint;
 import android.view.MotionEvent;
 
-import org.osmdroid.library.R;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.util.PointL;
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.Projection;
-import org.osmdroid.views.overlay.infowindow.BasicInfoWindow;
 import org.osmdroid.views.overlay.infowindow.InfoWindow;
 import org.osmdroid.views.overlay.milestones.MilestoneManager;
-import org.osmdroid.views.util.constants.MathConstants;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,7 +32,6 @@ public class Polyline extends OverlayWithIW {
     private final LineDrawer mLineDrawer = new LineDrawer(256);
     private LinearRing mOutline = new LinearRing(mLineDrawer);
     private List<MilestoneManager> mMilestoneManagers = new ArrayList<>();
-    protected static InfoWindow mDefaultInfoWindow = null;
     protected OnClickListener mOnClickListener;
     private GeoPoint mInfoWindowLocation;
     private float mDensity = 1.0f;
@@ -53,12 +49,9 @@ public class Polyline extends OverlayWithIW {
      */
     public Polyline(MapView mapView) {
         if (mapView != null) {
-            if (mDefaultInfoWindow == null || mDefaultInfoWindow.getMapView() != mapView) {
-                mDefaultInfoWindow = new BasicInfoWindow(R.layout.bonuspack_bubble, mapView);
-            }
+            setInfoWindow(mapView.getRepository().getDefaultPolylineInfoWindow());
             mDensity = mapView.getContext().getResources().getDisplayMetrics().density;
         }
-        setInfoWindow(mDefaultInfoWindow);
         //default as defined in Google API:
         this.mPaint.setColor(Color.BLACK);
         this.mPaint.setStrokeWidth(10.0f);
@@ -200,9 +193,6 @@ public class Polyline extends OverlayWithIW {
         if (mInfoWindow != null){
             if (mInfoWindow.getRelatedObject()==this)
                 mInfoWindow.setRelatedObject(null);
-            if (mInfoWindow != mDefaultInfoWindow) {
-                mInfoWindow.onDetach();
-            }
         }
         mInfoWindow = infoWindow;
     }

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/infowindow/InfoWindow.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/infowindow/InfoWindow.java
@@ -50,6 +50,7 @@ public abstract class InfoWindow {
      */
     public InfoWindow(int layoutResId, MapView mapView) {
         mMapView = mapView;
+        mMapView.getRepository().add(this);
         mIsVisible = false;
         ViewGroup parent = (ViewGroup) mapView.getParent();
         Context context = mapView.getContext();


### PR DESCRIPTION
New class:
* `MapViewRepository`: repository for a `MapView`, designed for "singleton-like" objects that need a clean detach

Impacted classes:
* `InfoWindow`: explicitly added in the constructor the `InfoWindow` to the `MapViewRepository`
* `MapView`: added a `MapViewRepository` member
* `Marker`: added a `MapViewRepository` member; replaced `static` members `mDefaultInfoWindow` and `mDefaultIcon` with `MapViewRepository.getDefaultMarkerInfoWindow` and `MapViewRepository.getDefaultMarkerIcon`; deprecated `static` method `cleanDefaults`; gently refactored
* `Polygon`: replaced `static` member `mDefaultInfoWindow` with `MapViewRepository.getDefaultPolygonInfoWindow`; gently refactored
* `Polyline`: replaced `static` member `mDefaultInfoWindow` with `MapViewRepository.getDefaultPolylineInfoWindow`; gently refactored