### PR TITLE
Bug/#1098 - Bump support lib to 26

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ android:
     #
     
     - android-26
-    - android-23
     #- addon-google_apis-google-23
     
     # Additional components - currently not required
@@ -50,7 +49,7 @@ env:
     #       so running API25 and up emulators is not possible right now.
     
     matrix:
-    - API=10 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default
+    #- API=10 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default
     #- API=10 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis     # currently no google apis needed
     #- API=14 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default         # emulator consistently times out
     #- API=15 ANDROID_ABI=armeabi-v7a ANDROID_TAG=default         # https://github.com/osmdroid/osmdroid/issues/1066

--- a/OpenStreetMapViewer/build.gradle
+++ b/OpenStreetMapViewer/build.gradle
@@ -47,9 +47,9 @@ dependencies {
     compile 'ch.acra:acra:4.7.0'
 
     //memory leak testing
-    debugCompile 'com.squareup.leakcanary:leakcanary-android:1.4-beta2'
-    releaseCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.4-beta2'
-    testCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.4-beta2'
+    debugCompile 'com.squareup.leakcanary:leakcanary-android:1.4'
+    releaseCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.4'
+    testCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.4'
 
     //on device testing
     androidTestCompile 'com.android.support.test:runner:0.4.+'

--- a/OpenStreetMapViewer/build.gradle
+++ b/OpenStreetMapViewer/build.gradle
@@ -7,6 +7,8 @@ android {
     defaultConfig {
         applicationId 'org.osmdroid'
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+
+        minSdkVersion Integer.parseInt(project.property('android-minSdkForSupportLib.version'))
     }
     testOptions {
         unitTests.all {

--- a/OpenStreetMapViewer/build.gradle
+++ b/OpenStreetMapViewer/build.gradle
@@ -3,6 +3,30 @@ description = 'OpenMap in the Play Store, the example app for using osmdroid'
 apply plugin: 'com.android.application'
 apply from: "https://raw.githubusercontent.com/gradle-fury/gradle-fury/v1.1.4/gradle/android-support.gradle"
 
+// Attention! HACK!
+// In https://raw.githubusercontent.com/gradle-fury/gradle-fury/v1.1.4/gradle/android-support.gradle
+// we have a hack to prevent builds from failing due to missing signing config. This is done by
+// removing the signing task from the build if no keystore/pass is provided.
+//
+// At some point the signing task has been renamed from "validateReleaseSigning" to
+// "validateSigningRelease", thus obviously breaking the build again.
+//
+// The following is just a copy of the relevant code from android-support.gradle adapted to the new
+// name. This should be cleaned up in the future!
+afterEvaluate { project ->
+    tasks.each { task ->
+        if (isAndroidApplication) {
+            if ((task.name.toLowerCase().startsWith("assemble") && task.name.toLowerCase().contains('release'))
+                    || (task.name.toLowerCase().startsWith("bundle") && task.name.toLowerCase().contains('release'))
+                    || (task.name.toLowerCase().startsWith("package") && task.name.toLowerCase().contains('release'))
+                    || (task.name.equals("validateSigningRelease"))) {
+
+                task.setEnabled(canSign)
+            }
+        }
+    }
+}
+
 android {
     defaultConfig {
         applicationId 'org.osmdroid'

--- a/OpenStreetMapViewer/src/main/AndroidManifest.xml
+++ b/OpenStreetMapViewer/src/main/AndroidManifest.xml
@@ -1,13 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
-    package="org.osmdroid"
-    android:versionCode="20"
-    android:versionName="5.3-SNAPSHOT">
+    package="org.osmdroid">
 
-    <uses-sdk tools:overrideLibrary="mil.army.missioncommand,armyc2.c2sd.singlepointrenderer,org.osmdroid.gpkg,mil.nga.geopackage,org.osmdroid.mapsforge,android.support.v13,com.github.angads25.filepicker,android.support.v7.gridlayout"
-              android:minSdkVersion="8"
-              android:targetSdkVersion="23"/>
+    <uses-sdk tools:overrideLibrary="mil.army.missioncommand,armyc2.c2sd.singlepointrenderer,org.osmdroid.gpkg,mil.nga.geopackage,org.osmdroid.mapsforge,android.support.v13,com.github.angads25.filepicker,android.support.v7.gridlayout" />
 
     <supports-screens
         android:anyDensity="true"

--- a/OpenStreetMapViewer/src/main/res/values/oss_licenses.xml
+++ b/OpenStreetMapViewer/src/main/res/values/oss_licenses.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="license_osmdroid">
+    <string name="license_osmdroid" translatable="false">
 https://github.com/osmdroid/osmdroid\n
                                 Apache License\n
                            Version 2.0, January 2004\n
@@ -205,7 +205,7 @@ https://github.com/osmdroid/osmdroid\n
    limitations under the License.\n
 </string>
 
-    <string name="license_geopackage">\n
+    <string name="license_geopackage" translatable="false">\n
         https://github.com/ngageoint/geopackage-android\n
         The MIT License (MIT)\n
 \n
@@ -230,7 +230,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\n
 SOFTWARE.\n
 </string>
 
-    <string name="license_mapsforge">\n
+    <string name="license_mapsforge" translatable="false">\n
                            GNU LESSER GENERAL PUBLIC LICENSE\n
                        Version 3, 29 June 2007\n
 \n
@@ -398,7 +398,7 @@ permanent authorization for you to choose that version for the\n
 Library.\n
     </string>
 
-    <string name="license_acra">
+    <string name="license_acra" translatable="false">
 https://github.com/ACRA/acra\n
 \n
                                  Apache License\n
@@ -604,7 +604,7 @@ https://github.com/ACRA/acra\n
    limitations under the License.\n
     </string>
 
-    <string name="license_leakcanary">
+    <string name="license_leakcanary" translatable="false">
         https://github.com/square/leakcanary/blob/master/LICENSE.txt\n
 \n
                                  Apache License\n
@@ -810,7 +810,7 @@ https://github.com/ACRA/acra\n
    limitations under the License.\n
     </string>\n
     \n
-    <string name="license_ormlite">
+    <string name="license_ormlite" translatable="false">
 dependency of geopackage-android\n
 ISC License\n
 \n
@@ -826,7 +826,7 @@ USE OR PERFORMANCE OF THIS SOFTWARE.\n
 The author may be contacted via http://ormlite.com/\n
     </string>
     \n
-    <string name="license_pngj">
+    <string name="license_pngj" translatable="false">
 dependency of geopackage-android\n
 https://github.com/leonbloy/pngj/\n
                                 Apache License\n

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,10 @@ buildscript {
         jcenter()
         mavenCentral()
         mavenLocal()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
     dependencies {
             classpath "com.android.tools.build:gradle:${project.property('android-plugin.version')}"
@@ -37,6 +41,10 @@ allprojects {
         mavenLocal()
         maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
         maven { url "http://repo.maven.apache.org/maven2" }
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
 
     tasks.withType(JavaCompile) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -45,7 +45,7 @@ android-support.version=26.1.0
 # To be used for packages that depend on support lib (minSDK = 14 since 26.0.0)
 android-minSdkForSupportLib.version=14
 junit.version=4.12
-robolectric.version=3.0
+robolectric.version=3.8
 
 
 # Maven Repository (i.e. Sonatype Nexus Repository Manager) Configuration --------------------------

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,8 +40,10 @@ org.gradle.jvmargs=-Xms256m -Xmx2048m -XX:MaxPermSize=256m
 gradleFury.version=1.0.14
 
 
-android-plugin.version=2.1.0
-android-support.version=23.1.1
+android-plugin.version=2.2.0
+android-support.version=26.1.0
+# To be used for packages that depend on support lib (minSDK = 14 since 26.0.0)
+android-minSdkForSupportLib.version=14
 junit.version=4.12
 robolectric.version=3.0
 

--- a/osmdroid-android/src/main/AndroidManifest.xml
+++ b/osmdroid-android/src/main/AndroidManifest.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-		package="org.osmdroid.library"
-		android:versionCode="1" android:versionName="5.3-SNAPSHOT">
-
-	<uses-sdk android:minSdkVersion="8" android:targetSdkVersion="23" />
+		package="org.osmdroid.library">
 	<supports-screens android:largeScreens="true" android:normalScreens="true" android:anyDensity="true" />
 
 	<uses-feature android:name="android.hardware.location.network" android:required="false" />

--- a/osmdroid-geopackage/build.gradle
+++ b/osmdroid-geopackage/build.gradle
@@ -3,6 +3,30 @@ description = 'Geopackage support for osmdroid'
 apply plugin: 'com.android.library'
 apply from: "https://raw.githubusercontent.com/gradle-fury/gradle-fury/v1.1.4/gradle/android-support.gradle"
 
+// Attention! HACK!
+// In https://raw.githubusercontent.com/gradle-fury/gradle-fury/v1.1.4/gradle/android-support.gradle
+// we have a hack to prevent builds from failing due to missing signing config. This is done by
+// removing the signing task from the build if no keystore/pass is provided.
+//
+// At some point the signing task has been renamed from "validateReleaseSigning" to
+// "validateSigningRelease", thus obviously breaking the build again.
+//
+// The following is just a copy of the relevant code from android-support.gradle adapted to the new
+// name. This should be cleaned up in the future!
+afterEvaluate { project ->
+    tasks.each { task ->
+        if (isAndroidApplication) {
+            if ((task.name.toLowerCase().startsWith("assemble") && task.name.toLowerCase().contains('release'))
+                    || (task.name.toLowerCase().startsWith("bundle") && task.name.toLowerCase().contains('release'))
+                    || (task.name.toLowerCase().startsWith("package") && task.name.toLowerCase().contains('release'))
+                    || (task.name.equals("validateSigningRelease"))) {
+
+                task.setEnabled(canSign)
+            }
+        }
+    }
+}
+
 android {
 
     defaultConfig {

--- a/osmdroid-geopackage/src/main/AndroidManifest.xml
+++ b/osmdroid-geopackage/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.osmdroid.gpkg"  >
+<manifest
+    package="org.osmdroid.gpkg">
   
 
 </manifest>

--- a/osmdroid-mapsforge/build.gradle
+++ b/osmdroid-mapsforge/build.gradle
@@ -1,6 +1,31 @@
 description = "An Android library to display OpenStreetMap views using Mapsforge. May use non ASF licensed dependencies"
 apply plugin: 'com.android.library'
 apply from: "https://raw.githubusercontent.com/gradle-fury/gradle-fury/v1.1.4/gradle/android-support.gradle"
+
+// Attention! HACK!
+// In https://raw.githubusercontent.com/gradle-fury/gradle-fury/v1.1.4/gradle/android-support.gradle
+// we have a hack to prevent builds from failing due to missing signing config. This is done by
+// removing the signing task from the build if no keystore/pass is provided.
+//
+// At some point the signing task has been renamed from "validateReleaseSigning" to
+// "validateSigningRelease", thus obviously breaking the build again.
+//
+// The following is just a copy of the relevant code from android-support.gradle adapted to the new
+// name. This should be cleaned up in the future!
+afterEvaluate { project ->
+    tasks.each { task ->
+        if (isAndroidApplication) {
+            if ((task.name.toLowerCase().startsWith("assemble") && task.name.toLowerCase().contains('release'))
+                    || (task.name.toLowerCase().startsWith("bundle") && task.name.toLowerCase().contains('release'))
+                    || (task.name.toLowerCase().startsWith("package") && task.name.toLowerCase().contains('release'))
+                    || (task.name.equals("validateSigningRelease"))) {
+
+                task.setEnabled(canSign)
+            }
+        }
+    }
+}
+
 android {
 
     defaultConfig {

--- a/osmdroid-mapsforge/src/main/AndroidManifest.xml
+++ b/osmdroid-mapsforge/src/main/AndroidManifest.xml
@@ -1,8 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+<manifest
     package="org.osmdroid.mapsforge">
-
-    <uses-sdk
-        android:minSdkVersion="10"
-        android:targetSdkVersion="23" />
 
 </manifest>

--- a/osmdroid-simple-map/build.gradle
+++ b/osmdroid-simple-map/build.gradle
@@ -6,7 +6,7 @@ apply from: "https://raw.githubusercontent.com/gradle-fury/gradle-fury/v1.1.4/gr
 android {
     defaultConfig {
         applicationId 'org.osmdroid.sample'
-
+        minSdkVersion Integer.parseInt(project.property('android-minSdkForSupportLib.version'))
     }
 }
 

--- a/osmdroid-simple-map/build.gradle
+++ b/osmdroid-simple-map/build.gradle
@@ -3,6 +3,30 @@ description = 'Simple Map'
 apply plugin: 'com.android.application'
 apply from: "https://raw.githubusercontent.com/gradle-fury/gradle-fury/v1.1.4/gradle/android-support.gradle"
 
+// Attention! HACK!
+// In https://raw.githubusercontent.com/gradle-fury/gradle-fury/v1.1.4/gradle/android-support.gradle
+// we have a hack to prevent builds from failing due to missing signing config. This is done by
+// removing the signing task from the build if no keystore/pass is provided.
+//
+// At some point the signing task has been renamed from "validateReleaseSigning" to
+// "validateSigningRelease", thus obviously breaking the build again.
+//
+// The following is just a copy of the relevant code from android-support.gradle adapted to the new
+// name. This should be cleaned up in the future!
+afterEvaluate { project ->
+    tasks.each { task ->
+        if (isAndroidApplication) {
+            if ((task.name.toLowerCase().startsWith("assemble") && task.name.toLowerCase().contains('release'))
+                    || (task.name.toLowerCase().startsWith("bundle") && task.name.toLowerCase().contains('release'))
+                    || (task.name.toLowerCase().startsWith("package") && task.name.toLowerCase().contains('release'))
+                    || (task.name.equals("validateSigningRelease"))) {
+
+                task.setEnabled(canSign)
+            }
+        }
+    }
+}
+
 android {
     defaultConfig {
         applicationId 'org.osmdroid.sample'

--- a/osmdroid-wms/build.gradle
+++ b/osmdroid-wms/build.gradle
@@ -2,6 +2,30 @@ description = 'OSMdroid Android WMS Client'
 apply plugin: 'com.android.library'
 apply from: "https://raw.githubusercontent.com/gradle-fury/gradle-fury/v1.1.4/gradle/android-support.gradle"
 
+// Attention! HACK!
+// In https://raw.githubusercontent.com/gradle-fury/gradle-fury/v1.1.4/gradle/android-support.gradle
+// we have a hack to prevent builds from failing due to missing signing config. This is done by
+// removing the signing task from the build if no keystore/pass is provided.
+//
+// At some point the signing task has been renamed from "validateReleaseSigning" to
+// "validateSigningRelease", thus obviously breaking the build again.
+//
+// The following is just a copy of the relevant code from android-support.gradle adapted to the new
+// name. This should be cleaned up in the future!
+afterEvaluate { project ->
+    tasks.each { task ->
+        if (isAndroidApplication) {
+            if ((task.name.toLowerCase().startsWith("assemble") && task.name.toLowerCase().contains('release'))
+                    || (task.name.toLowerCase().startsWith("bundle") && task.name.toLowerCase().contains('release'))
+                    || (task.name.toLowerCase().startsWith("package") && task.name.toLowerCase().contains('release'))
+                    || (task.name.equals("validateSigningRelease"))) {
+
+                task.setEnabled(canSign)
+            }
+        }
+    }
+}
+
 android {
     defaultConfig {
         minSdkVersion Integer.parseInt(project.property('android-minSdkForSupportLib.version'))

--- a/osmdroid-wms/build.gradle
+++ b/osmdroid-wms/build.gradle
@@ -3,18 +3,20 @@ apply plugin: 'com.android.library'
 apply from: "https://raw.githubusercontent.com/gradle-fury/gradle-fury/v1.1.4/gradle/android-support.gradle"
 
 android {
-
+    defaultConfig {
+        minSdkVersion Integer.parseInt(project.property('android-minSdkForSupportLib.version'))
+    }
 }
 
 
 dependencies {
 
     compile project(':osmdroid-android')
-    compile 'com.android.support:appcompat-v7:23.1.1'
+    compile "com.android.support:appcompat-v7:${project.property('android-support.version')}"
 
-    testCompile "org.robolectric:robolectric:3.0"
+    testCompile "org.robolectric:robolectric:${project.property('robolectric.version')}"
 
-    testCompile 'junit:junit:4.12'
+    testCompile "junit:junit:${project.property('junit.version')}"
 
 
 

--- a/osmdroid-wms/src/main/AndroidManifest.xml
+++ b/osmdroid-wms/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="org.osmdroid.wms"  >
+<manifest
+          package="org.osmdroid.wms">
 
 
 </manifest>

--- a/osmdroid-wms/src/test/java/org/osmdroid/wms/ParserTest.java
+++ b/osmdroid-wms/src/test/java/org/osmdroid/wms/ParserTest.java
@@ -4,7 +4,7 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.io.File;
@@ -13,7 +13,7 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-@RunWith(RobolectricGradleTestRunner.class)
+@RunWith(RobolectricTestRunner.class)
 @Config(constants = BuildConfig.class
     , sdk = 21)
 public class ParserTest{


### PR DESCRIPTION
The recent commits concerning #1098 only covered part of the problem: Having compileSDK on a different version than the support libs is guaranteed to cause issues.
This PR brings the support lib up to version to 26.x. Please note that I just made sure this builds an the tests run - there still might be some issues due to the rather large jump and the corresponding behavior changes in various components of the support lib. Ideally someone should go through https://developer.android.com/topic/libraries/support-library/revisions and check the notes for possible issues. 

Most importantly this PR also raises the minSDK for the demo app to 14, since the 26.0 support libs require it.