### PR TITLE
bug/#1193 - "offline second" option and smaller protected tile set

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleFactory.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleFactory.java
@@ -97,6 +97,8 @@ import org.osmdroid.samplefragments.tilesources.SampleInvertedTiles_NightMode;
 import org.osmdroid.samplefragments.tilesources.SampleLieFi;
 import org.osmdroid.samplefragments.tilesources.SampleMapBox;
 import org.osmdroid.samplefragments.tilesources.SampleMapQuest;
+import org.osmdroid.samplefragments.tilesources.SampleOfflineFirst;
+import org.osmdroid.samplefragments.tilesources.SampleOfflineSecond;
 import org.osmdroid.samplefragments.tilesources.SampleOpenSeaMap;
 import org.osmdroid.samplefragments.tilesources.SampleWMSSource;
 import org.osmdroid.samplefragments.tilesources.SampleWhackyColorFilter;
@@ -301,6 +303,8 @@ public final class SampleFactory implements ISampleFactory {
         mSamples.add(SampleItemizedOverlayMultiClick.class);
         mSamples.add(SampleMarkerMultiClick.class);
         mSamples.add(SampleMilestonesNonRepetitive.class);
+        mSamples.add(SampleOfflineFirst.class);
+        mSamples.add(SampleOfflineSecond.class);
     }
 
     public void addSample(Class<? extends BaseSampleFragment> clz) {

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/tilesources/SampleOfflineFirst.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/tilesources/SampleOfflineFirst.java
@@ -1,0 +1,14 @@
+package org.osmdroid.samplefragments.tilesources;
+
+/**
+ * Offline First demo
+ * @since 6.1.0
+ * @author Fabrice Fontaine
+ */
+public class SampleOfflineFirst extends SampleOfflinePriority {
+
+    @Override
+    protected boolean isOfflineFirst() {
+        return true;
+    }
+}

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/tilesources/SampleOfflinePriority.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/tilesources/SampleOfflinePriority.java
@@ -1,0 +1,53 @@
+package org.osmdroid.samplefragments.tilesources;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import org.osmdroid.samplefragments.BaseSampleFragment;
+import org.osmdroid.tileprovider.MapTileProviderBasic;
+import org.osmdroid.util.GeoPoint;
+import org.osmdroid.views.MapView;
+
+/**
+ * Offline First and Offline Second demos
+ * The typical difference is when you pan the map to places you've never been to.
+ * In the Offline First demo, you'll see an approximation of the tile before the actual downloaded
+ * In the Offline Second demo, you'll see a gray square before the actual downloaded
+ * @since 6.1.0
+ * @author Fabrice Fontaine
+ */
+abstract public class SampleOfflinePriority extends BaseSampleFragment {
+
+    private final GeoPoint mInitialCenter = new GeoPoint(41.8905495, 12.4924348); // Rome, Italy
+    private final double mInitialZoomLevel = 5;
+
+    protected abstract boolean isOfflineFirst();
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        final MapTileProviderBasic provider = new MapTileProviderBasic(getActivity());
+        provider.setOfflineFirst(isOfflineFirst());
+        mMapView = new MapView(inflater.getContext(), provider);
+        return mMapView;
+    }
+
+    @Override
+    protected void addOverlays() {
+        super.addOverlays();
+
+        mMapView.post(new Runnable() { // "post" because we need View.getWidth() to be set
+            @Override
+            public void run() {
+                mMapView.getController().setZoom(mInitialZoomLevel);
+                mMapView.setExpectedCenter(mInitialCenter);
+            }
+        });
+    }
+
+    @Override
+    public String getSampleTitle() {
+        return "Offline " + (isOfflineFirst() ? "First" : "Second");
+    }
+}

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/tilesources/SampleOfflineSecond.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/tilesources/SampleOfflineSecond.java
@@ -1,0 +1,14 @@
+package org.osmdroid.samplefragments.tilesources;
+
+/**
+ * Offline Second demo
+ * @since 6.1.0
+ * @author Fabrice Fontaine
+ */
+public class SampleOfflineSecond extends SampleOfflinePriority {
+
+    @Override
+    protected boolean isOfflineFirst() {
+        return false;
+    }
+}


### PR DESCRIPTION
New classes:
* `SampleOfflinePriority`: abstract demo class
* `SampleOfflineFirst`: Offline First demo, to be found in "More Samples / Tilesources / Offline First"
* `SampleOfflineSecond`: Offline Second demo, to be found in "More Samples / Tilesources / Offline Second"

Impacted classes:
* `MapTileProviderBasic`: added method `setOfflineFirst` (called by default with `true`); removed the resource intensive protected tile computer of zoom+1; transformed provider variables as members in order to implement method `setOfflineFirst`
* `SampleFactory`: added the Offline First and Offline Second demos