### PR TITLE
feature/#1122 - samples on how to handle a click on overlapping items

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleFactory.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleFactory.java
@@ -27,6 +27,8 @@ import org.osmdroid.samplefragments.data.SampleGridlines;
 import org.osmdroid.samplefragments.data.SampleIISTracker;
 import org.osmdroid.samplefragments.data.SampleIISTrackerMotionTrails;
 import org.osmdroid.samplefragments.data.SampleMarker;
+import org.osmdroid.samplefragments.data.SampleItemizedOverlayMultiClick;
+import org.osmdroid.samplefragments.data.SampleMarkerMultiClick;
 import org.osmdroid.samplefragments.data.SampleMilitaryIconsItemizedIcons;
 import org.osmdroid.samplefragments.data.SampleMilitaryIconsMarker;
 import org.osmdroid.samplefragments.data.SampleOsmPath;
@@ -295,6 +297,8 @@ public final class SampleFactory implements ISampleFactory {
         mSamples.add(LayerManager.class);
         mSamples.add(BookmarkSample.class);
         mSamples.add(SampleLieFi.class);
+        mSamples.add(SampleItemizedOverlayMultiClick.class);
+        mSamples.add(SampleMarkerMultiClick.class);
     }
 
     public void addSample(Class<? extends BaseSampleFragment> clz) {

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleItemizedOverlayMultiClick.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleItemizedOverlayMultiClick.java
@@ -1,0 +1,194 @@
+package org.osmdroid.samplefragments.data;
+
+import android.content.Context;
+import android.content.DialogInterface;
+import android.graphics.Color;
+import android.support.v7.app.AlertDialog;
+import android.widget.Toast;
+
+import org.osmdroid.api.IGeoPoint;
+import org.osmdroid.events.MapEventsReceiver;
+import org.osmdroid.samplefragments.BaseSampleFragment;
+import org.osmdroid.util.BoundingBox;
+import org.osmdroid.util.GeoPoint;
+import org.osmdroid.views.overlay.ItemizedIconOverlay;
+import org.osmdroid.views.overlay.ItemizedOverlayWithFocus;
+import org.osmdroid.views.overlay.MapEventsOverlay;
+import org.osmdroid.views.overlay.OverlayItem;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @since 6.0.3
+ * @author Fabrice Fontaine
+ * Sample on how to handle a click on overlapping {@link OverlayItem}s
+ */
+public class SampleItemizedOverlayMultiClick extends BaseSampleFragment {
+
+	public static final String TITLE = "Overlapping ItemizedOverlays' click";
+
+    private List<OverlayItem> mClicked = new ArrayList<>();
+
+	@Override
+	public String getSampleTitle() {
+		return TITLE;
+	}
+
+	@Override
+	protected void addOverlays() {
+		super.addOverlays();
+
+		final Context context = getActivity();
+
+		final List<DataContainer> datas = getData();
+		final List<OverlayItem> items = new ArrayList<>();
+		final List<IGeoPoint> geoPoints = new ArrayList<>();
+		for (final DataContainer data : datas) {
+			geoPoints.add(data.getGeoPoint());
+			items.add(new OverlayItem(data.getTitle(), data.getSnippet(), data.getGeoPoint()));
+		}
+		final BoundingBox box = BoundingBox.fromGeoPoints(geoPoints);
+
+		mMapView.getOverlays().add(new MapEventsOverlay(new MapEventsReceiver() {
+			@Override
+			public boolean singleTapConfirmedHelper(GeoPoint p) {
+				if (mClicked.size() == 0) {
+					return false;
+				}
+				if (mClicked.size() == 1) {
+					message(mClicked.get(0));
+					mClicked.clear();
+					return true;
+				}
+				final String[] titles = new String[mClicked.size()];
+				final OverlayItem[] items = new OverlayItem[titles.length];
+				int i = 0;
+				for(final OverlayItem item : mClicked) {
+					titles[i] = item.getTitle();
+					items[i] = item;
+					i ++;
+				}
+				new AlertDialog.Builder(getActivity())
+						.setItems(titles, new DialogInterface.OnClickListener() {
+							@Override
+							public void onClick(DialogInterface dialogInterface, int i) {
+								message(items[i]);
+							}
+						})
+						.setNegativeButton("Cancel", null)
+						.show();
+				mClicked.clear();
+				return false;
+			}
+
+			@Override
+			public boolean longPressHelper(GeoPoint p) {
+				return false;
+			}
+		}));
+
+		final ItemizedOverlayWithFocus<OverlayItem> myLocationOverlay;
+		myLocationOverlay = new ItemizedOverlayWithFocus<>(items,
+				new ItemizedIconOverlay.OnItemGestureListener<OverlayItem>() {
+					@Override
+					public boolean onItemSingleTapUp(final int index, final OverlayItem item) {
+					    mClicked.add(item);
+						return false;
+					}
+
+					@Override
+					public boolean onItemLongPress(final int index, final OverlayItem item) {
+						return false;
+					}
+				}, context);
+		myLocationOverlay.setMarkerBackgroundColor(Color.BLUE);
+		myLocationOverlay.setMarkerTitleForegroundColor(Color.WHITE);
+		myLocationOverlay.setMarkerDescriptionForegroundColor(Color.WHITE);
+		myLocationOverlay.setDescriptionBoxPadding(15);
+		mMapView.getOverlays().add(myLocationOverlay);
+
+		mMapView.post(new Runnable() {
+			@Override
+			public void run() {
+				mMapView.zoomToBoundingBox(box, true, 50);
+			}
+		});
+	}
+
+	private void message(final OverlayItem pItem) {
+		Toast.makeText(getActivity(), pItem.getTitle() + ": " + pItem.getSnippet(), Toast.LENGTH_LONG).show();
+	}
+
+	public static List<DataContainer> getData() {
+		final List<DataContainer> items = new ArrayList<>();
+		items.add(new DataContainer(
+				"Bode Museum",
+				"The sculpture collection shows art of the Christian Orient, sculptures from "
+						+ "Byzantium and Ravenna, sculptures of the Middle Ages, the Italian Gothic, and the early Renaissance.",
+				new GeoPoint(52.521944, 13.394722)));
+		items.add(new DataContainer(
+				"Altes Museum",
+				"It houses the Antikensammlung (antiquities collection) of the Berlin State Museums.",
+				new GeoPoint(52.519444, 13.398333)));
+		items.add(new DataContainer(
+				"Neues Museum",
+				"Exhibits include the Egyptian and Prehistory and Early History collections,"
+						+ "as it did before the war. The artifacts it houses include the iconic bust of the Egyptian queen Nefertiti.",
+				new GeoPoint(52.520555, 13.397777)));
+		items.add(new DataContainer(
+				"Alte Nationalgalerie",
+				"The collection contains works of the Neoclassical and Romantic movements,"
+						+" of the Biedermeier, French Impressionism and early Modernism.",
+				new GeoPoint(52.520833, 13.398055)));
+		items.add(new DataContainer(
+				"Pergamon Museum",
+				"The Pergamon Museum houses monumental buildings such as the Pergamon Altar,"
+						+" the Ishtar Gate of Babylon, the Market Gate of Miletus reconstructed from the ruins"
+						+" found in Anatolia, as well as the Mshatta Facade.",
+				new GeoPoint(52.521, 13.396)));
+		items.add(new DataContainer(
+				"Gemäldegalerie",
+				"It holds one of the world's leading collections of European paintings from the 13th to the 18th centuries.",
+				new GeoPoint(52.508472, 13.365416)));
+		items.add(new DataContainer(
+				"Kunstgewerbemuseum",
+				"It's an internationally important museum of the decorative arts.",
+				new GeoPoint(52.5097, 13.3674)));
+		items.add(new DataContainer(
+				"Musical Instrument Museum",
+				"The Museum holds over 3,500 musical instruments from the 16th century onward "
+						+ "and is one of the largest and most representative musical instrument collections in Germany.",
+				new GeoPoint(52.510277, 13.370833)));
+		items.add(new DataContainer(
+				"Kupferstichkabinett",
+				"It is the largest museum of graphic art in Germany, with more than 500,000 prints"
+						+ "and around 110,000 individual works on paper.",
+				new GeoPoint(52.508333, 13.366944)));
+		return items;
+	}
+
+	public static class DataContainer {
+		private final String mTitle;
+		private final String mSnippet;
+		private final IGeoPoint mGeoPoint;
+
+		DataContainer(final String pTitle, final String pSnippet, final IGeoPoint pGeoPoint) {
+			mTitle = pTitle;
+			mSnippet = pSnippet;
+			mGeoPoint = pGeoPoint;
+		}
+
+		public String getTitle() {
+			return mTitle;
+		}
+
+		public String getSnippet() {
+			return mSnippet;
+		}
+
+		public IGeoPoint getGeoPoint() {
+			return mGeoPoint;
+		}
+	}
+}

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleMarkerMultiClick.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleMarkerMultiClick.java
@@ -1,0 +1,123 @@
+package org.osmdroid.samplefragments.data;
+
+import android.content.DialogInterface;
+import android.graphics.drawable.Drawable;
+import android.support.v7.app.AlertDialog;
+
+import org.osmdroid.R;
+import org.osmdroid.api.IGeoPoint;
+import org.osmdroid.events.MapEventsReceiver;
+import org.osmdroid.samplefragments.BaseSampleFragment;
+import org.osmdroid.util.BoundingBox;
+import org.osmdroid.util.GeoPoint;
+import org.osmdroid.views.MapView;
+import org.osmdroid.views.overlay.MapEventsOverlay;
+import org.osmdroid.views.overlay.Marker;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @since 6.0.3
+ * @author Fabrice Fontaine
+ * Sample on how to handle a click on overlapping {@link Marker}s
+ */
+public class SampleMarkerMultiClick extends BaseSampleFragment {
+
+	public static final String TITLE = "Overlapping Markers' click";
+
+    private List<Marker> mClicked = new ArrayList<>();
+
+	@Override
+	public String getSampleTitle() {
+		return TITLE;
+	}
+
+	@Override
+	protected void addOverlays() {
+		super.addOverlays();
+
+		mMapView.getOverlays().add(new MapEventsOverlay(new MapEventsReceiver() {
+			@Override
+			public boolean singleTapConfirmedHelper(GeoPoint p) {
+				if (mClicked.size() == 0) {
+					return false;
+				}
+				if (mClicked.size() == 1) {
+					message(mClicked.get(0));
+					mClicked.clear();
+					return true;
+				}
+				final String[] titles = new String[mClicked.size()];
+				final Marker[] items = new Marker[titles.length];
+				int i = 0;
+				for(final Marker item : mClicked) {
+					titles[i] = item.getTitle();
+					items[i] = item;
+					i ++;
+				}
+				new AlertDialog.Builder(getActivity())
+						.setItems(titles, new DialogInterface.OnClickListener() {
+							@Override
+							public void onClick(DialogInterface dialogInterface, int i) {
+								message(items[i]);
+							}
+						})
+						.setNegativeButton("Cancel", null)
+						.show();
+				mClicked.clear();
+				return false;
+			}
+
+			@Override
+			public boolean longPressHelper(GeoPoint p) {
+				return false;
+			}
+		}));
+
+		final List<SampleItemizedOverlayMultiClick.DataContainer> datas = SampleItemizedOverlayMultiClick.getData();
+		final List<IGeoPoint> geoPoints = new ArrayList<>();
+		final Drawable drawable = getResources().getDrawable(R.drawable.icon);
+		for (final SampleItemizedOverlayMultiClick.DataContainer data : datas) {
+			geoPoints.add(data.getGeoPoint());
+			final Marker marker = new MyMarker(mMapView);
+			marker.setPosition(new GeoPoint(data.getGeoPoint()));
+			marker.setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM);
+			marker.setIcon(drawable);
+			marker.setTitle(data.getTitle());
+			marker.setSnippet(data.getSnippet());
+			marker.setOnMarkerClickListener(new Marker.OnMarkerClickListener() {
+				@Override
+				public boolean onMarkerClick(Marker marker, MapView mapView) {
+					mClicked.add(marker);
+					return false;
+				}
+			});
+            mMapView.getOverlays().add(marker);
+		}
+
+		final BoundingBox box = BoundingBox.fromGeoPoints(geoPoints);
+		mMapView.post(new Runnable() {
+			@Override
+			public void run() {
+				mMapView.zoomToBoundingBox(box, true, 50);
+			}
+		});
+	}
+
+	private void message(final Marker pMarker) {
+		((MyMarker)pMarker).onMarkerClickDefault(pMarker, mMapView);
+	}
+
+	static private class MyMarker extends Marker {
+
+		MyMarker(MapView mapView) {
+			super(mapView);
+		}
+
+		@Override
+		public boolean onMarkerClickDefault(Marker marker, MapView mapView) { // made public
+			return super.onMarkerClickDefault(marker, mapView);
+		}
+	}
+}

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleWithMinimapItemizedOverlayWithFocus.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleWithMinimapItemizedOverlayWithFocus.java
@@ -68,16 +68,16 @@ public class SampleWithMinimapItemizedOverlayWithFocus extends BaseSampleFragmen
 		{
 			/* Create a static ItemizedOverlay showing some Markers on various cities. */
 			final ArrayList<OverlayItem> items = new ArrayList<>();
-			items.add(new OverlayItem("Hannover", "Tiny SampleDescription", new GeoPoint(52370816,
-					9735936))); // Hannover
+			items.add(new OverlayItem("Hannover", "Tiny SampleDescription", new GeoPoint(52.370816,
+					9.735936))); // Hannover
 			items.add(new OverlayItem("Berlin", "This is a relatively short SampleDescription.",
-					new GeoPoint(52518333, 13408333))); // Berlin
+					new GeoPoint(52.518333, 13.408333))); // Berlin
 			items.add(new OverlayItem(
 					"Washington",
 					"This SampleDescription is a pretty long one. Almost as long as a the great wall in china.",
-					new GeoPoint(38895000, -77036667))); // Washington
-			items.add(new OverlayItem("San Francisco", "SampleDescription", new GeoPoint(37779300,
-					-122419200))); // San Francisco
+					new GeoPoint(38.895, -77.036667))); // Washington
+			items.add(new OverlayItem("San Francisco", "SampleDescription", new GeoPoint(37.7793,
+					-122.4192))); // San Francisco
 
 			/* OnTapListener for the Markers, shows a simple Toast. */
 			mMyLocationOverlay = new ItemizedOverlayWithFocus<>(items,
@@ -124,7 +124,7 @@ public class SampleWithMinimapItemizedOverlayWithFocus extends BaseSampleFragmen
 		}
 
 		// Zoom and center on the focused item.
