### PR TITLE
bug/#516 - fixed Marker.hitTest with rotation and optimized drawing

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleMarker.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleMarker.java
@@ -1,13 +1,17 @@
 package org.osmdroid.samplefragments.data;
 
+import android.graphics.drawable.Drawable;
 import android.widget.Toast;
 
 import org.osmdroid.R;
 import org.osmdroid.samplefragments.BaseSampleFragment;
+import org.osmdroid.util.BoundingBox;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.overlay.Marker;
-import org.osmdroid.views.overlay.infowindow.MarkerInfoWindow;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * An example on using osmbonuspack's Marker class by following the tutorial at
@@ -29,21 +33,26 @@ public class SampleMarker extends BaseSampleFragment {
     public void addOverlays(){
         super.addOverlays();
 
+        final List<GeoPoint> points = new ArrayList<>();
+        final Drawable drawable = getResources().getDrawable(R.drawable.icon);
+
         GeoPoint startPoint = new GeoPoint(38.8977, -77.0365);  //white house
+        points.add(startPoint);
         Marker startMarker = new Marker(mMapView);
         startMarker.setPosition(startPoint);
         startMarker.setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM);
-        startMarker.setIcon(getResources().getDrawable(R.drawable.icon));
+        startMarker.setIcon(drawable);
         startMarker.setTitle("White House");
         startMarker.setSnippet("The White House is the official residence and principal workplace of the President of the United States.");
         startMarker.setSubDescription("1600 Pennsylvania Ave NW, Washington, DC 20500");
         mMapView.getOverlays().add(startMarker);
 
         startPoint = new GeoPoint(38.8719, -77.0563);
+        points.add(startPoint);
         startMarker = new Marker(mMapView);
         startMarker.setPosition(startPoint);
         startMarker.setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM);
-        startMarker.setIcon(getResources().getDrawable(R.drawable.icon));
+        startMarker.setIcon(drawable);
         startMarker.setTitle("Pentagon");
         startMarker.setSnippet("The Pentagon.");
         startMarker.setSubDescription("The Pentagon is the headquarters of the United States Department of Defense.");
@@ -59,13 +68,15 @@ public class SampleMarker extends BaseSampleFragment {
 
 
         startPoint = new GeoPoint(38.8895, -77.0353);
+        points.add(startPoint);
         startMarker = new Marker(mMapView);
         startMarker.setPosition(startPoint);
         startMarker.setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM);
-        startMarker.setIcon(getResources().getDrawable(R.drawable.icon));
+        startMarker.setIcon(drawable);
         startMarker.setTitle("Washington Monument");
         startMarker.setSnippet("Washington Monument.");
         startMarker.setSubDescription("Washington Monument.");
