### PR TITLE
feature/#1122 - removed the confusing animation at start of demos

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleItemizedOverlayMultiClick.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleItemizedOverlayMultiClick.java
@@ -111,7 +111,7 @@ public class SampleItemizedOverlayMultiClick extends BaseSampleFragment {
 		mMapView.post(new Runnable() {
 			@Override
 			public void run() {
-				mMapView.zoomToBoundingBox(box, true, 50);
+				mMapView.zoomToBoundingBox(box, false, 50);
 			}
 		});
 	}

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleMarkerMultiClick.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleMarkerMultiClick.java
@@ -100,7 +100,7 @@ public class SampleMarkerMultiClick extends BaseSampleFragment {
 		mMapView.post(new Runnable() {
 			@Override
 			public void run() {
-				mMapView.zoomToBoundingBox(box, true, 50);
+				mMapView.zoomToBoundingBox(box, false, 50);
 			}
 		});
 	}


### PR DESCRIPTION
Impacted classes:
* `SampleItemizedOverlayMultiClick`
* `SampleMarkerMultiClick`