### PR TITLE
bug/#1181 - correct orientation for marker icons on orientated maps

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleMarker.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleMarker.java
@@ -34,7 +34,7 @@ public class SampleMarker extends BaseSampleFragment {
         super.addOverlays();
 
         final List<GeoPoint> points = new ArrayList<>();
-        final Drawable drawable = getResources().getDrawable(R.drawable.icon);
+        final Drawable drawable = getResources().getDrawable(R.drawable.marker_default);
 
         GeoPoint startPoint = new GeoPoint(38.8977, -77.0365);  //white house
         points.add(startPoint);

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Marker.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Marker.java
@@ -339,7 +339,7 @@ public class Marker extends OverlayWithIW {
 
 		mIcon.setAlpha((int)(mAlpha*255));
 		
-		float rotationOnScreen = (mFlat ? -mBearing : mapView.getMapOrientation()-mBearing);
+		float rotationOnScreen = (mFlat ? -mBearing : -mapView.getMapOrientation()-mBearing);
 		drawAt(canvas, mPositionPixels.x, mPositionPixels.y, rotationOnScreen);
 		if (isInfoWindowShown()) {
 			//showInfoWindow();


### PR DESCRIPTION
Impacted classes:
* `Marker`: fixed the orientation computation in method `draw`
* `SampleMarker`: used a more orientation-obvious icon for better tests