### PR TITLE
bug/#1217 - new "stressed memory" parameter in memory cache management

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/debug/CacheAnalyzerActivity.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/debug/CacheAnalyzerActivity.java
@@ -161,8 +161,14 @@ public class CacheAnalyzerActivity extends Activity implements AdapterView.OnIte
         final StringBuilder sb = new StringBuilder("Source: tile count\n");
         if (sources.isEmpty())
             sb.append("None");
-        for (int i = 0; i < sources.size(); i++) {
-            sb.append(sources.get(i).source + ": " + sources.get(i).rowCount + "\n");
+        for (final SqlTileWriterExt.SourceCount sourceCount : sources) {
+            sb.append("Source ").append(sourceCount.source);
+            sb.append(": count=").append(sourceCount.rowCount);
+            sb.append("; minsize=").append(sourceCount.sizeMin);
+            sb.append("; maxsize=").append(sourceCount.sizeMax);
+            sb.append("; totalsize=").append(sourceCount.sizeTotal);
+            sb.append("; avgsize=").append(sourceCount.sizeAvg);
+            sb.append("\n");
         }
         long expired = 0;
         if (cache!=null)

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileCache.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileCache.java
@@ -69,6 +69,11 @@ public class MapTileCache {
 	 */
 	private boolean mAutoEnsureCapacity;
 
+	/**
+	 * @since 6.0.4
+	 */
+	private boolean mStressedMemory;
+
 	// ===========================================================
 	// Constructors
 	// ===========================================================
@@ -111,6 +116,19 @@ public class MapTileCache {
 		mAutoEnsureCapacity = pAutoEnsureCapacity;
 	}
 
+	/**
+	 * @since 6.0.4
+	 * When true, all the tiles in the cache that eventually don't belong here are removed asap.
+	 * When false, we will still remove tiles that do not belong in the cache anymore,
+	 * but not necessarily all of them: only the amount we need in order to fit the cache size.
+	 * Should be set to true when you have small memory and big tiles in order to
+	 * avoid OutOfMemoryException.
+	 * Should be set to false for better performances.
+	 */
+	public void setStressedMemory(final boolean pStressedMemory) {
+		mStressedMemory = pStressedMemory;
+	}
+
 	public boolean ensureCapacity(final int pCapacity) {
 		if (mCapacity < pCapacity) {
 			Log.i(IMapView.LOGTAG, "Tile cache increased from " + mCapacity + " to " + pCapacity);
@@ -139,20 +157,26 @@ public class MapTileCache {
 	 * @since 6.0.0
 	 */
 	public void garbageCollection() {
+		// number of tiles to remove from cache
+		int toBeRemoved = Integer.MAX_VALUE; // MAX_VALUE for stressed memory case
 		final int size = mCachedTiles.size();
-		int toBeRemoved = size - mCapacity;
-		if (toBeRemoved <= 0) {
-			return;
+		if (!mStressedMemory) {
+			toBeRemoved = size - mCapacity;
+			if (toBeRemoved <= 0) {
+				return;
+			}
 		}
 
 		refreshAdditionalLists();
 
 		if (mAutoEnsureCapacity) {
-			long target = mMapTileArea.size() + mAdditionalMapTileList.size();
-			if (ensureCapacity((int)target)) {
-				toBeRemoved = size - mCapacity;
-				if (toBeRemoved <= 0) {
-					return;
+			final int target = mMapTileArea.size() + mAdditionalMapTileList.size();
+			if (ensureCapacity(target)) {
+				if (!mStressedMemory) {
+					toBeRemoved = size - mCapacity;
+					if (toBeRemoved <= 0) {
+						return;
+					}
 				}
 			}
 		}

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderBasic.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderBasic.java
@@ -110,6 +110,7 @@ public class MapTileProviderBasic extends MapTileProviderArray implements IMapTi
 		getTileCache().getProtectedTileComputers().add(new MapTileAreaZoomComputer(1));
 		getTileCache().getProtectedTileComputers().add(new MapTileAreaBorderComputer(1));
 		getTileCache().setAutoEnsureCapacity(true);
+		getTileCache().setStressedMemory(false);
 
 		// pre-cache providers
 		getTileCache().getPreCache().addProvider(assetsProvider);

--- a/osmdroid-android/src/main/java/org/osmdroid/util/MapTileArea.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/MapTileArea.java
@@ -151,4 +151,12 @@ public class MapTileArea implements MapTileContainer, IterableWithSize<Long>{
         }
         return Math.min(mMapTileUpperBound, pBottomRight - pTopLeft + 1);
     }
+
+    @Override
+    public String toString() {
+        if (mWidth == 0) {
+            return "MapTileArea:empty";
+        }
+        return "MapTileArea:zoom=" + mZoom + ",left=" + mLeft + ",top=" + mTop + ",width=" + mWidth + ",height=" + mHeight;
+    }
 }


### PR DESCRIPTION
Impacted classes:
* `MapTileCache`: added the concept (member + setter) of "stressed memory" - when `true`, we systematically remove asap the useless tiles from the memory cache, when `false` (default value) we just remove enough tiles to fit the cache size, cf. method `garbageCollection`
* `MapTileProviderBasic`: explicitly defaulted the memory cache stressed memory parameter to `false`
* `SqlTileWriterExt`: slightly unrelated - added info about the tile sizes in method `getSources` and class `SourceCount`
* `CacheAnalyzerActivity`: slightly unrelated - added info about tile sizes in the display header, cf. method `run`
* `MapTileArea`: slightly unrelated - overrode `toString`