### PR TITLE
bug/#1116_2 - parameter purpose change in MapView.zoomToBoundingBox

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
@@ -508,17 +508,24 @@ public class MapView extends ViewGroup implements IMapView,
 
 	/**
 	 * @since 6.0.3
+	 * @param pBoundingBox Bounding box we want to zoom to; may be a single {@link GeoPoint}
+	 * @param pAnimated Animation or immediate action?
+	 * @param pBorderSizeInPixels Border size around the bounding box
+	 * @param pMaximumZoom Maximum zoom we want from bounding box computation
+	 * @param pAnimationSpeed Animation duration, in milliseconds
 	 */
-	public double zoomToBoundingBox(final BoundingBox boundingBox, final boolean animated, final int borderSizeInPixels,
-								  final double pZoomFallback, final Long animationSpeed) {
-		double nextZoom = mTileSystem.getBoundingBoxZoom(boundingBox, getWidth() - 2 * borderSizeInPixels, getHeight() - 2 * borderSizeInPixels);
-		if (nextZoom == Double.MIN_VALUE) {
-			nextZoom = pZoomFallback;
+	public double zoomToBoundingBox(final BoundingBox pBoundingBox, final boolean pAnimated,
+									final int pBorderSizeInPixels, final double pMaximumZoom,
+									final Long pAnimationSpeed) {
+		double nextZoom = mTileSystem.getBoundingBoxZoom(pBoundingBox, getWidth() - 2 * pBorderSizeInPixels, getHeight() - 2 * pBorderSizeInPixels);
+		if (nextZoom == Double.MIN_VALUE // e.g. single point bounding box
+				|| nextZoom > pMaximumZoom) { // e.g. tiny bounding box
+			nextZoom = pMaximumZoom;
 		}
 		nextZoom = Math.min(getMaxZoomLevel(), Math.max(nextZoom, getMinZoomLevel()));
-		final IGeoPoint center = boundingBox.getCenterWithDateLine();
-		if(animated) {
-			getController().animateTo(center, nextZoom, animationSpeed);
+		final IGeoPoint center = pBoundingBox.getCenterWithDateLine();
+		if(pAnimated) {
+			getController().animateTo(center, nextZoom, pAnimationSpeed);
 		} else { // it's best to set the zoom first, so that the center is accurate
 			getController().setZoom(nextZoom);
 			getController().setCenter(center);


### PR DESCRIPTION
Impacted class:
* `MapView`: edited method `zoomToBoundingBox` - renamed parameter `pZoomFallback` to a more explicit `pMaximumZoom`, slightly changed the code accordingly, added Javadoc, gently refactored