-		mMapView.getController().setZoom(5);
+		mMapView.getController().setZoom(5.);
         IGeoPoint geoPoint = mMyLocationOverlay.getFocusedItem().getPoint();
 		mMapView.getController().animateTo(geoPoint);
 

--- a/osmdroid-android/src/main/java/org/osmdroid/util/GeoPoint.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/GeoPoint.java
@@ -71,6 +71,14 @@ public class GeoPoint implements IGeoPoint, MathConstants, GeoConstants, Parcela
 		this.mAltitude = aGeopoint.mAltitude;
 	}
 
+	/**
+	 * @since 6.0.3
+	 */
+	public GeoPoint(final IGeoPoint pGeopoint) {
+		this.mLatitude = pGeopoint.getLatitude();
+		this.mLongitude = pGeopoint.getLongitude();
+	}
+
 	public static GeoPoint fromDoubleString(final String s, final char spacer) {
 		final int spacerPos1 = s.indexOf(spacer);
 		final int spacerPos2 = s.indexOf(spacer, spacerPos1 + 1);


### PR DESCRIPTION
I created 2 new samples, to be found in "More Samples / Data": "Overlapping ItemizedOverlays' click" and "Overlapping Markers' click"

New classes:
* `SampleItemizedOverlayMultiClick`: Sample on how to handle a click on overlapping `OverlayItem`s, to be found in "More Samples / Data / Overlapping ItemizedOverlays' click"
* `SampleMarkerMultiClick`: Sample on how to handle a click on overlapping `Marker`s, to be found in "More Samples / Data / Overlapping Markers' click"

Impacted classes:
* `GeoPoint`: added a constructor with `IGeoPoint` as parameter
* `SampleFactory`: added the 2 new classes `SampleItemizedOverlayMultiClick` and `SampleMarkerMultiClick`
* `SampleWithMinimapItemizedOverlayWithFocus`: unrelated - used not-deprecated new versions of old methods