### PR TITLE
feature/#990 - step 1 - Overlay.draw(Canvas, Projection)

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/bugtestfragments/Bug82WinDeath.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/bugtestfragments/Bug82WinDeath.java
@@ -8,7 +8,7 @@ import android.util.Log;
 
 import org.osmdroid.samplefragments.BaseSampleFragment;
 import org.osmdroid.util.GeoPoint;
-import org.osmdroid.views.MapView;
+import org.osmdroid.views.Projection;
 import org.osmdroid.views.overlay.Overlay;
 
 /**
@@ -47,14 +47,10 @@ public class Bug82WinDeath extends BaseSampleFragment {
         }
 
         @Override
-        public void draw(Canvas canvas, MapView mapView, boolean shadow) {
-            if (!shadow) {
-                // && mapView.getZoomLevel() > 5
-                Log.i(TAG, "Drawing Bug82 Windeath circle");
-                Point point = mapView.getProjection().toPixels(new GeoPoint(50.71838, -103.42443), new Point());
-                canvas.drawCircle(point.x, point.y, 100.0f, innerPaint);
-            }
-
+        public void draw(Canvas canvas, Projection pProjection) {
+            Log.i(TAG, "Drawing Bug82 Windeath circle");
+            Point point = pProjection.toPixels(new GeoPoint(50.71838, -103.42443), new Point());
+            canvas.drawCircle(point.x, point.y, 100.0f, innerPaint);
         }
     }
 }

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/drawing/CirclePlottingOverlay.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/drawing/CirclePlottingOverlay.java
@@ -1,6 +1,5 @@
 package org.osmdroid.samplefragments.drawing;
 
-import android.graphics.Canvas;
 import android.util.Log;
 import android.view.MotionEvent;
 
@@ -26,11 +25,6 @@ public class CirclePlottingOverlay extends Overlay {
     public CirclePlottingOverlay(float distanceKm) {
         super();
         this.distanceKm = distanceKm;
-    }
-
-    @Override
-    public void draw(Canvas c, MapView osmv, boolean shadow) {
-
     }
 
     @Override

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/drawing/IconPlottingOverlay.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/drawing/IconPlottingOverlay.java
@@ -1,6 +1,5 @@
 package org.osmdroid.samplefragments.drawing;
 
-import android.graphics.Canvas;
 import android.graphics.drawable.Drawable;
 import android.view.MotionEvent;
 
@@ -26,11 +25,6 @@ public class IconPlottingOverlay extends Overlay {
     public IconPlottingOverlay(Drawable m) {
         super();
         markerIcon = m;
-
-    }
-
-    @Override
-    public void draw(Canvas c, MapView osmv, boolean shadow) {
 
     }
 

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/milstd2525/MilStdPointPlottingOverlay.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/milstd2525/MilStdPointPlottingOverlay.java
@@ -1,6 +1,5 @@
 package org.osmdroid.samplefragments.milstd2525;
 
-import android.graphics.Canvas;
 import android.graphics.drawable.BitmapDrawable;
 import android.util.SparseArray;
 import android.view.MotionEvent;
@@ -35,11 +34,6 @@ public class MilStdPointPlottingOverlay extends Overlay {
 
     public void setSymbol(SimpleSymbol def) {
         this.def = def;
-    }
-
-    @Override
-    public void draw(Canvas c, MapView osmv, boolean shadow) {
-
     }
 
     @Override

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/tileproviders/SampleTileStates.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/tileproviders/SampleTileStates.java
@@ -12,7 +12,7 @@ import android.widget.TextView;
 import org.osmdroid.R;
 import org.osmdroid.samplefragments.BaseSampleFragment;
 import org.osmdroid.tileprovider.TileStates;
-import org.osmdroid.views.MapView;
+import org.osmdroid.views.Projection;
 import org.osmdroid.views.overlay.Overlay;
 
 /**
@@ -50,7 +50,7 @@ public class SampleTileStates extends BaseSampleFragment {
         final Bitmap ko = ((BitmapDrawable)getResources().getDrawable(R.drawable.twotone_warning_black_36)).getBitmap();
         mMapView.getOverlayManager().add(new Overlay() {
             @Override
-            public void draw(Canvas c, MapView osmv, boolean shadow) {
+            public void draw(Canvas c, Projection projection) {
                 final Bitmap bitmap = mOk ? ok : ko;
                 c.drawBitmap(bitmap, c.getWidth() / 2 - bitmap.getWidth() / 2, c.getHeight() / 2 - bitmap.getHeight() / 2, null);
             }

--- a/osmdroid-android/src/main/java/org/osmdroid/views/Projection.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/Projection.java
@@ -780,4 +780,25 @@ public class Projection implements IProjection {
 		pMapView.setMapScroll(mScrollX, mScrollY);
 		return true;
 	}
+
+	/**
+	 * @since 6.1.0
+	 */
+	public boolean isHorizontalWrapEnabled() {
+		return horizontalWrapEnabled;
+	}
+
+	/**
+	 * @since 6.1.0
+	 */
+	public boolean isVerticalWrapEnabled() {
+		return verticalWrapEnabled;
+	}
+
+	/**
+	 * @since 6.1.0
+	 */
+	public float getOrientation() {
+		return mOrientation;
+	}
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/CopyrightOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/CopyrightOverlay.java
@@ -32,6 +32,7 @@ import android.util.DisplayMetrics;
 
 import org.osmdroid.tileprovider.tilesource.ITileSource;
 import org.osmdroid.views.MapView;