+        startMarker.setRotation(45); // for demo purposes
         startMarker.setOnMarkerClickListener(new Marker.OnMarkerClickListener() {
             @Override
             public boolean onMarkerClick(Marker marker, MapView mapView) {
@@ -78,6 +89,12 @@ public class SampleMarker extends BaseSampleFragment {
         mMapView.getOverlays().add(startMarker);
 
 
-        mMapView.invalidate();
+        final BoundingBox boundingBox = BoundingBox.fromGeoPoints(points);
+        mMapView.post(new Runnable() {
+            @Override
+            public void run() {
+                mMapView.zoomToBoundingBox(boundingBox, false, drawable.getIntrinsicWidth());
+            }
+        });
     }
 }

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleMilitaryIconsMarker.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleMilitaryIconsMarker.java
@@ -7,17 +7,15 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.widget.Toast;
 
-import org.osmdroid.api.IGeoPoint;
 import org.osmdroid.samplefragments.BaseSampleFragment;
 import org.osmdroid.util.GeoPoint;
-import org.osmdroid.views.overlay.ItemizedIconOverlay;
-import org.osmdroid.views.overlay.ItemizedOverlayWithFocus;
+import org.osmdroid.views.MapView;
 import org.osmdroid.views.overlay.Marker;
-import org.osmdroid.views.overlay.OverlayItem;
 import org.osmdroid.views.overlay.gestures.RotationGestureOverlay;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 
 /**
  * icons generated from https://github.com/missioncommand/mil-sym-java
@@ -42,8 +40,8 @@ public class SampleMilitaryIconsMarker extends BaseSampleFragment {
      // Fields
      // ===========================================================
      private RotationGestureOverlay mRotationGestureOverlay;
-     private OverlayItem overlayItem;
      private List<Drawable> icons = new ArrayList<>(4);
+     private final Random mRandom = new Random();
 
      @Override
      public String getSampleTitle() {
@@ -129,14 +127,11 @@ public class SampleMilitaryIconsMarker extends BaseSampleFragment {
 
      private void addIcons(int count) {
           for (int i = 0; i < count; i++) {
-               double random_lon = (Math.random() * 360) - 180;
-               double random_lat = (Math.random() * 180) - 90;
+               double random_lon = MapView.getTileSystem().getRandomLongitude(mRandom.nextDouble());
+               double random_lat = MapView.getTileSystem().getRandomLatitude(mRandom.nextDouble());
                Marker m = new Marker(mMapView);
                m.setPosition(new GeoPoint(random_lat, random_lon));
-               int index = (int) (Math.random() * (icons.size()));
-               if (index == icons.size()) {
-                    index--;
-               }
+               final int index = mRandom.nextInt(icons.size());
                m.setSnippet("A random point");
                m.setSubDescription("location: " + random_lat + "," + random_lon);
                m.setIcon(icons.get(index));

--- a/osmdroid-android/src/main/java/org/osmdroid/util/TileSystem.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/TileSystem.java
@@ -609,6 +609,14 @@ abstract public class TileSystem {
 	}
 
 	/**
+	 * @since 6.0.3
+	 * @param pRandom01 [0,1]
+	 */
+	public double getRandomLatitude(final double pRandom01) {
+		return getRandomLatitude(pRandom01, getMinLatitude());
+	}
+
+	/**
 	 * @since 6.0.0
 	 */
 	public static int getTileFromMercator(final long pMercator, final double pTileSize) {

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/DefaultOverlayManager.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/DefaultOverlayManager.java
@@ -128,14 +128,6 @@ public class DefaultOverlayManager extends AbstractList<Overlay> implements Over
             }
         }
 
-        if (mTilesOverlay!=null)
-            mTilesOverlay.protectDisplayedTilesForCache(c, pMapView);
-        for (final Overlay overlay : mOverlayList) {
-            if (overlay!=null && overlay.isEnabled() && overlay instanceof TilesOverlay) {
-                ((TilesOverlay) overlay).protectDisplayedTilesForCache(c, pMapView);
-            }
-        }
-
         //always pass false, the shadow parameter will be removed in a later version of osmdroid, this change should result in the on draw being called twice
         if (mTilesOverlay != null && mTilesOverlay.isEnabled()) {
             mTilesOverlay.draw(c, pMapView, false);

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Marker.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Marker.java
@@ -335,14 +335,22 @@ public class Marker extends OverlayWithIW {
 	public void showInfoWindow(){
 		if (mInfoWindow == null)
 			return;
-		int markerWidth = 0, markerHeight = 0;
-		markerWidth = mIcon.getIntrinsicWidth(); 
-		markerHeight = mIcon.getIntrinsicHeight();
-		
-		int offsetX = (int)(mIWAnchorU*markerWidth) - (int)(mAnchorU*markerWidth);
-		int offsetY = (int)(mIWAnchorV*markerHeight) - (int)(mAnchorV*markerHeight);
-		
-		mInfoWindow.open(this, mPosition, offsetX, offsetY);
+		final int markerWidth = mIcon.getIntrinsicWidth();
+		final int markerHeight = mIcon.getIntrinsicHeight();
+		final int offsetX = (int)(markerWidth * (mIWAnchorU - mAnchorU));
+		final int offsetY = (int)(markerHeight * (mIWAnchorV - mAnchorV));
+		if (mBearing == 0) {
+			mInfoWindow.open(this, mPosition, offsetX, offsetY);
+			return;
+		}
+		final int centerX = 0;
+		final int centerY = 0;
+		final double radians = -mBearing * Math.PI / 180.;
+		final double cos = Math.cos(radians);
+		final double sin = Math.sin(radians);
+		final int rotatedX = (int)RectL.getRotatedX(offsetX, offsetY, centerX, centerY, cos, sin);
+		final int rotatedY = (int)RectL.getRotatedY(offsetX, offsetY, centerX, centerY, cos, sin);
+		mInfoWindow.open(this, mPosition, rotatedX, rotatedY);
 	}
 	
 	public boolean isInfoWindowShown(){


### PR DESCRIPTION
In the process of fixing the initial issue, I optimized the code for Marker drawing, with the following results:
* drawing 5050 markers, all visible - with the latest optim: 130ms, with the old version: 204ms (55%)
* drawing 5050 markers, all visible - with the latest optim: 130ms, without the `BitmapDrawable optim`: 155ms (15%)
* drawing 5050 markers, all visible - with the latest optim: 130ms, without the `rotation==0` optim: 165ms (25%)
* drawing 5050 markers, only one actually visible - with the latest optim: 64ms, with the old version: 200ms (210%)

Impacted classes:
* `DefaultOverlayManager`: unrelated duplicate code fix in method `onDraw`
* `Marker`: added display helper members `mDisplayed`, `mRect` and `mOrientedMarkerRect`; created optimized display method `drawAt`; impacted method `hitTest`; gently refactored
* `SampleMarker`: added a rotation out of nowhere for demo purposes; added a zoom to bounding box feature; gently refactored
* `TileSystem`: added a version of method `getRandomLatitude`
* `SampleMilitaryIconsMarker`: gently refactored around `Random`