### PR TITLE
Fix scroll lag when "follow location" is cancelled by user input

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapController.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapController.java
@@ -241,13 +241,15 @@ public class MapController implements IMapController, OnFirstLayoutListener {
                 stopPanning();
         }
 
-        // We ignore the jumpToTarget for zoom levels since it doesn't make sense to stop
-        // the animation in the middle. Maybe we could have it cancel the zoom operation and jump
-        // back to original zoom level?
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
             final Animator currentAnimator = this.mCurrentAnimator;
             if (mMapView.mIsAnimating.get()) {
-                currentAnimator.end();
+                if (jumpToTarget) {
+                    currentAnimator.end();
+                }
+                else {
+                    currentAnimator.cancel();
+                }
             }
         } else {
             if (mMapView.mIsAnimating.get()) {
@@ -487,7 +489,7 @@ public class MapController implements IMapController, OnFirstLayoutListener {
 
         @Override
         public void onAnimationCancel(Animator animator) {
-            //noOp
+            mMapController.onAnimationEnd();
         }
 
         @Override

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapController.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapController.java
@@ -155,6 +155,9 @@ public class MapController implements IMapController, OnFirstLayoutListener {
                 mapAnimator.setDuration(pSpeed);
             }
 
+            if (mCurrentAnimator != null) {
+                mCurrentAnimator.end();
+            }
             mCurrentAnimator = mapAnimator;
             mapAnimator.start();
             return;

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/mylocation/MyLocationNewOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/mylocation/MyLocationNewOverlay.java
@@ -298,11 +298,13 @@ public class MyLocationNewOverlay extends Overlay implements IMyLocationConsumer
 
 	@Override
 	public boolean onTouchEvent(final MotionEvent event, final MapView mapView) {
-		if (event.getAction() == MotionEvent.ACTION_MOVE) {
-			if (enableAutoStop)
+		if (event.getAction() == MotionEvent.ACTION_DOWN) {
+			if (enableAutoStop) {
+				mMapController.stopAnimation(false);
 				this.disableFollowLocation();
-			else
+			} else {
 				return true;//prevent the pan
+			}
 		}
 
 		return super.onTouchEvent(event, mapView);

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/mylocation/MyLocationNewOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/mylocation/MyLocationNewOverlay.java
@@ -298,13 +298,10 @@ public class MyLocationNewOverlay extends Overlay implements IMyLocationConsumer
 
 	@Override
 	public boolean onTouchEvent(final MotionEvent event, final MapView mapView) {
-		if (event.getAction() == MotionEvent.ACTION_DOWN) {
-			if (enableAutoStop) {
-				mMapController.stopAnimation(false);
-				this.disableFollowLocation();
-			} else {
-				return true;//prevent the pan
-			}
+		if (event.getAction() == MotionEvent.ACTION_DOWN && enableAutoStop) {
+			this.disableFollowLocation();
+		} else if (event.getAction() == MotionEvent.ACTION_MOVE && isFollowLocationEnabled()) {
+			return true;  // prevent the pan
 		}
 
 		return super.onTouchEvent(event, mapView);
@@ -407,6 +404,7 @@ public class MyLocationNewOverlay extends Overlay implements IMyLocationConsumer
 	 * Disables "follow" functionality.
 	 */
 	public void disableFollowLocation() {
+		mMapController.stopAnimation(false);
 		mIsFollowing = false;
 	}
 


### PR DESCRIPTION
_Do I need to open an issue?_

### What is wrong
When the "follow location" option is enabled and "auto stop" feature is enabled too, then when the user tries to scroll the map it causes a weird lag before performing the actual map pan based on user input.

### RCA
`MyLocationNewOverlay`'s `onTouchEvent` doesn't stop the animation coming from `setLocation` method. Controller doesn't end it's scroller animation even if it is supposed to do so.

### Fix
Make `onTouchEvent` stop the map animation on `ACTION_DOWN` and fix `MapController` to actually end the animation.

### Please see
`MapController`'s `stopAnimation` comments are not clear for me. The animator is not only for zoom but for scroll too.

### Testing
- Device with Android 9.0
- Device with Android 4.4

- Sample osmdroid app: More samples -> Location -> Follow Me