### PR TITLE
bug/#1167 - using also http header cache-control:max-age for tile expiration

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/constants/OpenStreetMapTileProviderConstants.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/constants/OpenStreetMapTileProviderConstants.java
@@ -34,6 +34,11 @@ public class OpenStreetMapTileProviderConstants {
 	public static final String HTTP_EXPIRES_HEADER = "Expires";
 
 	/**
+	 * @since 6.0.3
+	 */
+	public static final String HTTP_CACHECONTROL_HEADER = "Cache-Control";
+
+	/**
 	 * this is the default and expected http header for Expires, date time format that is used
 	 * for more http servers. Can be overridden via Configuration
 	 * @since 5.1

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/TileDownloader.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/TileDownloader.java
@@ -139,7 +139,9 @@ public class TileDownloader {
             dataStream = new ByteArrayOutputStream();
             out = new BufferedOutputStream(dataStream, StreamUtils.IO_BUFFER_SIZE);
             final long expirationTime = computeExpirationTime(
-                    c.getHeaderField(OpenStreetMapTileProviderConstants.HTTP_EXPIRES_HEADER));
+                    c.getHeaderField(OpenStreetMapTileProviderConstants.HTTP_EXPIRES_HEADER),
+                    c.getHeaderField(OpenStreetMapTileProviderConstants.HTTP_CACHECONTROL_HEADER),
+                    System.currentTimeMillis());
             StreamUtils.copy(in, out);
             out.flush();
             final byte[] data = dataStream.toByteArray();
@@ -183,30 +185,69 @@ public class TileDownloader {
         return null;
     }
 
-    private long computeExpirationTime(final String pHttpExpiresHeader) {
-        Long httpExpirationTime = null;
+    /**
+     * @since 6.0.3
+     * @return the Epoch timestamp corresponding to the http header (in milliseconds), or null
+     */
+    public Long getHttpExpiresTime(final String pHttpExpiresHeader) {
         if (pHttpExpiresHeader != null && pHttpExpiresHeader.length() > 0) {
             try {
                 final Date dateExpires = Configuration.getInstance().getHttpHeaderDateTimeFormat().parse(pHttpExpiresHeader);
-                httpExpirationTime = dateExpires.getTime();
+                return dateExpires.getTime();
             } catch (final Exception ex) {
                 if (Configuration.getInstance().isDebugMapTileDownloader())
-                    Log.d(IMapView.LOGTAG, "Unable to parse expiration tag for tile, using default, server returned " + pHttpExpiresHeader, ex);
+                    Log.d(IMapView.LOGTAG, "Unable to parse expiration tag for tile, server returned " + pHttpExpiresHeader, ex);
             }
         }
-        return computeExpirationTime(httpExpirationTime);
+        return null;
     }
 
-    protected long computeExpirationTime(final Long pHttpExpiresTime) {
+    /**
+     * @since 6.0.3
+     * @return the max-age corresponding to the http header (in seconds), or null
+     */
+    public Long getHttpCacheControlDuration(final String pHttpCacheControlHeader) {
+        if (pHttpCacheControlHeader != null && pHttpCacheControlHeader.length() > 0) {
+            try {
+                final String[] parts = pHttpCacheControlHeader.split(", ");
+                final String maxAge = "max-age=";
+                for (final String part : parts) {
+                    final int pos = part.indexOf(maxAge);
+                    if (pos == 0) {
+                        final String durationString = part.substring(maxAge.length());
+                        return Long.valueOf(durationString);
+                    }
+                }
+            } catch (final Exception ex) {
+                if (Configuration.getInstance().isDebugMapTileDownloader())
+                    Log.d(IMapView.LOGTAG,
+                            "Unable to parse cache control tag for tile, server returned " + pHttpCacheControlHeader, ex);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @since 6.0.3
+     * @return the expiration time (as Epoch timestamp in milliseconds)
+     */
+    public long computeExpirationTime(final String pHttpExpiresHeader, final String pHttpCacheControlHeader, final long pNow) {
         final Long override=Configuration.getInstance().getExpirationOverrideDuration();
-        final long now = System.currentTimeMillis();
         if (override != null) {
-            return now + override;
+            return pNow + override;
         }
+
         final long extension = Configuration.getInstance().getExpirationExtendedDuration();
-        if (pHttpExpiresTime != null) {
-            return pHttpExpiresTime + extension;
+        final Long cacheControlDuration = getHttpCacheControlDuration(pHttpCacheControlHeader);
+        if (cacheControlDuration != null) {
+            return pNow + cacheControlDuration * 1000 + extension;
         }
-        return now + OpenStreetMapTileProviderConstants.DEFAULT_MAXIMUM_CACHED_FILE_AGE + extension;
+
+        final Long httpExpiresTime = getHttpExpiresTime(pHttpExpiresHeader);
+        if (httpExpiresTime != null) {
+            return httpExpiresTime + extension;
+        }
+
+        return pNow + OpenStreetMapTileProviderConstants.DEFAULT_MAXIMUM_CACHED_FILE_AGE + extension;
     }
 }

--- a/osmdroid-android/src/test/java/org/osmdroid/tileprovider/modules/TileDownloaderTest.java
+++ b/osmdroid-android/src/test/java/org/osmdroid/tileprovider/modules/TileDownloaderTest.java
@@ -1,0 +1,84 @@
+package org.osmdroid.tileprovider.modules;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.osmdroid.config.Configuration;
+import org.osmdroid.tileprovider.constants.OpenStreetMapTileProviderConstants;
+
+import java.util.Random;
+
+/**
+ * @author Fabrice Fontaine
+ * @since 6.0.3
+ */
+public class TileDownloaderTest {
+
+    private final long mCacheControlValue           = 172800; // in seconds
+    private final String mCacheControlStringOK[]    = {"max-age=172800, public", "public, max-age=172800", "max-age=172800"};
+    private final String mCacheControlStringKO[]    = {"max-age=, public", "public"};
+
+    private final long mExpiresValue                = 1539971220000L;
+    private final String mExpiresStringOK[]         = {"Fri, 19 Oct 2018 17:47:00 GMT"};
+    private final String mExpiresStringKO[]         = {"Frfgi, 19 Oct 2018 17:47:00 GMT"};
+
+    @Test
+    public void testGetHttpExpiresTime(){
+        final TileDownloader tileDownloader = new TileDownloader();
+        for (final String string : mExpiresStringOK) {
+            Assert.assertEquals(mExpiresValue, (long) tileDownloader.getHttpExpiresTime(string));
+        }
+        for (final String string : mExpiresStringKO) {
+            Assert.assertNull(tileDownloader.getHttpExpiresTime(string));
+        }
+    }
+
+    @Test
+    public void testGetHttpCacheControlDuration(){
+        final TileDownloader tileDownloader = new TileDownloader();
+        for (final String string : mCacheControlStringOK) {
+            Assert.assertEquals(mCacheControlValue, (long) tileDownloader.getHttpCacheControlDuration(string));
+        }
+        for (final String string : mCacheControlStringKO) {
+            Assert.assertNull(tileDownloader.getHttpCacheControlDuration(string));
+        }
+    }
+
+    @Test
+    public void testComputeExpirationTime(){
+        final Random random = new Random();
+        final int oneWeek = 7 * 24 * 3600 * 1000; // 7 days in milliseconds
+        testComputeExpirationTimeHelper(null, random.nextInt(oneWeek));
+        testComputeExpirationTimeHelper((long)random.nextInt(oneWeek), random.nextInt(oneWeek));
+    }
+
+    private void testComputeExpirationTimeHelper(final Long pOverride, final long pExtension){
+        final TileDownloader tileDownloader = new TileDownloader();
+        final long now = System.currentTimeMillis();
+        Configuration.getInstance().setExpirationOverrideDuration(pOverride);
+        Configuration.getInstance().setExpirationExtendedDuration(pExtension);
+        for (final String cacheControlString : mCacheControlStringOK) {
+            for (final String expiresString : mExpiresStringOK) {
+                Assert.assertEquals(
+                        pOverride != null ? now + pOverride : now + mCacheControlValue * 1000 + pExtension,
+                        tileDownloader.computeExpirationTime(expiresString, cacheControlString, now));
+            }
+            for (final String expiresString : mExpiresStringKO) {
+                Assert.assertEquals(
+                        pOverride != null ? now + pOverride : now + mCacheControlValue * 1000 + pExtension,
+                        tileDownloader.computeExpirationTime(expiresString, cacheControlString, now));
+            }
+        }
+        for (final String cacheControlString : mCacheControlStringKO) {
+            for (final String expiresString : mExpiresStringOK) {
+                Assert.assertEquals(
+                        pOverride != null ? now + pOverride : mExpiresValue + pExtension,
+                        tileDownloader.computeExpirationTime(expiresString, cacheControlString, now));
+            }
+            for (final String expiresString : mExpiresStringKO) {
+                Assert.assertEquals(
+                        pOverride != null ? now + pOverride : now + OpenStreetMapTileProviderConstants.DEFAULT_MAXIMUM_CACHED_FILE_AGE + pExtension,
+                        tileDownloader.computeExpirationTime(expiresString, cacheControlString, now));
+            }
+        }
+    }
+}


### PR DESCRIPTION
New class:
* `TileDownloaderTest`: unit test class for `TileDownloader`, especially regarding tile expiration computation

Impacted classes:
* `OpenStreetMapTileProviderConstants`: added constant `HTTP_CACHECONTROL_HEADER` (as `"Cache-Control"`)
* `TileDownloader`: now also uses the cache-control http header in tile expiration computation in method `downloadTile`; created helper methods `getHttpExpiresTime` and `getHttpCacheControlDuration` and modified method `computeExpirationTime` accordingly