### PR TITLE
feature/#1168 - Total distance of a Polyline or Polygon in meters

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polygon.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polygon.java
@@ -399,4 +399,11 @@ public class Polygon extends OverlayWithIW {
 		mOnClickListener = listener;
 	}
 
+	/**
+	 * @since 6.0.3
+	 * @return aggregate distance (in meters)
+	 */
+	public double getDistance() {
+		return mOutline.getDistance();
+	}
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polyline.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polyline.java
@@ -301,4 +301,12 @@ public class Polyline extends OverlayWithIW {
             mMilestoneManagers = pMilestoneManagers;
         }
     }
+
+    /**
+     * @since 6.0.3
+     * @return aggregate distance (in meters)
+     */
+    public double getDistance() {
+        return mOutline.getDistance();
+    }
 }


### PR DESCRIPTION
Impacted classes:
* `LinearRing`: split member `mPrecomputed` in `mProjectedPrecomputed` and `mDistancePrecomputed`; split method `computeProjectedAndDistances` in `computeProjected` and `computeDistances`; created method `getDistance` that aggregates segment distances
* `Polygon`: created method `getDistance`
* `Polyline`: created method `getDistance`