### PR TITLE
bug/#1172 - consistency between tile writer and tile provider

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/tilesources/SampleLieFi.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/tilesources/SampleLieFi.java
@@ -12,6 +12,7 @@ import org.osmdroid.samplefragments.BaseSampleFragment;
 import org.osmdroid.tileprovider.IMapTileProviderCallback;
 import org.osmdroid.tileprovider.IRegisterReceiver;
 import org.osmdroid.tileprovider.MapTileProviderArray;
+import org.osmdroid.tileprovider.MapTileProviderBasic;
 import org.osmdroid.tileprovider.modules.CantContinueException;
 import org.osmdroid.tileprovider.modules.IFilesystemCache;
 import org.osmdroid.tileprovider.modules.INetworkAvailablityCheck;
@@ -20,8 +21,6 @@ import org.osmdroid.tileprovider.modules.MapTileAssetsProvider;
 import org.osmdroid.tileprovider.modules.MapTileDownloader;
 import org.osmdroid.tileprovider.modules.MapTileFileArchiveProvider;
 import org.osmdroid.tileprovider.modules.MapTileFileStorageProviderBase;
-import org.osmdroid.tileprovider.modules.MapTileFilesystemProvider;
-import org.osmdroid.tileprovider.modules.MapTileSqlCacheProvider;
 import org.osmdroid.tileprovider.modules.NetworkAvailabliltyCheck;
 import org.osmdroid.tileprovider.modules.SqlTileWriter;
 import org.osmdroid.tileprovider.modules.TileWriter;
@@ -96,12 +95,8 @@ public class SampleLieFi extends BaseSampleFragment {
                     pRegisterReceiver, pContext.getAssets(), pTileSource);
             mTileProviderList.add(assetsProvider);
 
-            final MapTileFileStorageProviderBase cacheProvider;
-            if (Build.VERSION.SDK_INT < 10) {
-                cacheProvider = new MapTileFilesystemProvider(pRegisterReceiver, pTileSource);
-            } else {
-                cacheProvider = new MapTileSqlCacheProvider(pRegisterReceiver, pTileSource);
-            }
+            final MapTileFileStorageProviderBase cacheProvider =
+                    MapTileProviderBasic.getMapTileFileStorageProviderBase(pRegisterReceiver, pTileSource, tileWriter);
             mTileProviderList.add(cacheProvider);
 
             final MapTileFileArchiveProvider archiveProvider = new MapTileFileArchiveProvider(

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderBasic.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderBasic.java
@@ -54,8 +54,7 @@ public class MapTileProviderBasic extends MapTileProviderArray implements IMapTi
 	 * Creates a {@link MapTileProviderBasic}.
 	 */
 	public MapTileProviderBasic(final Context pContext, final ITileSource pTileSource) {
-		this(new SimpleRegisterReceiver(pContext), new NetworkAvailabliltyCheck(pContext),
-				pTileSource, pContext,null);
+		this(pContext, pTileSource, null);
 	}
 
 	/**
@@ -88,12 +87,8 @@ public class MapTileProviderBasic extends MapTileProviderArray implements IMapTi
 				pRegisterReceiver, pContext.getAssets(), pTileSource);
 		mTileProviderList.add(assetsProvider);
 
-		final MapTileFileStorageProviderBase cacheProvider;
-		if (Build.VERSION.SDK_INT < 10) {
-			cacheProvider = new MapTileFilesystemProvider(pRegisterReceiver, pTileSource);
-		} else {
-			cacheProvider = new MapTileSqlCacheProvider(pRegisterReceiver, pTileSource);
-		}
+		final MapTileFileStorageProviderBase cacheProvider =
+				getMapTileFileStorageProviderBase(pRegisterReceiver, pTileSource, tileWriter);
 		mTileProviderList.add(cacheProvider);
 
 		final MapTileFileArchiveProvider archiveProvider = new MapTileFileArchiveProvider(
@@ -169,5 +164,20 @@ public class MapTileProviderBasic extends MapTileProviderArray implements IMapTi
 		}
 		final int zoom = MapTileIndex.getZoom(pMapTileIndex);
 		return zoom < zoomMin || zoom > zoomMax;
+	}
+
+	/**
+	 * @since 6.0.3
+	 * cf. https://github.com/osmdroid/osmdroid/issues/1172
+	 */
+	public static MapTileFileStorageProviderBase getMapTileFileStorageProviderBase(
+			final IRegisterReceiver pRegisterReceiver,
+			final ITileSource pTileSource,
+			final IFilesystemCache pTileWriter
+	) {
+		if (pTileWriter instanceof TileWriter) {
+			return new MapTileFilesystemProvider(pRegisterReceiver, pTileSource);
+		}
+		return new MapTileSqlCacheProvider(pRegisterReceiver, pTileSource);
 	}
 }

--- a/osmdroid-geopackage/src/main/java/org/osmdroid/gpkg/tiles/raster/GeoPackageProvider.java
+++ b/osmdroid-geopackage/src/main/java/org/osmdroid/gpkg/tiles/raster/GeoPackageProvider.java
@@ -8,10 +8,9 @@ import org.osmdroid.api.IMapView;
 import org.osmdroid.tileprovider.IMapTileProviderCallback;
 import org.osmdroid.tileprovider.IRegisterReceiver;
 import org.osmdroid.tileprovider.MapTileProviderArray;
+import org.osmdroid.tileprovider.MapTileProviderBasic;
 import org.osmdroid.tileprovider.modules.IFilesystemCache;
 import org.osmdroid.tileprovider.modules.INetworkAvailablityCheck;
-import org.osmdroid.tileprovider.modules.MapTileFilesystemProvider;
-import org.osmdroid.tileprovider.modules.MapTileSqlCacheProvider;
 import org.osmdroid.tileprovider.modules.NetworkAvailabliltyCheck;
 import org.osmdroid.tileprovider.modules.SqlTileWriter;
 import org.osmdroid.tileprovider.modules.TileWriter;
@@ -63,14 +62,7 @@ public class GeoPackageProvider extends MapTileProviderArray implements IMapTile
             }
         }
 
-        if (Build.VERSION.SDK_INT < 10) {
-            final MapTileFilesystemProvider fileSystemProvider = new MapTileFilesystemProvider(
-                pRegisterReceiver, pTileSource);
-            mTileProviderList.add(fileSystemProvider);
-        } else {
-            final MapTileSqlCacheProvider cachedProvider = new MapTileSqlCacheProvider(pRegisterReceiver, pTileSource);
-            mTileProviderList.add(cachedProvider);
-        }
+        mTileProviderList.add(MapTileProviderBasic.getMapTileFileStorageProviderBase(pRegisterReceiver, pTileSource, tileWriter));
         geopackage = new GeoPackageMapTileModuleProvider(databases, pContext, tileWriter);
         mTileProviderList.add(geopackage);
 


### PR DESCRIPTION
Impacted classes:
* `MapTileProviderBasic`: new `static` method `getMapTileFileStorageProviderBase` that fixes the possible inconsistency between the `IFilesystemCache` and the `MapTileFileStorageProviderBase`; used this method the constructor; unrelated constructor gentle refactoring
* `GeoPackageProvider`: used new `static` method `MapTileProviderBasic.getMapTileFileStorageProviderBase` in the constructor
* `SampleLieFi`: used new `static` method `MapTileProviderBasic.getMapTileFileStorageProviderBase` in `MapTileProviderLieFi`'s constructor