### PR TITLE
bug/#1217_2 - zoom and cache management refactoring

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileCache.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileCache.java
@@ -281,7 +281,7 @@ public class MapTileCache {
 	 * @since 6.0.0
 	 * Was in LRUMapTileCache
 	 */
-	public void remove(final long pMapTileIndex) {
+	protected void remove(final long pMapTileIndex) {
 		final Drawable drawable;
 		synchronized (mCachedTiles) {
 			drawable = mCachedTiles.remove(pMapTileIndex);

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderBase.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderBase.java
@@ -297,7 +297,7 @@ public abstract class MapTileProviderBase implements IMapTileProviderCallback {
 	public void rescaleCache(final Projection pProjection, final double pNewZoomLevel,
 			final double pOldZoomLevel, final Rect pViewPort) {
 
-		if (pNewZoomLevel == pOldZoomLevel) {
+		if (TileSystem.getInputTileZoomLevel(pNewZoomLevel) == TileSystem.getInputTileZoomLevel(pOldZoomLevel)) {
 			return;
 		}
 
@@ -454,7 +454,6 @@ public abstract class MapTileProviderBase implements IMapTileProviderCallback {
 									x * mTileSize_2, y * mTileSize_2,
 									(x + 1) * mTileSize_2, (y + 1) * mTileSize_2);
 							canvas.drawBitmap(oldBitmap, null, mDestRect, null);
-							mTileCache.remove(oldTile);
 						}
 					}
 				}

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
@@ -172,6 +172,11 @@ public class MapView extends ViewGroup implements IMapView,
 
 	private static TileSystem mTileSystem = new TileSystemWebMercator();
 
+	/**
+	 * @since 6.1.0
+	 */
+	private final Rect mRescaleScreenRect = new Rect(); // optimization
+
 	// ===========================================================
 	// Constructors
 	// ===========================================================
@@ -480,7 +485,7 @@ public class MapView extends ViewGroup implements IMapView,
 				getController().animateTo(geoPoint);
 			}
 
-			mTileProvider.rescaleCache(pj, newZoomLevel, curZoomLevel, getScreenRect(null));
+			mTileProvider.rescaleCache(pj, newZoomLevel, curZoomLevel, getScreenRect(mRescaleScreenRect));
 			pauseFling = true;	// issue 269, pause fling during zoom changes
 		}
 


### PR DESCRIPTION
There used to be an unexpected removal of tiles from cache when zooming out. Not only did I remove this impact on cache, but I also made it less likely to happen again by downgrading cache method `remove` from `public` to `protected`.
The rest is about code optimization when zooming in and out.

Impacted classes:
* `MapTileCache`: downgraded method `remove` from `public` to `protected`, in order to avoid undesired cache management from outside
* `MapTileProviderBase`: edited the "is it worth?" check at the beginning of method `rescaleCache` in order to avoid eventually unnecessary code and instance creations; removed the removal of tile from cache in `ZoomOutTileLooper.computeTile`
* `MapView`: optimized the call to `MapTileProviderBase.rescaleCache` using the new `Rect mRescaleScreenRect` member
* `TilesOverlay`: replaced in method `protectDisplayedTilesForCache` the call to now removed inner class `CacheTileLooper` with a more direct code; created member `Rect mProtectedTiles` for optimization