### PR TITLE
bug/#1218 - added the zoom button test in map view double tap listener

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/views/CustomZoomButtonsController.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/CustomZoomButtonsController.java
@@ -188,14 +188,14 @@ public class CustomZoomButtonsController {
 		if (checkJustActivated()) {
 			return false;
 		}
-		if (mZoomInEnabled && mDisplay.isTouchedRotated(pMotionEvent, true)) {
-			if (mListener != null) {
+		if (mDisplay.isTouchedRotated(pMotionEvent, true)) {
+			if (mZoomInEnabled && mListener != null) {
 				mListener.onZoom(true);
 			}
 			return true;
 		}
-		if (mZoomOutEnabled && mDisplay.isTouchedRotated(pMotionEvent, false)) {
-			if (mListener != null) {
+		if (mDisplay.isTouchedRotated(pMotionEvent, false)) {
+			if (mZoomOutEnabled && mListener != null) {
 				mListener.onZoom(false);
 			}
 			return true;

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
@@ -1539,8 +1539,10 @@ public class MapView extends ViewGroup implements IMapView,
 				return true;
 			}
 
-			// final IGeoPoint center = getProjection().fromPixels((int) e.getX(), (int) e.getY(),
-			// null);
+			if (mZoomController != null && mZoomController.onSingleTapConfirmed(e)) {
+				return true;
+			}
+
 			getProjection().rotateAndScalePoint((int) e.getX(), (int) e.getY(), mRotateScalePoint);
 			return getController().zoomInFixing(mRotateScalePoint.x, mRotateScalePoint.y);
 		}


### PR DESCRIPTION
Impacted classes:
* `CustomZoomButtonsController`: slight unrelated edit - even when the zoom button is deactivated (_id est_ looks gray) a tap on it is caught, in order to prevent the case where someone frantically clicks on the zoom out button down to zoom 0 - when in zoom 0 a double click on the zoom out button is supposed to stay on zoom 0, not zoom in
* `MapView`: added the zoom button test in `MapViewDoubleClickListener.onDoubleTap`