### PR TITLE
feature/#1144 - using the new MapTileAreaList class in CacheManager (refactoring)

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/util/TileSystem.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/TileSystem.java
@@ -711,4 +711,46 @@ abstract public class TileSystem {
 	public String toStringLatitudeSpan() {
 		return "[" + getMinLatitude() + "," + getMaxLatitude() + "]";
 	}
+
+	/**
+	 * @since 6.0.3
+	 */
+	public int getTileXFromLongitude(final double pLongitude, final int pZoom) {
+		return clipTile((int) Math.floor(getX01FromLongitude(pLongitude) * (1 << pZoom)), pZoom);
+	}
+
+	/**
+	 * @since 6.0.3
+	 */
+	public int getTileYFromLatitude(final double pLatitude, final int pZoom) {
+		return clipTile((int) Math.floor(getY01FromLatitude(pLatitude) * (1 << pZoom)), pZoom);
+	}
+
+	/**
+	 * @since 6.0.3
+	 */
+	public double getLatitudeFromTileY(final int pY, final int pZoom) {
+		return getLatitudeFromY01(((double)clipTile(pY, pZoom)) / (1 << pZoom));
+	}
+
+	/**
+	 * @since 6.0.3
+	 */
+	public double getLongitudeFromTileX(final int pX, final int pZoom) {
+		return getLongitudeFromX01(((double)clipTile(pX, pZoom)) / (1 << pZoom));
+	}
+
+	/**
+	 * @since 6.0.3
+	 */
+	private int clipTile(final int pTile, final int pZoom) {
+		if (pTile < 0) {
+			return 0;
+		}
+		final int max = 1 << pZoom;
+		if (pTile >= max) {
+			return max - 1;
+		}
+		return pTile;
+	}
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/util/TileSystemWebMercator.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/TileSystemWebMercator.java
@@ -6,8 +6,8 @@ package org.osmdroid.util;
  */
 public class TileSystemWebMercator extends TileSystem{
 
-    private static final double MinLatitude = -85.05112877980659;
-    private static final double MaxLatitude = 85.05112877980659;
+    private static final double MinLatitude = -85.05112877980658;
+    private static final double MaxLatitude = 85.05112877980658;
     private static final double MinLongitude = -180;
     private static final double MaxLongitude = 180;
 

--- a/osmdroid-android/src/test/java/org/osmdroid/util/MapTileAreaTest.java
+++ b/osmdroid-android/src/test/java/org/osmdroid/util/MapTileAreaTest.java
@@ -52,6 +52,20 @@ public class MapTileAreaTest {
     }
 
     @Test
+    public void testCorners() {
+        final MapTileArea area = new MapTileArea();
+        for (int zoom = 0; zoom <= TileSystem.getMaximumZoomLevel(); zoom++) {
+            final int mapTileUpperBound = getMapTileUpperBound(zoom);
+            final int max = mapTileUpperBound - 1;
+            setNewWorld(area, zoom);
+            Assert.assertTrue(area.contains(MapTileIndex.getTileIndex(zoom, 0, 0)));
+            Assert.assertTrue(area.contains(MapTileIndex.getTileIndex(zoom, 0, max)));
+            Assert.assertTrue(area.contains(MapTileIndex.getTileIndex(zoom, max, max)));
+            Assert.assertTrue(area.contains(MapTileIndex.getTileIndex(zoom, max, 0)));
+        }
+    }
+
+    @Test
     public void testNextSize() {
         final Set<Long> set = new HashSet<>();
         final MapTileArea area = new MapTileArea();

--- a/osmdroid-android/src/test/java/org/osmdroid/util/TileSystemWebMercatorTest.java
+++ b/osmdroid-android/src/test/java/org/osmdroid/util/TileSystemWebMercatorTest.java
@@ -1,0 +1,40 @@
+package org.osmdroid.util;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+/**
+ * @since 6.0.3
+ * @author Fabrice Fontaine
+ * Unit test class related to {@link TileSystemWebMercator}
+ */
+public class TileSystemWebMercatorTest {
+
+    private final TileSystemWebMercator tileSystem = new TileSystemWebMercator();
+
+    @Test
+    public void test01() {
+        test01Lon(tileSystem.getMaxLongitude(), 1);
+        test01Lon(tileSystem.getMinLongitude(), 0);
+        test01Lat(tileSystem.getMaxLatitude(), 0);
+        test01Lat(tileSystem.getMinLatitude(), 1);
+    }
+
+    private void test01Lon(final double pLongitude, final double pExpected) {
+        final double value = tileSystem.getX01FromLongitude(pLongitude);
+        test01Value("longitude:" + pLongitude, value, pExpected);
+    }
+
+    private void test01Lat(final double pLatitude, final double pExpected) {
+        final double value = tileSystem.getY01FromLatitude(pLatitude);
+        test01Value("latitude:" + pLatitude, value, pExpected);
+    }
+
+    private void test01Value(final String pText, final double pValue, final double pExpected) {
+        final double mDelta = 1E-10;
+        Assert.assertTrue(pText, pValue >= 0);
+        Assert.assertTrue(pText, pValue <= 1);
+        Assert.assertEquals(pText, pExpected, pValue, mDelta);
+    }
+}


### PR DESCRIPTION
New class:
* `TileSystemWebMercatorTest`: slightly unrelated unit test class about class `TileSystemWebMercatorTest`

Impacted classes:
* `CacheManager`: deprecated methods `getMapTileFromCoordinates` and `getCoordinatesFromMapTile` in favor of new `TileSystem` methods; replaced in method `getTilesCoverageIterable` an on-the-fly `IterableWithSize<Long>` class with an instance of `MapTileAreaList`; made `static` method `getTilesRect` `public`
* `CacheManagerTest`: created new test methods `testGetTilesRectSingleTile` and `testGetTilesRectWholeWorld`; used now `public` method `CacheManager.getTilesRect` in method `getTilesCoverage`
* `MapTileAreaTest`: slightly unrelated new `testCorners` method
* `TileSystem`: created methods `getTileXFromLongitude`, `getTileYFromLatitude`, `getLatitudeFromTileY` and `getLongitudeFromTileX`, whose code was more or less previously in class `CacheManager` but will be more comfortable here, because we can handle other tile systems, and because even in the web mercator case the conversion formula was slightly deprecated (as we now use a more precise projection function); created helper method `clipTile`
* `TileSystemWebMercator`: very slightly fine-tune min and max latitude values, so that their projection into [0,1] fit into [0,1]