### PR TITLE
bug/#909 - Polyline info bubble is now anchored on the Polyline, not on the initial touch event

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/util/Distance.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/Distance.java
@@ -11,7 +11,7 @@ package org.osmdroid.util;
 public class Distance {
 
     /**
-     * Compute the distance between two points
+     * Square of the distance between two points
      */
     public static double getSquaredDistanceToPoint(
             final double pFromX, final double pFromY, final double pToX, final double pToY) {
@@ -27,11 +27,8 @@ public class Distance {
             final double pFromX, final double pFromY,
             final double pAX, final double pAY, final double pBX, final double pBY
     ) {
-        if (pAX == pBX && pAY == pBY) {
-            return getSquaredDistanceToPoint(pAX, pAY, pFromX, pFromY);
-        }
-        final double cross = crossProduct(pAX, pAY, pBX, pBY, pFromX, pFromY);
-        return cross * cross / getSquaredDistanceToPoint(pAX, pAY, pBX, pBY);
+        return getSquaredDistanceToProjection(pFromX, pFromY, pAX, pAY, pBX, pBY,
+                getProjectionFactorToLine(pFromX, pFromY, pAX, pAY, pBX, pBY));
     }
 
     /**
@@ -41,28 +38,58 @@ public class Distance {
             final double pFromX, final double pFromY,
             final double pAX, final double pAY, final double pBX, final double pBY
     ) {
-        if (pAX == pBX && pAY == pBY) {
-            return getSquaredDistanceToPoint(pAX, pAY, pFromX, pFromY);
-        }
-        double dot = dotProduct(pAX, pAY, pBX, pBY, pFromX, pFromY);
-        if (dot > 0) {
-            return getSquaredDistanceToPoint(pFromX, pFromY, pBX, pBY);
-        }
-        dot = dotProduct(pBX, pBY, pAX, pAY, pFromX, pFromY);
-        if (dot > 0) {
-            return getSquaredDistanceToPoint(pFromX, pFromY, pAX, pAY);
-        }
-        final double cross = crossProduct(pAX, pAY, pBX, pBY, pFromX, pFromY);
-        return cross * cross / getSquaredDistanceToPoint(pAX, pAY, pBX, pBY);
+        return getSquaredDistanceToProjection(pFromX, pFromY, pAX, pAY, pBX, pBY,
+                getProjectionFactorToSegment(pFromX, pFromY, pAX, pAY, pBX, pBY));
     }
 
     /**
-     * Compute the cross product AB x AC
+     * @since 6.0.3
+     * Square of the distance between a point and its projection on line AB
      */
-    private static double crossProduct(
+    public static double getSquaredDistanceToProjection(
+            final double pFromX, final double pFromY,
             final double pAX, final double pAY, final double pBX, final double pBY,
-            final double pCX, final double pCY) {
-        return (pBX - pAX) * (pCY - pAY) - (pBY - pAY) * (pCX - pAX);
+            final double pProjectionFactor
+    ) {
+        final double projectedX = pAX + (pBX - pAX) * pProjectionFactor;
+        final double projectedY = pAY + (pBY - pAY) * pProjectionFactor;
+        return getSquaredDistanceToPoint(pFromX, pFromY, projectedX, projectedY);
+    }
+
+    /**
+     * @since 6.0.3
+     * Projection factor on line AB from a point
+     * @return 0 if projected to A, 1 if projected to B, [0,1] if projected inside segment [A,B],
+     * &lt; 0 or &gt; 1 if projected outside of the segment
+     */
+    public static double getProjectionFactorToLine(
+            final double pFromX, final double pFromY,
+            final double pAX, final double pAY, final double pBX, final double pBY
+    ) {
+        if (pAX == pBX && pAY == pBY) {
+            return 0;
+        }
+        return dotProduct(pAX, pAY, pBX, pBY, pFromX, pFromY)
+                / getSquaredDistanceToPoint(pAX, pAY, pBX, pBY);
+    }
+
+    /**
+     * @since 6.0.3
+     * Projection factor on segment AB from a point
+     * @return [0,1]; 0 if projected to A, 1 if projected to B
+     */
+    public static double getProjectionFactorToSegment(
+            final double pFromX, final double pFromY,
+            final double pAX, final double pAY, final double pBX, final double pBY
+    ) {
+        final double result = getProjectionFactorToLine(pFromX, pFromY, pAX, pAY, pBX, pBY);
+        if (result < 0) {
+            return 0;
+        }
+        if (result > 1) {
+            return 1;
+        }
+        return result;
     }
 
     /**
@@ -71,6 +98,6 @@ public class Distance {
     private static double dotProduct(
             final double pAX, final double pAY, final double pBX, final double pBY,
             final double pCX, final double pCY) {
-        return (pBX - pAX) * (pCX - pBX) + (pBY - pAY) * (pCY - pBY);
+        return (pBX - pAX) * (pCX - pAX) + (pBY - pAY) * (pCY - pAY);
     }
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/LinearRing.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/LinearRing.java
@@ -417,6 +417,18 @@ class LinearRing{
 		final PointL offset = new PointL();
 		getBestOffset(pProjection, offset);
 		clipAndStore(pProjection, offset, pClosePath, true, null);
+		final double mapSize = TileSystem.MapSize(pProjection.getZoomLevel());
+		final Rect screenRect = pProjection.getIntrinsicScreenRect();
+		final int screenWidth = screenRect.width();
+		final int screenHeight = screenRect.height();
+		double startX = pixel.x; // in order to deal with world replication
+		while(startX - mapSize >= 0) {
+			startX -= mapSize;
+		}
+		double startY = pixel.y;
+		while(startY - mapSize >= 0) {
+			startY -= mapSize;
+		}
 		final double squaredTolerance = tolerance * tolerance;
 		final PointL point0 = new PointL();
 		final PointL point1 = new PointL();
@@ -427,18 +439,22 @@ class LinearRing{
 			if (first) {
 				first = false;
 			} else {
-				final double projectionFactor = Distance.getProjectionFactorToSegment(pixel.x, pixel.y, point0.x, point0.y, point1.x, point1.y);
-				final double squaredDistance = Distance.getSquaredDistanceToProjection(pixel.x, pixel.y, point0.x, point0.y, point1.x, point1.y, projectionFactor);
-				if (squaredTolerance > squaredDistance) {
-                    final long pointAX = mProjectedPoints[2 * (index - 1)];
-                    final long pointAY = mProjectedPoints[2 * (index - 1) + 1];
-                    final long pointBX = mProjectedPoints[2 * index];
-                    final long pointBY = mProjectedPoints[2 * index + 1];
-                    final long projectionX = (long) (pointAX + (pointBX - pointAX) * projectionFactor);
-                    final long projectionY = (long) (pointAY + (pointBY - pointAY) * projectionFactor);
-                    return MapView.getTileSystem().getGeoFromMercator(
-                            projectionX, projectionY, pProjection.mProjectedMapSize,
-                            null, false, false);
+				for (double x = startX ; x < screenWidth ; x += mapSize) {
+					for (double y = startY ; y < screenHeight ; y += mapSize) {
+						final double projectionFactor = Distance.getProjectionFactorToSegment(x, y, point0.x, point0.y, point1.x, point1.y);
+						final double squaredDistance = Distance.getSquaredDistanceToProjection(x, y, point0.x, point0.y, point1.x, point1.y, projectionFactor);
+						if (squaredTolerance > squaredDistance) {
+							final long pointAX = mProjectedPoints[2 * (index - 1)];
+							final long pointAY = mProjectedPoints[2 * (index - 1) + 1];
+							final long pointBX = mProjectedPoints[2 * index];
+							final long pointBY = mProjectedPoints[2 * index + 1];
+							final long projectionX = (long) (pointAX + (pointBX - pointAX) * projectionFactor);
+							final long projectionY = (long) (pointAY + (pointBY - pointAY) * projectionFactor);
+							return MapView.getTileSystem().getGeoFromMercator(
+									projectionX, projectionY, pProjection.mProjectedMapSize,
+									null, false, false);
+						}
+					}
 				}
 			}
 			point0.set(point1);

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polyline.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polyline.java
@@ -180,7 +180,19 @@ public class Polyline extends OverlayWithIW {
      * @return true if the Polyline is close enough to the point.
      */
     public boolean isCloseTo(GeoPoint point, double tolerance, MapView mapView) {
-        return mOutline.isCloseTo(point, tolerance, mapView.getProjection(), false);
+        return getCloseTo(point, tolerance, mapView) != null;
+    }
+
+    /**
+     * @since 6.0.3
+     * Detection is done is screen coordinates.
+     *
+     * @param point
+     * @param tolerance in pixels
+     * @return the first GeoPoint of the Polyline close enough to the point
+     */
+    public GeoPoint getCloseTo(GeoPoint point, double tolerance, MapView mapView) {
+        return mOutline.getCloseTo(point, tolerance, mapView.getProjection(), false);
     }
 
     /**
@@ -212,15 +224,15 @@ public class Polyline extends OverlayWithIW {
         final Projection pj = mapView.getProjection();
         GeoPoint eventPos = (GeoPoint) pj.fromPixels((int) event.getX(), (int) event.getY());
         double tolerance = mPaint.getStrokeWidth() * mDensity;
-        boolean touched = isCloseTo(eventPos, tolerance, mapView);
-        if (touched) {
+        final GeoPoint closest = getCloseTo(eventPos, tolerance, mapView);
+        if (closest != null) {
             if (mOnClickListener == null) {
-                return onClickDefault(this, mapView, eventPos);
+                return onClickDefault(this, mapView, closest);
             } else {
-                return mOnClickListener.onClick(this, mapView, eventPos);
+                return mOnClickListener.onClick(this, mapView, closest);
             }
         } else
-            return touched;
+            return false;
     }
 
     /**

--- a/osmdroid-android/src/test/java/org/osmdroid/util/DistanceTest.java
+++ b/osmdroid-android/src/test/java/org/osmdroid/util/DistanceTest.java
@@ -33,18 +33,44 @@ public class DistanceTest {
 	public void test_getSquareDistanceToSegment() {
 		final int xA = 100;
 		final int yA = 200;
-		final int deltaX = 10;
-		final int deltaY = 20;
 		Assert.assertEquals(0,
 				Distance.getSquaredDistanceToSegment(xA, yA, xA, yA, xA, yA), mDelta);
-		Assert.assertEquals(deltaX * deltaX,
-				Distance.getSquaredDistanceToSegment(xA, yA, xA + deltaX, yA, xA + deltaX, yA), mDelta);
-		Assert.assertEquals(deltaY * deltaY,
-				Distance.getSquaredDistanceToSegment(xA, yA, xA, yA + deltaY, xA, yA + deltaY), mDelta);
+		Assert.assertEquals(10 * 10,
+				Distance.getSquaredDistanceToSegment(xA, yA, xA + 10, yA, xA + 10, yA), mDelta);
+		Assert.assertEquals(20 * 20,
+				Distance.getSquaredDistanceToSegment(xA, yA, xA, yA + 20, xA, yA + 20), mDelta);
 		Assert.assertEquals(20 * 20,
 				Distance.getSquaredDistanceToSegment(xA, yA + 20, xA, yA, xA + 100, yA), mDelta);
 		Assert.assertEquals(10 * 10 + 30 * 30,
 				Distance.getSquaredDistanceToSegment(xA - 10, yA - 30, xA, yA, xA + 100, yA), mDelta);
+		Assert.assertEquals(100 * 100 + 70 * 70,
+				Distance.getSquaredDistanceToSegment(xA + 200, yA - 70, xA, yA, xA + 100, yA), mDelta);
+		Assert.assertEquals(7000 * 7000,
+				Distance.getSquaredDistanceToSegment(xA + 200, yA - 7000, xA, yA, xA + 200, yA), mDelta);
+		Assert.assertEquals(7000 * 7000,
+				Distance.getSquaredDistanceToSegment(xA + 200, yA - 7000, xA, yA, xA + 1000, yA), mDelta);
+	}
+
+	@Test
+	public void test_getProjectionFactorToLine() {
+		final int xA = 100;
+		final int yA = 200;
+		Assert.assertEquals(0,
+				Distance.getProjectionFactorToLine(xA, yA, xA, yA, xA, yA), mDelta);
+		Assert.assertEquals(0,
+				Distance.getProjectionFactorToLine(xA, yA, xA + 10, yA, xA + 10, yA), mDelta);
+		Assert.assertEquals(0,
+				Distance.getProjectionFactorToLine(xA, yA, xA, yA + 20, xA, yA + 20), mDelta);
+		Assert.assertEquals(0,
+				Distance.getProjectionFactorToLine(xA, yA + 20, xA, yA, xA + 100, yA), mDelta);
+		Assert.assertEquals(-10./100, // < 0
+				Distance.getProjectionFactorToLine(xA - 10, yA - 30, xA, yA, xA + 100, yA), mDelta);
+		Assert.assertEquals(2, // > 1
+				Distance.getProjectionFactorToLine(xA + 200, yA - 70, xA, yA, xA + 100, yA), mDelta);
+		Assert.assertEquals(1, // 1
+				Distance.getProjectionFactorToLine(xA + 200, yA - 7000, xA, yA, xA + 200, yA), mDelta);
+		Assert.assertEquals(.2, // ]0,1[
+				Distance.getProjectionFactorToLine(xA + 200, yA - 7000, xA, yA, xA + 1000, yA), mDelta);
 	}
 
 	@Test
@@ -63,5 +89,11 @@ public class DistanceTest {
 				Distance.getSquaredDistanceToLine(xA, yA + 20, xA, yA, xA + 100, yA), mDelta);
 		Assert.assertEquals(30 * 30,
 				Distance.getSquaredDistanceToLine(xA - 10, yA - 30, xA, yA, xA + 100, yA), mDelta);
+		Assert.assertEquals(70 * 70,
+				Distance.getSquaredDistanceToLine(xA + 200, yA - 70, xA, yA, xA + 100, yA), mDelta);
+		Assert.assertEquals(7000 * 7000,
+				Distance.getSquaredDistanceToLine(xA + 200, yA - 7000, xA, yA, xA + 200, yA), mDelta);
+		Assert.assertEquals(7000 * 7000,
+				Distance.getSquaredDistanceToLine(xA + 200, yA - 7000, xA, yA, xA + 1000, yA), mDelta);
 	}
 }


### PR DESCRIPTION
Tested from zoom 0 to zoom 29: no drifting at all for Polyline info window bubbles.

Impacted classes:
* `Distance`: introduced the concept of "projection factor"; created methods `getSquaredDistanceToProjection`, `getProjectionFactorToLine` and `getProjectionFactorToSegment`; removed unused `private` method `crossProduct`; fixed comments
* `DistanceTest`: created method `test_getProjectionFactorToLine`
* `LinearRing`: created method `getCloseTo` for a precise touch computation; rewrote method `isCloseTo` build on `getCloseTo`
* `Polyline`: created method `getCloseTo` for a precise touch computation; rewrote method `isCloseTo` build on `getCloseTo`; impacted method `onSingleTapConfirmed` that now uses a `GeoPoint` that belongs to the `Polyline`