### PR TITLE
bug/#825 - new custom zoom controller

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/BaseSampleFragment.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/BaseSampleFragment.java
@@ -113,7 +113,6 @@ public abstract class BaseSampleFragment extends Fragment {
                 copyrightOverlay.setOffset(0, (int) (55 * dm.density));
 
 			mMapView.getOverlays().add(copyrightOverlay);
-			mMapView.setBuiltInZoomControls(true);
 			mMapView.setMultiTouchControls(true);
 			mMapView.setTilesScaledToDpi(true);
 		}

--- a/osmdroid-android/src/main/java/org/osmdroid/util/MapTileAreaZoomComputer.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/MapTileAreaZoomComputer.java
@@ -24,7 +24,7 @@ public class MapTileAreaZoomComputer implements MapTileAreaComputer {
         final int sourceZoom = pSource.getZoom();
         int destZoom = sourceZoom + mZoomDelta;
         if (destZoom < 0 || destZoom > MapTileIndex.mMaxZoomLevel) {
-            out.set(-1, 0, 0, 0, 0);
+            out.reset();
             return out;
         }
         if (mZoomDelta <= 0) {

--- a/osmdroid-android/src/main/java/org/osmdroid/views/CustomZoomButtonsController.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/CustomZoomButtonsController.java
@@ -1,0 +1,223 @@
+package org.osmdroid.views;
+
+import android.animation.ValueAnimator;
+import android.graphics.Canvas;
+import android.os.Build;
+import android.view.MotionEvent;
+import android.view.animation.LinearInterpolator;
+
+/**
+ * @since 6.1.0
+ * @author Fabrice Fontaine
+ */
+public class CustomZoomButtonsController {
+
+	public enum Visibility {ALWAYS, NEVER, SHOW_AND_FADEOUT	}
+
+	private final Object mThreadSync = new Object();
+    private final MapView mMapView;
+	private final ValueAnimator mFadeOutAnimation;
+	private CustomZoomButtonsDisplay mDisplay;
+	private OnZoomListener mListener;
+	private boolean mZoomInEnabled;
+	private boolean mZoomOutEnabled;
+	private float mAlpha01;
+	private boolean detached;
+	private Visibility mVisibility = Visibility.NEVER;
+    private int mFadeOutAnimationDurationInMillis = 500;
+    private int mShowDelayInMillis = 3500;
+	private boolean mJustActivated;
+	private long mLatestActivation;
+	private Thread mThread;
+	private final Runnable mRunnable;
+
+	public CustomZoomButtonsController(final MapView pMapView) {
+        mMapView = pMapView;
+        mDisplay = new CustomZoomButtonsDisplay(mMapView);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+            mFadeOutAnimation = ValueAnimator.ofFloat(0, 1);
+            mFadeOutAnimation.setInterpolator(new LinearInterpolator());
+            mFadeOutAnimation.setDuration(mFadeOutAnimationDurationInMillis);
+            mFadeOutAnimation.addUpdateListener(
+                    new ValueAnimator.AnimatorUpdateListener() {
+                        @Override
+                        public void onAnimationUpdate(ValueAnimator valueAnimator) {
+                        	if (detached) {
+                        		mFadeOutAnimation.cancel();
+                        		return;
+							}
+                            mAlpha01 = 1 - (float) valueAnimator.getAnimatedValue();
+                            invalidate();
+                        }
+                    }
+            );
+        } else {
+            mFadeOutAnimation = null;
+        }
+		mRunnable = new Runnable() {
+			@Override
+			public void run() {
+				while(true) {
+					final long pending = mLatestActivation + mShowDelayInMillis - nowInMillis();
+					if (pending <= 0) {
+						break;
+					}
+					try {
+						Thread.sleep(pending, 0);
+					} catch(InterruptedException e) {
+						//
+					}
+				}
+				startFadeOut();
+			}
+		};
+    }
+
+	public void setZoomInEnabled(final boolean pEnabled) {
+		mZoomInEnabled = pEnabled;
+	}
+
+	public void setZoomOutEnabled(final boolean pEnabled) {
+		mZoomOutEnabled = pEnabled;
+	}
+
+	public CustomZoomButtonsDisplay getDisplay() {
+		return mDisplay;
+	}
+
+    public void setOnZoomListener(final OnZoomListener pListener) {
+		mListener = pListener;
+	}
+
+	public void setVisibility(final Visibility pVisibility) {
+		mVisibility = pVisibility;
+		switch(mVisibility) {
+			case ALWAYS:
+				mAlpha01 = 1;break;
+			case NEVER:
+			case SHOW_AND_FADEOUT:
+				mAlpha01 = 0;break;
+		}
+	}
+
+    public void setShowFadeOutDelays(final int pShowDelayInMillis,
+									 final int pFadeOutAnimationDurationInMillis) {
+        mShowDelayInMillis = pShowDelayInMillis;
+        mFadeOutAnimationDurationInMillis = pFadeOutAnimationDurationInMillis;
+    }
+
+	public void onDetach() {
+		detached = true;
+	    stopFadeOut();
+    }
+
+	private long nowInMillis() {
+	    return System.currentTimeMillis();
+    }
+
+    private void startFadeOut() {
+        if (detached) {
+			return;
+		}
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+            mFadeOutAnimation.setStartDelay(0);
+            mMapView.post(new Runnable() {
+                @Override
+                public void run() {
+                    mFadeOutAnimation.start();
+                }
+            });
+        } else {
+            mAlpha01 = 0;
+			invalidate();
+        }
+    }
+
+	private void stopFadeOut() {
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+			mFadeOutAnimation.cancel();
+		}
+	}
+
+    private void invalidate() {
+		if (detached) {
+			return;
+		}
+		mMapView.postInvalidate();
+	}
+
+	public void activate() {
+		if (detached) {
+			return;
+		}
+		if (mVisibility != Visibility.SHOW_AND_FADEOUT) {
+		    return;
+        }
+        final float alpha = mAlpha01;
+		if (!mJustActivated) {
+			mJustActivated = alpha == 0;
+		} else {
+			mJustActivated = false;
+		}
+		stopFadeOut();
+		mAlpha01 = 1;
+		mLatestActivation = nowInMillis();
+		invalidate();
+		if (mThread == null || mThread.getState() == Thread.State.TERMINATED) {
+			synchronized (mThreadSync) {
+				if (mThread == null || mThread.getState() == Thread.State.TERMINATED) {
+					mThread = new Thread(mRunnable);
+					mThread.start();
+				}
+			}
+		}
+	}
+
+	private boolean checkJustActivated() {
+		if (mJustActivated) {
+			mJustActivated = false;
+			return true;
+		}
+		return false;
+	}
+
+	private boolean isTouched(final MotionEvent pMotionEvent) {
+		if (mAlpha01 == 0) {
+			return false;
+		}
+		if (checkJustActivated()) {
+			return false;
+		}
+		if (mZoomInEnabled && mDisplay.isTouchedRotated(pMotionEvent, true)) {
+			if (mListener != null) {
+				mListener.onZoom(true);
+			}
+			return true;
+		}
+		if (mZoomOutEnabled && mDisplay.isTouchedRotated(pMotionEvent, false)) {
+			if (mListener != null) {
+				mListener.onZoom(false);
+			}
+			return true;
+		}
+		return false;
+	}
+
+	public interface OnZoomListener {
+		void onVisibilityChanged(boolean b);
+
+		void onZoom(boolean b);
+	}
+
+	public boolean onSingleTapConfirmed(final MotionEvent pMotionEvent) {
+		return isTouched(pMotionEvent);
+	}
+
+	public boolean onLongPress(final MotionEvent pMotionEvent) {
+		return isTouched(pMotionEvent);
+	}
+
+	public void draw(final Canvas pCanvas) {
+		mDisplay.draw(pCanvas, mAlpha01, mZoomInEnabled, mZoomOutEnabled);
+	}
+}