+import org.osmdroid.views.Projection;
 
 
 /**
@@ -55,6 +56,7 @@ public class CopyrightOverlay extends Overlay {
     protected boolean alignBottom = true;
     protected boolean alignRight = false;
     final DisplayMetrics dm;
+    private String mCopyrightNotice;
     // Constructor
 
     public CopyrightOverlay(Context context) {
@@ -104,11 +106,16 @@ public class CopyrightOverlay extends Overlay {
 
     @Override
     public void draw(Canvas canvas, MapView map, boolean shadow) {
-        if (shadow) return;
+        setCopyrightNotice(map.getTileProvider().getTileSource().getCopyrightNotice());
+        draw(canvas, map.getProjection());
+    }
 
-
-        if (map.getTileProvider().getTileSource().getCopyrightNotice() == null ||
-            map.getTileProvider().getTileSource().getCopyrightNotice().length() == 0)
+    /**
+     * @since 6.1.0
+     */
+    @Override
+    public void draw(final Canvas canvas, final Projection pProjection) {
+        if (mCopyrightNotice == null || mCopyrightNotice.length() == 0)
             return;
 
         int width = canvas.getWidth();
@@ -131,8 +138,15 @@ public class CopyrightOverlay extends Overlay {
             y = paint.getTextSize() + yOffset;
 
         // Draw the text
-        map.getProjection().save(canvas, false, false);
-        canvas.drawText(map.getTileProvider().getTileSource().getCopyrightNotice(), x, y, paint);
-        map.getProjection().restore(canvas, false);
+        pProjection.save(canvas, false, false);
+        canvas.drawText(mCopyrightNotice, x, y, paint);
+        pProjection.restore(canvas, false);
+    }
+
+    /**
+     * @since 6.1.0
+     */
+    public void setCopyrightNotice(final String pCopyrightNotice) {
+        mCopyrightNotice = pCopyrightNotice;
     }
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/DefaultOverlayManager.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/DefaultOverlayManager.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.osmdroid.api.IMapView;
 import org.osmdroid.views.MapView;
+import org.osmdroid.views.Projection;
 import org.osmdroid.views.overlay.Overlay.Snappable;
 
 import android.graphics.Canvas;
@@ -31,7 +32,7 @@ public class DefaultOverlayManager extends AbstractList<Overlay> implements Over
 
     public DefaultOverlayManager(final TilesOverlay tilesOverlay) {
         setTilesOverlay(tilesOverlay);
-        mOverlayList = new CopyOnWriteArrayList<Overlay>();
+        mOverlayList = new CopyOnWriteArrayList<>();
     }
 
     @Override
@@ -119,25 +120,33 @@ public class DefaultOverlayManager extends AbstractList<Overlay> implements Over
 
     @Override
     public void onDraw(final Canvas c, final MapView pMapView) {
+        onDraw(c, pMapView.getProjection());
+    }
+
+    /**
+     * @since 6.1.0
+     */
+    @Override
+    public void onDraw(final Canvas c, final Projection pProjection) {
         //fix for https://github.com/osmdroid/osmdroid/issues/904
         if (mTilesOverlay!=null)
-            mTilesOverlay.protectDisplayedTilesForCache(c, pMapView);
+            mTilesOverlay.protectDisplayedTilesForCache(c, pProjection);
         for (final Overlay overlay : mOverlayList) {
             if (overlay!=null && overlay.isEnabled() && overlay instanceof TilesOverlay) {
-                ((TilesOverlay) overlay).protectDisplayedTilesForCache(c, pMapView);
+                ((TilesOverlay) overlay).protectDisplayedTilesForCache(c, pProjection);
             }
         }
 
         //always pass false, the shadow parameter will be removed in a later version of osmdroid, this change should result in the on draw being called twice
         if (mTilesOverlay != null && mTilesOverlay.isEnabled()) {
-            mTilesOverlay.draw(c, pMapView, false);
+            mTilesOverlay.draw(c, pProjection);
         }
 
         //always pass false, the shadow parameter will be removed in a later version of osmdroid, this change should result in the on draw being called twice
         for (final Overlay overlay : mOverlayList) {
             //#396 fix, null check
             if (overlay!=null && overlay.isEnabled()) {
-                overlay.draw(c, pMapView, false);
+                overlay.draw(c, pProjection);
             }
         }
         //potential fix for #52 pMapView.invalidate();

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/FolderOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/FolderOverlay.java
@@ -3,6 +3,7 @@ package org.osmdroid.views.overlay;
 import java.util.List;
 
 import org.osmdroid.views.MapView;
+import org.osmdroid.views.Projection;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
@@ -67,10 +68,8 @@ public class FolderOverlay extends Overlay {
 	}
 
 	@SuppressLint("WrongCall")
-	@Override public void draw(Canvas canvas, MapView osm, boolean shadow) {
-		if (shadow)
-			return;
-		mOverlayManager.onDraw(canvas, osm);
+	@Override public void draw(final Canvas pCanvas, final Projection pProjection) {
+		mOverlayManager.onDraw(pCanvas, pProjection);
 	}
 
 	@Override public boolean onSingleTapUp(MotionEvent e, MapView mapView){

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/GroundOverlay2.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/GroundOverlay2.java
@@ -6,7 +6,6 @@ import android.graphics.Matrix;
 import android.graphics.Paint;
 
 import org.osmdroid.util.GeoPoint;
-import org.osmdroid.views.MapView;
 import org.osmdroid.views.Projection;
 
 /**
@@ -73,13 +72,11 @@ public class GroundOverlay2 extends Overlay {
 	
 
     @Override
-    public void draw(Canvas canvas, MapView mapView, boolean shadow)
+    public void draw(Canvas canvas, Projection pj)
     {
-		if(null == mImage || shadow) {
+		if(null == mImage) {
 			return;
 		}
-
-        final Projection pj = mapView.getProjection();
 
         long x0 = pj.getLongPixelXFromLongitude(mLonL),
              y0 = pj.getLongPixelYFromLatitude(mLatU),

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/IconOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/IconOverlay.java
@@ -47,15 +47,11 @@ public class IconOverlay extends Overlay {
      * Draw the icon.
      */
     @Override
-    public void draw(Canvas canvas, MapView mapView, boolean shadow) {
-        if (shadow)
-            return;
+    public void draw(Canvas canvas, Projection pj) {
         if (mIcon == null)
             return;
         if (mPosition == null)
             return;
-
-        final Projection pj = mapView.getProjection();
 
         pj.toPixels(mPosition, mPositionPixels);
         int width = mIcon.getIntrinsicWidth();
@@ -66,7 +62,7 @@ public class IconOverlay extends Overlay {
 
         mIcon.setAlpha((int) (mAlpha * 255));
 
-        float rotationOnScreen = (mFlat ? -mBearing : mapView.getMapOrientation()-mBearing);
+        float rotationOnScreen = (mFlat ? -mBearing : pj.getOrientation()-mBearing);
         drawAt(canvas, mIcon, mPositionPixels.x, mPositionPixels.y, false, rotationOnScreen);
     }
 

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/ItemizedOverlayWithFocus.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/ItemizedOverlayWithFocus.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.osmdroid.library.R;
 import org.osmdroid.views.MapView;
+import org.osmdroid.views.Projection;
 import org.osmdroid.views.overlay.OverlayItem.HotspotPlace;
 
 import android.content.Context;
@@ -228,13 +229,9 @@ public class ItemizedOverlayWithFocus<Item extends OverlayItem> extends Itemized
 	private final Rect mRect = new Rect();
 
 	@Override
-	public void draw(final Canvas c, final MapView osmv, final boolean shadow) {
+	public void draw(final Canvas c, final Projection pProjection) {
 
-		super.draw(c, osmv, shadow);
-
-		if (shadow) {
-			return;
-		}
+		super.draw(c, pProjection);
 
 		if (this.mFocusedItemIndex == NOT_SET) {
 			return;
@@ -251,7 +248,7 @@ public class ItemizedOverlayWithFocus<Item extends OverlayItem> extends Itemized
 		}
 
 		/* Calculate and set the bounds of the marker. */
-		osmv.getProjection().toPixels(focusedItem.getPoint(), mFocusedScreenCoords);
+		pProjection.toPixels(focusedItem.getPoint(), mFocusedScreenCoords);
 
 		markerFocusedBase.copyBounds(mRect);
 		mRect.offset(mFocusedScreenCoords.x, mFocusedScreenCoords.y);
@@ -328,9 +325,9 @@ public class ItemizedOverlayWithFocus<Item extends OverlayItem> extends Itemized
 				- (lines.length + 1) * DESCRIPTION_LINE_HEIGHT /* +1 because of the title. */
 				- 2 * DESCRIPTION_BOX_PADDING;
 
-		if (osmv.getMapOrientation() != 0) {
+		if (pProjection.getOrientation() != 0) {
 			c.save();
-			c.rotate(-osmv.getMapOrientation(), mFocusedScreenCoords.x, mFocusedScreenCoords.y);
+			c.rotate(-pProjection.getOrientation(), mFocusedScreenCoords.x, mFocusedScreenCoords.y);
 		}
 
 		/* Twice draw a RoundRect, once in black with 1px as a small border. */
@@ -365,7 +362,7 @@ public class ItemizedOverlayWithFocus<Item extends OverlayItem> extends Itemized
         mRect.offset(-mFocusedScreenCoords.x, -mFocusedScreenCoords.y);
         markerFocusedBase.setBounds(mRect);
 
-		if (osmv.getMapOrientation() != 0) {
+		if (pProjection.getOrientation() != 0) {
 			c.restore();
 		}
 	}

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/LinearRing.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/LinearRing.java
@@ -436,10 +436,11 @@ class LinearRing{
 	 * @since 6.0.0
 	 * Mandatory use before clipping.
 	 */
-	public void setClipArea(final MapView pMapView) {
+	public void setClipArea(final Projection pProjection) {
 		final double border = .1;
-		final int halfWidth = pMapView.getWidth() / 2;
-		final int halfHeight = pMapView.getHeight() / 2;
+		final Rect rect = pProjection.getIntrinsicScreenRect();
+		final int halfWidth = rect.width() / 2;
+		final int halfHeight = rect.height() / 2;
 		// People less lazy than me would do more refined computations for width and height
 		// that include the map orientation: the covered area would be smaller but still big enough
 		// Now we use the circle which contains the `MapView`'s 4 corners
@@ -450,8 +451,8 @@ class LinearRing{
 				halfWidth + scaledRadius, halfHeight + scaledRadius
 		);
 		// TODO: Not sure if this is the correct approach 
-		this.isHorizontalRepeating = pMapView.isHorizontalMapRepetitionEnabled();
-		this.isVerticalRepeating = pMapView.isVerticalMapRepetitionEnabled();
+		this.isHorizontalRepeating = pProjection.isHorizontalWrapEnabled();
+		this.isVerticalRepeating = pProjection.isVerticalWrapEnabled();
 	}
 
 	/**

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/MapEventsOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/MapEventsOverlay.java
@@ -6,7 +6,6 @@ import org.osmdroid.views.MapView;
 import org.osmdroid.views.Projection;
 
 import android.content.Context;
-import android.graphics.Canvas;
 import android.view.MotionEvent;
 
 /**
@@ -34,10 +33,6 @@ public class MapEventsOverlay extends Overlay {
 		mReceiver = receiver;
     }
 
-	@Override public void draw(Canvas c, MapView osmv, boolean shadow) {
-		//Nothing to draw
-	}
-	
 	@Override public boolean onSingleTapConfirmed(MotionEvent e, MapView mapView){
 		Projection proj = mapView.getProjection();
 		GeoPoint p = (GeoPoint)proj.fromPixels((int)e.getX(), (int)e.getY());

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Marker.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Marker.java
@@ -324,17 +324,13 @@ public class Marker extends OverlayWithIW {
 			return super.isInfoWindowOpen();
 	}
 	
-	@Override public void draw(Canvas canvas, MapView mapView, boolean shadow) {
-		if (shadow)
-			return;
+	@Override public void draw(Canvas canvas, Projection pj) {
 		if (mIcon == null)
 			return;
 		
-		final Projection pj = mapView.getProjection();
-		
 		pj.toPixels(mPosition, mPositionPixels);
 
-		float rotationOnScreen = (mFlat ? -mBearing : -mapView.getMapOrientation()-mBearing);
+		float rotationOnScreen = (mFlat ? -mBearing : -pj.getOrientation()-mBearing);
 		drawAt(canvas, mPositionPixels.x, mPositionPixels.y, rotationOnScreen);
 		if (isInfoWindowShown()) {
 			//showInfoWindow();

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/MinimapOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/MinimapOverlay.java
@@ -3,7 +3,6 @@ package org.osmdroid.views.overlay;
 import org.osmdroid.tileprovider.MapTileProviderBase;
 import org.osmdroid.tileprovider.MapTileProviderBasic;
 import org.osmdroid.tileprovider.tilesource.ITileSource;
-import org.osmdroid.util.TileSystem;
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.Projection;
 
@@ -12,9 +11,7 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Paint.Style;
-import android.graphics.Point;
 import android.graphics.Rect;
-import android.graphics.drawable.Drawable;
 import android.os.Handler;
 import android.view.MotionEvent;
 
@@ -116,23 +113,19 @@ public class MinimapOverlay extends TilesOverlay {
 	}
 
 	@Override
-	public void draw(Canvas c, MapView osmv, boolean shadow) {
-		if (shadow) {
-			return;
-		}
-
-		if (!setViewPort(c, osmv)) {
+	public void draw(Canvas c, Projection pProjection) {
+		if (!setViewPort(c, pProjection)) {
 			return;
 		}
 
 		// Draw a solid background where the minimap will be drawn with a 2 pixel inset
-		osmv.getProjection().save(c, false, true);
+		pProjection.save(c, false, true);
 		c.drawRect(
 				getCanvasRect().left - 2, getCanvasRect().top - 2,
 				getCanvasRect().right + 2, getCanvasRect().bottom + 2, mPaint);
 
 		super.drawTiles(c, getProjection(), getProjection().getZoomLevel(), mViewPort);
-		osmv.getProjection().restore(c, true);
+		pProjection.restore(c, true);
 	}
 
 	@Override
@@ -222,8 +215,8 @@ public class MinimapOverlay extends TilesOverlay {
 	}
 
 	@Override
-	protected boolean setViewPort(final Canvas pCanvas, final MapView pMapView) {
-		final double zoomLevel = pMapView.getProjection().getZoomLevel() - getZoomDifference();
+	protected boolean setViewPort(final Canvas pCanvas, final Projection pProjection) {
+		final double zoomLevel = pProjection.getZoomLevel() - getZoomDifference();
 		if (zoomLevel < mTileProvider.getMinimumZoomLevel()) {
 			return false;
 		}
@@ -231,7 +224,7 @@ public class MinimapOverlay extends TilesOverlay {
 		final int left = pCanvas.getWidth() - getPadding() - getWidth();
 		final int top = pCanvas.getHeight() - getPadding() - getHeight();
 		setCanvasRect(new Rect(left, top, left + getWidth(), top + getHeight()));
-		setProjection(pMapView.getProjection().getOffspring(zoomLevel, getCanvasRect()));
+		setProjection(pProjection.getOffspring(zoomLevel, getCanvasRect()));
 		getProjection().getMercatorViewPort(mViewPort);
 		return true;
 	}

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Overlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Overlay.java
@@ -6,8 +6,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.osmdroid.api.IMapView;
 import org.osmdroid.util.BoundingBox;
 import org.osmdroid.util.TileSystem;
-import org.osmdroid.util.TileSystemWebMercator;
 import org.osmdroid.views.MapView;
+import org.osmdroid.views.Projection;
 import org.osmdroid.views.util.constants.OverlayConstants;
 
 import android.content.Context;
@@ -131,8 +131,22 @@ public abstract class Overlay implements OverlayConstants {
 	 * should check isEnabled() before calling draw(). By default, draws nothing.
 	 *
 	 * changed for 5.6 to be public see https://github.com/osmdroid/osmdroid/issues/466
+	 * @deprecated Use {@link #draw(Canvas, Projection)} instead
 	 */
-	public abstract void draw(final Canvas c, final MapView osmv, final boolean shadow);
+	@Deprecated
+	public void draw(final Canvas pCanvas, final MapView pMapView, final boolean pShadow) {
+		if (pShadow) {
+			return;
+		}
+		draw(pCanvas, pMapView.getProjection());
+	}
+
+	/**
+	 * @since 6.1.0
+	 */
+	public void draw(final Canvas pCanvas, final Projection pProjection) {
+		// display nothing by default
+	}
 
 	// ===========================================================
 	// Methods

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/OverlayManager.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/OverlayManager.java
@@ -9,6 +9,7 @@ import android.view.MotionEvent;
 
 import org.osmdroid.api.IMapView;
 import org.osmdroid.views.MapView;
+import org.osmdroid.views.Projection;
 
 import java.util.List;
 
@@ -43,7 +44,16 @@ public interface OverlayManager extends List<Overlay> {
 
     Iterable<Overlay> overlaysReversed();
 
+    /**
+     * @deprecated Use {@link #onDraw(Canvas, Projection)} instead
+     */
+    @Deprecated
     void onDraw(Canvas c, MapView pMapView);
+
+    /**
+     * @since 6.1.0
+     */
+    void onDraw(Canvas c, Projection pProjection);
 
     void onDetach(MapView pMapView);
 

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/PathOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/PathOverlay.java
@@ -8,7 +8,6 @@ import org.osmdroid.util.BoundingBox;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.util.PointL;
 import org.osmdroid.util.RectL;
-import org.osmdroid.views.MapView;
 import org.osmdroid.views.Projection;
 
 import android.content.Context;
@@ -16,7 +15,6 @@ import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.Point;
-import android.graphics.Rect;
 
 /**
  * 
@@ -200,19 +198,13 @@ public class PathOverlay extends Overlay {
 	 * Should be fine up to 10K points.
 	 */
 	@Override
-	public void draw(final Canvas canvas, final MapView mapView, final boolean shadow) {
-
-		if (shadow) {
-			return;
-		}
+	public void draw(final Canvas canvas, final Projection pj) {
 
 		final int size = this.mPoints.size();
 		if (size < 2) {
 			// nothing to paint
 			return;
 		}
-
-		final Projection pj = mapView.getProjection();
 
 		// precompute new points to the intermediate projection.
 		while (this.mPointsPrecomputed < size) {

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polygon.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polygon.java
@@ -238,16 +238,11 @@ public class Polygon extends OverlayWithIW {
 		return points;
 	}
 	
-	@Override public void draw(Canvas canvas, MapView mapView, boolean shadow) {
+	@Override public void draw(Canvas canvas, Projection pj) {
 
-		if (shadow) {
-			return;
-		}
-
-		final Projection pj = mapView.getProjection();
 		mPath.rewind();
 
-		mOutline.setClipArea(mapView);
+		mOutline.setClipArea(pj);
 		final PointL offset = mOutline.buildPathPortion(pj, null, mMilestoneManagers.size() > 0);
 		for (final MilestoneManager milestoneManager : mMilestoneManagers) {
 			milestoneManager.init();
@@ -259,7 +254,7 @@ public class Polygon extends OverlayWithIW {
 		}
 
 		for (LinearRing hole:mHoles){
-			hole.setClipArea(mapView);
+			hole.setClipArea(pj);
 			hole.buildPathPortion(pj, offset, mMilestoneManagers.size() > 0);
 		}
 		mPath.setFillType(Path.FillType.EVEN_ODD); //for correct support of holes

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polyline.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polyline.java
@@ -144,16 +144,10 @@ public class Polyline extends OverlayWithIW {
     }
 
     @Override
-    public void draw(final Canvas canvas, final MapView mapView, final boolean shadow) {
-
-        if (shadow) {
-            return;
-        }
-
-        final Projection pj = mapView.getProjection();
+    public void draw(final Canvas canvas, final Projection pj) {
 
         mLineDrawer.setCanvas(canvas);
-        mOutline.setClipArea(mapView);
+        mOutline.setClipArea(pj);
         mOutline.buildLinePortion(pj, mMilestoneManagers.size() > 0);
         for (final MilestoneManager milestoneManager : mMilestoneManagers) {
             milestoneManager.init();

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/ScaleBarOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/ScaleBarOverlay.java
@@ -356,24 +356,16 @@ public class ScaleBarOverlay extends Overlay implements GeoConstants {
 	// ===========================================================
 
 	@Override
-	public void draw(Canvas c, MapView mapView, boolean shadow) {
-		if (shadow) {
-			return;
-		}
+	public void draw(Canvas c, Projection projection) {
 
-		final double zoomLevel = mapView.getZoomLevelDouble();
+		final double zoomLevel = projection.getZoomLevel();
 
 		if (zoomLevel < minZoom) {
 			return;
 		}
-		final Projection projection = mapView.getProjection();
-
-		if (projection == null) {
-			return;
-		}
-
-		int _screenWidth	   = mapView.getWidth();
-		int _screenHeight   = mapView.getHeight();
+		final Rect rect = projection.getIntrinsicScreenRect();
+		int _screenWidth = rect.width();
+		int _screenHeight = rect.height();
 		boolean screenSizeChanged = _screenHeight!=screenHeight || _screenWidth != screenWidth;
 		screenHeight = _screenHeight;
 		screenWidth = _screenWidth;

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/compass/CompassOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/compass/CompassOverlay.java
@@ -255,13 +255,9 @@ public class CompassOverlay extends Overlay implements IOverlayMenuProvider, IOr
     // ===========================================================
 
     @Override
-    public void draw(Canvas c, MapView mapView, boolean shadow) {
-        if (shadow) {
-            return;
-        }
-
+    public void draw(Canvas c, Projection pProjection) {
         if (isCompassEnabled() && !Float.isNaN(mAzimuth)) {
-            drawCompass(c, mMode * (mAzimuth + mAzimuthOffset + getDisplayOrientation()), mapView.getProjection()
+            drawCompass(c, mMode * (mAzimuth + mAzimuthOffset + getDisplayOrientation()), pProjection
                 .getScreenRect());
         }
     }

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/gestures/RotationGestureOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/gestures/RotationGestureOverlay.java
@@ -5,7 +5,6 @@ import org.osmdroid.views.overlay.IOverlayMenuProvider;
 import org.osmdroid.views.overlay.Overlay;
 
 import android.content.Context;
-import android.graphics.Canvas;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.MotionEvent;
@@ -33,11 +32,6 @@ public class RotationGestureOverlay extends Overlay implements
         super();
         mMapView = mapView;
         mRotationDetector = new RotationGestureDetector(this);
-    }
-
-    @Override
-	public void draw(Canvas c, MapView osmv, boolean shadow) {
-        // No drawing necessary
     }
 
     @Override

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/mylocation/DirectedLocationOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/mylocation/DirectedLocationOverlay.java
@@ -122,14 +122,8 @@ public class DirectedLocationOverlay extends Overlay {
 	}
 
 	@Override
-	public void draw(final Canvas c, final MapView osmv, final boolean shadow) {
-
-		if (shadow) {
-			return;
-		}
-
+	public void draw(final Canvas c, final Projection pj) {
 		if (this.mLocation != null) {
-			final Projection pj = osmv.getProjection();
 			pj.toPixels(this.mLocation, screenCoords);
 
 			if (this.mShowAccuracy && this.mAccuracy > 10) {

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/mylocation/MyLocationNewOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/mylocation/MyLocationNewOverlay.java
@@ -212,14 +212,13 @@ public class MyLocationNewOverlay extends Overlay implements IMyLocationConsumer
 		mPersonHotspot.set(x, y);
 	}
 
-	protected void drawMyLocation(final Canvas canvas, final MapView mapView, final Location lastFix) {
-		final Projection pj = mapView.getProjection();
+	protected void drawMyLocation(final Canvas canvas, final Projection pj, final Location lastFix) {
 		pj.toPixels(mGeoPoint, mDrawPixel);
 
 		if (mDrawAccuracyEnabled) {
 			final float radius = lastFix.getAccuracy()
 					/ (float) TileSystem.GroundResolution(lastFix.getLatitude(),
-							mapView.getZoomLevelDouble());
+							pj.getZoomLevel());
 
 			mCirclePaint.setAlpha(50);
 			mCirclePaint.setStyle(Style.FILL);
@@ -233,7 +232,7 @@ public class MyLocationNewOverlay extends Overlay implements IMyLocationConsumer
 		if (lastFix.hasBearing()) {
 			canvas.save();
 			// Rotate the icon if we have a GPS fix, take into account if the map is already rotated
-			float mapRotation=mapView.getMapOrientation();
+			float mapRotation;
 			mapRotation=lastFix.getBearing();
 			if (mapRotation >=360.0f)
 				mapRotation=mapRotation-360f;
@@ -260,12 +259,9 @@ public class MyLocationNewOverlay extends Overlay implements IMyLocationConsumer
 	// ===========================================================
 
 	@Override
-	public void draw(Canvas c, MapView mapView, boolean shadow) {
-		if (shadow)
-			return;
-
+	public void draw(Canvas c, Projection pProjection) {
 		if (mLocation != null && isMyLocationEnabled()) {
-			drawMyLocation(c, mapView, mLocation);
+			drawMyLocation(c, pProjection, mLocation);
 		}
 	}
 

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/mylocation/SimpleLocationOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/mylocation/SimpleLocationOverlay.java
@@ -75,9 +75,8 @@ public class SimpleLocationOverlay extends Overlay {
 		//this.PERSON_ICON.recycle();
 	}
 	@Override
-	public void draw(final Canvas c, final MapView osmv, final boolean shadow) {
-		if (!shadow && this.mLocation != null) {
-			final Projection pj = osmv.getProjection();
+	public void draw(final Canvas c, final Projection pj) {
+		if (this.mLocation != null) {
 			pj.toPixels(this.mLocation, screenCoords);
 
 			c.drawBitmap(PERSON_ICON, screenCoords.x - PERSON_HOTSPOT.x, screenCoords.y


### PR DESCRIPTION
Note: All tests are welcomed: do you still see your `Overlay`s without any problem?

Created method `Overlay.draw(Canvas, Projection)`, to be used and overridden rather than the now deprecated method `draw(Canvas, MapView, boolean)`.

Impacted interface:
* `OverlayManager`: created method `onDraw(Canvas, Projection)`, to be used and overridden rather than the now deprecated method `onDraw(Canvas, MapView)`

Impacted classes:
* `Overlay`: created method `draw(Canvas, Projection)`, to be used and overridden rather than the now deprecated method `draw(Canvas, MapView, boolean)`; gently refactored
* `Projection`: added getters `isHorizontalWrapEnabled`, `isVerticalWrapEnabled` and `getOrientation`

* `CirclePlottingOverlay`: removed useless overridden code of `draw(Canvas, MapView, boolean)` as there's no display
* `IconPlottingOverlay`: removed useless overridden code of `draw(Canvas, MapView, boolean)` as there's no display
* `MapEventsOverlay`: removed useless overridden code of `draw(Canvas, MapView, boolean)` as there's no display
* `MilStdPointPlottingOverlay`: removed useless overridden code of `draw(Canvas, MapView, boolean)` as there's no display
* `RotationGestureOverlay`: removed useless overridden code of `draw(Canvas, MapView, boolean)` as there's no display

* `Bug82WinDeath`: moved code from `draw(Canvas, MapView, boolean)` to `draw(Canvas, Projection)`
* `CompassOverlay`: moved code from `draw(Canvas, MapView, boolean)` to `draw(Canvas, Projection)`
* `CopyrightOverlay`: added field `mCopyrightNotice` and its setter; moved most of the code from `draw(Canvas, MapView, boolean)` to `draw(Canvas, Projection)`
* `DirectedLocationOverlay`: moved code from `draw(Canvas, MapView, boolean)` to `draw(Canvas, Projection)`
* `FolderOverlay`: moved code from `draw(Canvas, MapView, boolean)` to `draw(Canvas, Projection)`
* `GroundOverlay2`: moved code from `draw(Canvas, MapView, boolean)` to `draw(Canvas, Projection)`
* `IconOverlay`: moved code from `draw(Canvas, MapView, boolean)` to `draw(Canvas, Projection)`
* `ItemizedOverlay`: moved code from `draw(Canvas, MapView, boolean)` to `draw(Canvas, Projection)`; replaced parameter `MapView` with `Projection` in method `onDrawItem(Canvas, Item, Point, MapView)`
* `ItemizedOverlayWithFocus`: moved code from `draw(Canvas, MapView, boolean)` to `draw(Canvas, Projection)`
* `Marker`: moved code from `draw(Canvas, MapView, boolean)` to `draw(Canvas, Projection)`
* `MinimapOverlay`: moved code from `draw(Canvas, MapView, boolean)` to `draw(Canvas, Projection)`; replaced method `setViewPort(Canvas, MapView)` with `setViewPort(Canvas, Projection)`
* `MyLocationNewOverlay`: moved code from `draw(Canvas, MapView, boolean)` to `draw(Canvas, Projection)`; replaced method `drawMyLocation(Canvas, MapView, Location)` with `drawMyLocation(Canvas, Projection, Location)`
* `PathOverlay`: moved code from `draw(Canvas, MapView, boolean)` to `draw(Canvas, Projection)`
* `Polygon`: moved code from `draw(Canvas, MapView, boolean)` to `draw(Canvas, Projection)`
* `Polyline`: moved code from `draw(Canvas, MapView, boolean)` to `draw(Canvas, Projection)`
* `SampleTileStates`: moved code from `draw(Canvas, MapView, boolean)` to `draw(Canvas, Projection)`
* `ScaleBarOverlay`: moved code from `draw(Canvas, MapView, boolean)` to `draw(Canvas, Projection)`
* `SimpleLocationOverlay`: moved code from `draw(Canvas, MapView, boolean)` to `draw(Canvas, Projection)`
* `TilesOverlay`: moved code from `draw(Canvas, MapView, boolean)` to `draw(Canvas, Projection)`; replaced method `protectDisplayedTilesForCache(Canvas, MapView)` with `protectDisplayedTilesForCache(Canvas, Projection)`; replaced method `setViewPort(Canvas, MapView)` with `setViewPort(Canvas, Projection)`; `OverlayTileLooper`; unrelated little optimization in method `onTileReadyToDraw`

* `DefaultOverlayManager`: moved code from `onDraw(Canvas, MapView)` to new method `onDraw(Canvas, Projection)`
* `LinearRing`: remplace method `setClipArea(MapView)` with `setClipArea(Projection)`