### PR TITLE
bug/#1241 - enabling/disabling zoom buttons at MapView init time too

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
@@ -226,6 +226,7 @@ public class MapView extends ViewGroup implements IMapView,
 
 		mZoomController = new CustomZoomButtonsController(this);
 		mZoomController.setOnZoomListener(new MapViewZoomListener());
+		checkZoomButtons();
 
 		mGestureDetector = new GestureDetector(context, new MapViewGestureDetectorListener());
 		mGestureDetector.setOnDoubleTapListener(new MapViewDoubleClickListener());


### PR DESCRIPTION
If you don't use something like `MapView.setZoomLevel`:
* your map will be on zoom 0 - fair enough
* the zoom buttons need to be initialized - which was not the case, and both were inactive

Impacted class:
* `MapView`: added an explicit call to `checkZoomButtons` in the constructor