--- a/osmdroid-android/src/main/java/org/osmdroid/views/CustomZoomButtonsDisplay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/CustomZoomButtonsDisplay.java
@@ -1,0 +1,198 @@
+package org.osmdroid.views;
+
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.Point;
+import android.view.MotionEvent;
+
+/**
+ * @since 6.1.0
+ * @author Fabrice Fontaine
+ */
+public class CustomZoomButtonsDisplay {
+
+	public enum HorizontalPosition {LEFT, CENTER, RIGHT}
+	public enum VerticalPosition {TOP, CENTER, BOTTOM}
+
+	private final MapView mMapView;
+	private final Point mUnrotatedPoint = new Point();
+	private Bitmap mZoomInBitmapEnabled;
+	private Bitmap mZoomOutBitmapEnabled;
+	private Bitmap mZoomInBitmapDisabled;
+	private Bitmap mZoomOutBitmapDisabled;
+	private Paint mAlphaPaint;
+	private int mBitmapSize;
+	private float mBitmapStrokeWidth;
+	private int mBitmapSegmentSize;
+	private HorizontalPosition mHorizontalPosition;
+	private VerticalPosition mVerticalPosition;
+	private boolean mHorizontalOrVertical;
+	private int mMargin;
+	private int mPadding;
+
+	public CustomZoomButtonsDisplay(final MapView pMapView) {
+		mMapView = pMapView;
+		// default values
+		setPositions(true, HorizontalPosition.CENTER, VerticalPosition.BOTTOM);
+		setDrawingSizes(50, 5, 20);
+		setMarginPadding(25, 16);
+	}
+
+	public void setPositions(
+			final boolean pHorizontalOrVertical,
+			final HorizontalPosition pHorizontalPosition, final VerticalPosition pVerticalPosition) {
+		mHorizontalOrVertical = pHorizontalOrVertical;
+		mHorizontalPosition = pHorizontalPosition;
+		mVerticalPosition = pVerticalPosition;
+	}
+
+	public void setDrawingSizes(final int pSize, final float pStrokeWidth, final int pSegmentSize) {
+		mBitmapSize = pSize;
+		mBitmapStrokeWidth = pStrokeWidth;
+		mBitmapSegmentSize = pSegmentSize;
+	}
+
+	public void setMarginPadding(final int pMargin, final int pPadding) {
+		mMargin = pMargin;
+		mPadding = pPadding;
+	}
+
+	public void setBitmaps(final Bitmap pInEnabled, final Bitmap pInDisabled,
+						   final Bitmap pOutEnabled, final Bitmap pOutDisabled) {
+		mZoomInBitmapEnabled = pInEnabled;
+		mZoomInBitmapDisabled = pInDisabled;
+		mZoomOutBitmapEnabled = pOutEnabled;
+		mZoomOutBitmapDisabled = pOutDisabled;
+	}
+
+	protected Bitmap getZoomBitmap(final boolean pInOrOut, final boolean pEnabled) {
+		final Bitmap bitmap = Bitmap.createBitmap(mBitmapSize, mBitmapSize, Bitmap.Config.ARGB_8888);
+		final Canvas canvas = new Canvas(bitmap);
+		final Paint backgroundPaint = new Paint();
+		backgroundPaint.setColor(pEnabled ? Color.WHITE : Color.LTGRAY);
+		backgroundPaint.setStyle(Paint.Style.FILL);
+		final Paint segmentPaint = new Paint();
+		segmentPaint.setColor(Color.BLACK);
+		segmentPaint.setStyle(Paint.Style.STROKE);
+		segmentPaint.setStrokeWidth(mBitmapStrokeWidth);
+		final int half = (mBitmapSize - mBitmapSegmentSize) / 2;
+		canvas.drawRect(0, 0, mBitmapSize - 1, mBitmapSize - 1, backgroundPaint);
+		canvas.drawLine(
+				half, mBitmapSize / 2,
+				half + mBitmapSegmentSize, mBitmapSize / 2, segmentPaint);
+		if (pInOrOut) {
+			canvas.drawLine(
+					mBitmapSize / 2, half,
+					mBitmapSize / 2, half + mBitmapSegmentSize, segmentPaint);
+		}
+		return bitmap;
+	}
+
+	public void draw(final Canvas pCanvas, final float pAlpha01,
+					 final boolean pZoomInEnabled, final boolean pZoomOutEnabled) {
+		if (pAlpha01 == 0) {
+			return;
+		}
+		final Paint paint;
+		if (pAlpha01 == 1) {
+			paint = null;
+		} else {
+			if (mAlphaPaint == null) {
+				mAlphaPaint = new Paint();
+			}
+			mAlphaPaint.setAlpha((int)(pAlpha01 * 255));
+			paint = mAlphaPaint;
+		}
+		pCanvas.drawBitmap(
+				getBitmap(true, pZoomInEnabled),
+				getTopLeft(true, true),
+				getTopLeft(true, false),
+				paint);
+		pCanvas.drawBitmap(
+				getBitmap(false, pZoomOutEnabled),
+				getTopLeft(false, true),
+				getTopLeft(false, false),
+				paint);
+	}
+
+	private int getTopLeft(final boolean pInOrOut, final boolean pXOrY) {
+		final int topLeft;
+		if (pXOrY) {
+			topLeft = getLeftForZoomIn(mMapView.getWidth());
+			if (pInOrOut) {
+				return topLeft;
+			}
+			return mHorizontalOrVertical ? topLeft + mBitmapSize + mPadding : topLeft;
+		}
+		topLeft = getTopForZoomIn(mMapView.getHeight());
+		if (pInOrOut) {
+			return topLeft;
+		}
+		return mHorizontalOrVertical ? topLeft : topLeft + mBitmapSize + mPadding;
+	}
+
+	public int getLeftForZoomIn(final int pMapViewWidth) {
+		switch(mHorizontalPosition) {
+			case LEFT:
+				return mMargin;
+			case RIGHT:
+				return pMapViewWidth - mMargin - mBitmapSize
+						- (mHorizontalOrVertical ? mPadding + mBitmapSize : 0);
+			case CENTER:
+				return pMapViewWidth / 2
+						- (mHorizontalOrVertical ? mPadding / 2 + mBitmapSize : mBitmapSize / 2);
+		}
+		throw new IllegalArgumentException();
+	}
+
+	public int getTopForZoomIn(final int pMapViewHeight) {
+		switch(mVerticalPosition) {
+			case TOP:
+				return mMargin;
+			case BOTTOM:
+				return pMapViewHeight - mMargin - mBitmapSize
+						- (mHorizontalOrVertical ? 0 : mPadding + mBitmapSize);
+			case CENTER:
+				return pMapViewHeight / 2
+						- (mHorizontalOrVertical ? mBitmapSize / 2 : mPadding / 2 + mBitmapSize);
+		}
+		throw new IllegalArgumentException();
+	}
+
+	private Bitmap getBitmap(final boolean pInOrOut, final boolean pEnabled) {
+		if (mZoomInBitmapEnabled == null) {
+			setBitmaps(
+					getZoomBitmap(true, true),
+					getZoomBitmap(true, false),
+					getZoomBitmap(false, true),
+					getZoomBitmap(false, false)
+			);
+		}
+		if (pInOrOut) {
+			return pEnabled ? mZoomInBitmapEnabled : mZoomInBitmapDisabled;
+		}
+		return pEnabled ? mZoomOutBitmapEnabled : mZoomOutBitmapDisabled;
+	}
+
+	public boolean isTouchedRotated(final MotionEvent pMotionEvent, final boolean pInOrOut) {
+		if (mMapView.getMapOrientation() == 0) {
+			mUnrotatedPoint.set((int) pMotionEvent.getX(), (int) pMotionEvent.getY());
+		} else {
+			mMapView.getProjection().rotateAndScalePoint(
+					(int) pMotionEvent.getX(), (int) pMotionEvent.getY(), mUnrotatedPoint);
+		}
+		return isTouched(mUnrotatedPoint.x, mUnrotatedPoint.y, pInOrOut);
+	}
+
+	private boolean isTouched(final int pEventX, final int pEventY, final boolean pInOrOut) {
+		return isTouched(pInOrOut, true, pEventX)
+				&& isTouched(pInOrOut, false, pEventY);
+	}
+
+	private boolean isTouched(final boolean pInOrOut, final boolean pXOrY, final float pEvent) {
+		final int topLeft = getTopLeft(pInOrOut, pXOrY);
+		return pEvent >= topLeft && pEvent <= topLeft + mBitmapSize;
+	}
+}

