### PR TITLE
bug/#1222 - SqlTileWriter.loadTile refactoring and memory side effect

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderBasic.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderBasic.java
@@ -109,7 +109,7 @@ public class MapTileProviderBasic extends MapTileProviderArray implements IMapTi
 		getTileCache().getProtectedTileComputers().add(new MapTileAreaZoomComputer(-1));
 		getTileCache().getProtectedTileComputers().add(new MapTileAreaZoomComputer(1));
 		getTileCache().getProtectedTileComputers().add(new MapTileAreaBorderComputer(1));
-		getTileCache().setAutoEnsureCapacity(true);
+		getTileCache().setAutoEnsureCapacity(false);
 		getTileCache().setStressedMemory(false);
 
 		// pre-cache providers


### PR DESCRIPTION
Impacted classes:
* `MapTileProviderBasic`: set the default `setAutoEnsureCapacity` to `false` (instead of `true`) because of alleged memory side-effect crash
* `SqlTileWriter`: refactored method `loadTile` - cleaner and optimized cursor management