--- a/osmdroid-android/src/test/java/org/osmdroid/util/MapTileAreaZoomComputerTest.java
+++ b/osmdroid-android/src/test/java/org/osmdroid/util/MapTileAreaZoomComputerTest.java
@@ -73,6 +73,19 @@ public class MapTileAreaZoomComputerTest {
         }
     }
 
+    /**
+     * @since 6.1.0
+     */
+    @Test
+    public void testBugANRSideEffect() {
+        final MapTileArea source = new MapTileArea();
+        final MapTileArea dest = new MapTileArea();
+        source.set(0, 0, 0, 1, 1);
+        final MapTileAreaZoomComputer computer = new MapTileAreaZoomComputer(-1);
+        computer.computeFromSource(source, dest);
+        Assert.assertEquals(0, dest.getWidth());
+    }
+
     private int getMapTileUpperBound(final int pZoom) {
         return 1 << pZoom;
     }

--- a/osmdroid-android/src/test/java/org/osmdroid/views/CustomZoomButtonsDisplayTest.java
+++ b/osmdroid-android/src/test/java/org/osmdroid/views/CustomZoomButtonsDisplayTest.java
@@ -1,0 +1,84 @@
+package org.osmdroid.views;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+import java.util.Random;
+
+/**
+ * @author Fabrice Fontaine
+ * @since 6.1.0
+ */
+
+public class CustomZoomButtonsDisplayTest {
+
+    private final Random mRandom = new Random();
+
+    @Test
+    public void testTopLeft() {
+        final int randomMargin = 20;
+        final int bitmapSize = 50 + mRandom.nextInt(randomMargin);
+        final int margin = 25 + mRandom.nextInt(randomMargin);
+        final int padding = 16 + mRandom.nextInt(randomMargin);
+        final float strokeWidth = bitmapSize * mRandom.nextFloat();
+        final int segmentSize = mRandom.nextInt(bitmapSize);
+        final int mapViewWidth = 600 + mRandom.nextInt(randomMargin);
+        final int mapViewHeight = 800 + mRandom.nextInt(randomMargin);
+        final boolean[] horizontalOrVerticals = new boolean[] {true, false};
+        final CustomZoomButtonsDisplay.HorizontalPosition[] horizontalPositions = new CustomZoomButtonsDisplay.HorizontalPosition[] {
+                CustomZoomButtonsDisplay.HorizontalPosition.LEFT,
+                CustomZoomButtonsDisplay.HorizontalPosition.CENTER,
+                CustomZoomButtonsDisplay.HorizontalPosition.RIGHT,
+        };
+        final CustomZoomButtonsDisplay.VerticalPosition[] verticalPositions = new CustomZoomButtonsDisplay.VerticalPosition[] {
+                CustomZoomButtonsDisplay.VerticalPosition.TOP,
+                CustomZoomButtonsDisplay.VerticalPosition.CENTER,
+                CustomZoomButtonsDisplay.VerticalPosition.BOTTOM,
+        };
+	    final CustomZoomButtonsDisplay display = new CustomZoomButtonsDisplay(null);
+        display.setDrawingSizes(bitmapSize, strokeWidth, segmentSize);
+        display.setMarginPadding(margin, padding);
+
+        for (final boolean horizontalOrVertical : horizontalOrVerticals) {
+            for (final CustomZoomButtonsDisplay.HorizontalPosition horizontalPosition : horizontalPositions) {
+                for (final CustomZoomButtonsDisplay.VerticalPosition verticalPosition : verticalPositions) {
+                    display.setPositions(horizontalOrVertical, horizontalPosition, verticalPosition);
+                    if (horizontalPosition == CustomZoomButtonsDisplay.HorizontalPosition.LEFT) {
+                        Assert.assertEquals(margin, display.getLeftForZoomIn(mapViewWidth));
+                    }
+                    if (verticalPosition == CustomZoomButtonsDisplay.VerticalPosition.TOP) {
+                        Assert.assertEquals(margin, display.getTopForZoomIn(mapViewHeight));
+                    }
+                    if (horizontalOrVertical) {
+                        switch(horizontalPosition) {
+                            case CENTER:
+                                Assert.assertEquals(mapViewWidth / 2 - bitmapSize - padding / 2, display.getLeftForZoomIn(mapViewWidth)); break;
+                            case RIGHT:
+                                Assert.assertEquals(mapViewWidth - 2 * bitmapSize - margin - padding, display.getLeftForZoomIn(mapViewWidth)); break;
+                        }
+                        switch(verticalPosition) {
+                            case CENTER:
+                                Assert.assertEquals(mapViewHeight / 2 - bitmapSize / 2, display.getTopForZoomIn(mapViewHeight)); break;
+                            case BOTTOM:
+                                Assert.assertEquals(mapViewHeight - bitmapSize - margin, display.getTopForZoomIn(mapViewHeight)); break;
+                        }
+                    } else {
+                        switch(horizontalPosition) {
+                            case CENTER:
+                                Assert.assertEquals(mapViewWidth / 2 - bitmapSize / 2, display.getLeftForZoomIn(mapViewWidth)); break;
+                            case RIGHT:
+                                Assert.assertEquals(mapViewWidth - bitmapSize - margin, display.getLeftForZoomIn(mapViewWidth)); break;
+                        }
+                        switch(verticalPosition) {
+                            case CENTER:
+                                Assert.assertEquals(mapViewHeight / 2 - bitmapSize - padding / 2, display.getTopForZoomIn(mapViewHeight)); break;
+                            case BOTTOM:
+                                Assert.assertEquals(mapViewHeight - 2 * bitmapSize - margin - padding, display.getTopForZoomIn(mapViewHeight)); break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
The `CustomZoomButtonsController` class replaces the use of `android.widget.ZoomButtonsController`:
* no more crash when the `MapView` is detached
* customizable display using method `getDisplay`, including icons and position
* customizable visibility using method `setVisibility` (display always / never / show and then fade out)
* customizable alpha animation when fading out
* handle short click and long click the same way, including when the map is rotated

New classes:
* `CustomZoomButtonsController`: controller of the zoom buttons, as a substitute for to-be-deprecated `android.widget.ZoomButtonsController`
* `CustomZoomButtonsDisplay`: display of the zoom buttons
* `CustomZoomButtonsDisplayTest`: unit test class for class `CustomZoomButtonsDisplay`

Impacted class:
* `MapView`: replaced `ZoomButtonsController` by `CustomZoomButtonsController`; removed mEnableZoomController; replaced `dispatchDraw`by `onDraw` for better `invalidate` reactions; unrelated new version of method `getMapCenter` with a "reuse" parameter