### PR TITLE
bug/#1256 - added a "clockwise" parameter in method MapController.animateTo

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleFactory.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleFactory.java
@@ -35,6 +35,7 @@ import org.osmdroid.samplefragments.data.SampleOsmPath;
 import org.osmdroid.samplefragments.data.SampleRace;
 import org.osmdroid.samplefragments.data.SampleSimpleFastPointOverlay;
 import org.osmdroid.samplefragments.data.SampleSimpleLocation;
+import org.osmdroid.samplefragments.events.SampleAnimateToWithOrientation;
 import org.osmdroid.samplefragments.tileproviders.SampleTileStates;
 import org.osmdroid.samplefragments.data.SampleWithMinimapItemizedOverlayWithFocus;
 import org.osmdroid.samplefragments.data.SampleWithMinimapItemizedOverlayWithScale;
@@ -307,6 +308,7 @@ public final class SampleFactory implements ISampleFactory {
         mSamples.add(SampleOfflineFirst.class);
         mSamples.add(SampleOfflineSecond.class);
         mSamples.add(SampleTileStates.class);
+        mSamples.add(SampleAnimateToWithOrientation.class);
     }
 
     public void addSample(Class<? extends BaseSampleFragment> clz) {

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/events/SampleAnimateToWithOrientation.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/events/SampleAnimateToWithOrientation.java
@@ -1,0 +1,69 @@
+package org.osmdroid.samplefragments.events;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.LinearLayout;
+
+import org.osmdroid.R;
+import org.osmdroid.samplefragments.BaseSampleFragment;
+import org.osmdroid.util.GeoPoint;
+import org.osmdroid.views.MapView;
+
+/**
+ * @since 6.1.0
+ * @author Fabrice Fontaine
+ */
+public class SampleAnimateToWithOrientation extends BaseSampleFragment implements View.OnClickListener {
+
+    private static final float[] ORIENTATIONS = new float[] {30, 0, -30, 0, -30, 0};
+    private static final Boolean[] CLOCKWISES = new Boolean[] {null, null, null, null, Boolean.TRUE, Boolean.FALSE};
+
+    private final GeoPoint MAP_CENTER = new GeoPoint(0., 0);
+    private int mIndex = -1;
+    private String mLabel;
+
+    @Override
+    public String getSampleTitle() {
+        return "Animate To With Orientation";
+    }
+
+    private Button btnCache;
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        final View root = inflater.inflate(R.layout.sample_cachemgr, container,false);
+
+        mMapView = new MapView(getActivity());
+        ((LinearLayout) root.findViewById(R.id.mapview)).addView(mMapView);
+        btnCache = root.findViewById(R.id.btnCache);
+        btnCache.setOnClickListener(this);
+        next();
+
+/*        final RotationGestureOverlay rotationGestureOverlay = new RotationGestureOverlay(mMapView);
+        rotationGestureOverlay.setEnabled(true);
+        mMapView.getOverlays().add(rotationGestureOverlay);
+*/
+        return root;
+    }
+
+    @Override
+    public void onClick(View v) {
+        switch (v.getId()){
+            case R.id.btnCache:
+                mMapView.getController().animateTo(MAP_CENTER, null, null, ORIENTATIONS[mIndex], CLOCKWISES[mIndex]);
+                next();
+                break;
+        }
+    }
+
+    private void next() {
+        mIndex ++;
+        mIndex %= ORIENTATIONS.length;
+        mLabel = "To " + ORIENTATIONS[mIndex] + " " +
+                (CLOCKWISES[mIndex] == null ? "" : CLOCKWISES[mIndex] ? "clockwise" : "anticlockwise");
+        btnCache.setText(mLabel);
+    }
+}

--- a/osmdroid-android/src/main/java/org/osmdroid/api/IMapController.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/api/IMapController.java
@@ -126,4 +126,9 @@ public interface IMapController {
 	 * @since 6.0.3
 	 */
 	void animateTo(final IGeoPoint point, final Double pZoom, final Long pSpeed, final Float pOrientation);
+
+	/**
+	 * @since 6.1.0
+	 */
+	void animateTo(final IGeoPoint point, final Double pZoom, final Long pSpeed, final Float pOrientation, final Boolean pClockwise);
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/util/MyMath.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/MyMath.java
@@ -82,6 +82,45 @@ public class MyMath implements MathConstants {
 		return result - 1;
 	}
 
+	/**
+	 * @since 6.1.0
+	 * @param pStart start angle
+	 * @param pEnd end angle
+	 * @param pClockwise if null, get the smallest difference (in absolute value)
+	 *                      if true, go clockwise
+	 *                      if false, go anticlockwise
+	 */
+	public static double getAngleDifference(double pStart, double pEnd, final Boolean pClockwise) {
+		final double difference = cleanPositiveAngle(pEnd - pStart);
+		if (pClockwise != null) {
+			if (pClockwise) {
+				return difference;
+			} else {
+				return difference - 360;
+			}
+		}
+		if (difference < 180) {
+			return difference;
+		}
+		return difference - 360;
+	}
+
+
+	/**
+	 * @since 6.1.0
+	 * @param pAngle angle in degree
+	 * @return the same angle in [0,360[
+	 */
+	public static double cleanPositiveAngle(double pAngle) {
+		while (pAngle < 0) {
+			pAngle += 360;
+		}
+		while (pAngle >= 360) {
+			pAngle -= 360;
+		}
+		return pAngle;
+	}
+
 	// ===========================================================
 	// Inner and Anonymous Classes
 	// ===========================================================

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapController.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapController.java
@@ -134,9 +134,17 @@ public class MapController implements IMapController, OnFirstLayoutListener {
      */
     @Override
     public void animateTo(final IGeoPoint point, final Double pZoom, final Long pSpeed, final Float pOrientation) {
+        animateTo(point, pZoom, pSpeed, pOrientation, null);
+    }
+
+    /**
+     * @since 6.1.0
+     */
+    @Override
+    public void animateTo(final IGeoPoint point, final Double pZoom, final Long pSpeed, final Float pOrientation, final Boolean pClockwise) {
         // If no layout, delay this call
         if (!mMapView.isLayoutOccurred()) {
-            mReplayController.animateTo(point, pZoom, pSpeed);
+            mReplayController.animateTo(point, pZoom, pSpeed, pOrientation, pClockwise);
             return;
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
@@ -145,7 +153,7 @@ public class MapController implements IMapController, OnFirstLayoutListener {
                     new MapAnimatorListener(this,
                             mMapView.getZoomLevelDouble(), pZoom,
                             currentCenter, point,
-                            mMapView.getMapOrientation(), pOrientation);
+                            mMapView.getMapOrientation(), pOrientation, pClockwise);
             final ValueAnimator mapAnimator = ValueAnimator.ofFloat(0, 1);
             mapAnimator.addListener(mapAnimatorListener);
             mapAnimator.addUpdateListener(mapAnimatorListener);
@@ -379,7 +387,7 @@ public class MapController implements IMapController, OnFirstLayoutListener {
             final MapAnimatorListener zoomAnimatorListener = new MapAnimatorListener(this,
                     currentZoomLevel, zoomLevel,
                     null, null,
-                    null, null);
+                    null, null, null);
             final ValueAnimator zoomToAnimator = ValueAnimator.ofFloat(0, 1);
             zoomToAnimator.addListener(zoomAnimatorListener);
             zoomToAnimator.addUpdateListener(zoomAnimatorListener);
@@ -457,19 +465,25 @@ public class MapController implements IMapController, OnFirstLayoutListener {
         private final IGeoPoint mCenterStart;
         private final IGeoPoint mCenterEnd;
         private final Float mOrientationStart;
-        private final Float mOrientationEnd;
+        private final Float mOrientationSpan;
 
         public MapAnimatorListener(final MapController pMapController,
                                    final Double pZoomStart, final Double pZoomEnd,
                                    final IGeoPoint pCenterStart, final IGeoPoint pCenterEnd,
-                                   final Float pOrientationStart, final Float pOrientationEnd) {
+                                   final Float pOrientationStart, final Float pOrientationEnd,
+                                   final Boolean pClockwise) {
             mMapController = pMapController;
             mZoomStart = pZoomStart;
             mZoomEnd = pZoomEnd;
             mCenterStart = pCenterStart;
             mCenterEnd = pCenterEnd;
-            mOrientationStart = pOrientationStart;
-            mOrientationEnd = pOrientationEnd;
+            if (pOrientationEnd == null) {
+                mOrientationStart = null;
+                mOrientationSpan = null;
+            } else {
+                mOrientationStart = pOrientationStart;
+                mOrientationSpan = (float)org.osmdroid.util.MyMath.getAngleDifference(mOrientationStart, pOrientationEnd, pClockwise);
+            }
         }
 
         @Override
@@ -500,10 +514,10 @@ public class MapController implements IMapController, OnFirstLayoutListener {
                 //map events listeners are triggered by this call
                 mMapController.mMapView.setZoomLevel(zoom);
             }
-            if (mOrientationEnd != null) {
-                final double orientation = mOrientationStart + (mOrientationEnd - mOrientationStart) * value;
+            if (mOrientationSpan != null) {
+                final float orientation = mOrientationStart + mOrientationSpan * value;
                 //map events listeners are triggered by this call
-                mMapController.mMapView.setMapOrientation((float)orientation);
+                mMapController.mMapView.setMapOrientation(orientation);
             }
             if (mCenterEnd != null) {
                 final TileSystem tileSystem = mMapController.mMapView.getTileSystem();
@@ -553,8 +567,10 @@ public class MapController implements IMapController, OnFirstLayoutListener {
     private class ReplayController {
         private LinkedList<ReplayClass> mReplayList = new LinkedList<ReplayClass>();
 
-        public void animateTo(IGeoPoint geoPoint, Double pZoom, Long pSpeed) {
-            mReplayList.add(new ReplayClass(ReplayType.AnimateToGeoPoint, null, geoPoint, pZoom, pSpeed));
+        public void animateTo(IGeoPoint geoPoint,
+                              Double pZoom, Long pSpeed, Float pOrientation, Boolean pClockwise) {
+            mReplayList.add(new ReplayClass(ReplayType.AnimateToGeoPoint, null, geoPoint,
+                    pZoom, pSpeed, pOrientation, pClockwise));
         }
 
         public void animateTo(int x, int y) {
@@ -579,7 +595,7 @@ public class MapController implements IMapController, OnFirstLayoutListener {
                 switch (replay.mReplayType) {
                     case AnimateToGeoPoint:
                         if (replay.mGeoPoint != null)
-                            MapController.this.animateTo(replay.mGeoPoint, replay.mZoom, replay.mSpeed);
+                            MapController.this.animateTo(replay.mGeoPoint, replay.mZoom, replay.mSpeed, replay.mOrientation, replay.mClockwise);
                         break;
                     case AnimateToPoint:
                         if (replay.mPoint != null)
@@ -604,20 +620,25 @@ public class MapController implements IMapController, OnFirstLayoutListener {
             private IGeoPoint mGeoPoint;
             private final Long mSpeed;
             private final Double mZoom;
+            private final Float mOrientation;
+            private final Boolean mClockwise;
 
             public ReplayClass(ReplayType mReplayType, Point mPoint, IGeoPoint mGeoPoint) {
-                this(mReplayType, mPoint, mGeoPoint, null, null);
+                this(mReplayType, mPoint, mGeoPoint, null, null, null, null);
             }
 
             /**
              * @since 6.0.2
              */
-            public ReplayClass(ReplayType pReplayType, Point pPoint, IGeoPoint pGeoPoint, Double pZoom, Long pSpeed) {
+            public ReplayClass(ReplayType pReplayType, Point pPoint, IGeoPoint pGeoPoint,
+                               Double pZoom, Long pSpeed, Float pOrientation, Boolean pClockwise) {
                 mReplayType = pReplayType;
                 mPoint = pPoint;
                 mGeoPoint = pGeoPoint;
                 mSpeed = pSpeed;
                 mZoom = pZoom;
+                mOrientation = pOrientation;
+                mClockwise = pClockwise;
             }
         }
     }

--- a/osmdroid-android/src/test/java/org/osmdroid/util/MyMathTest.java
+++ b/osmdroid-android/src/test/java/org/osmdroid/util/MyMathTest.java
@@ -1,0 +1,33 @@
+package org.osmdroid.util;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+/**
+ * @since 6.1.0
+ * @author Fabrice Fontaine
+ */
+public class MyMathTest {
+
+    private static final double DELTA = 1E-20;
+
+    @Test
+    public void testGetAngleDifference() {
+        Assert.assertEquals(20, MyMath.getAngleDifference(10, 30, null), DELTA);
+        Assert.assertEquals(20, MyMath.getAngleDifference(10, 30, Boolean.TRUE), DELTA);
+        Assert.assertEquals(-340, MyMath.getAngleDifference(10, 30, Boolean.FALSE), DELTA);
+
+        Assert.assertEquals(-20, MyMath.getAngleDifference(30, 10, null), DELTA);
+        Assert.assertEquals(340, MyMath.getAngleDifference(30, 10, Boolean.TRUE), DELTA);
+        Assert.assertEquals(-20, MyMath.getAngleDifference(30, 10, Boolean.FALSE), DELTA);
+
+        Assert.assertEquals(2, MyMath.getAngleDifference(179, -179, null), DELTA);
+        Assert.assertEquals(2, MyMath.getAngleDifference(179, -179, Boolean.TRUE), DELTA);
+        Assert.assertEquals(-358, MyMath.getAngleDifference(179, -179, Boolean.FALSE), DELTA);
+
+        Assert.assertEquals(2, MyMath.getAngleDifference(359, 1, null), DELTA);
+        Assert.assertEquals(2, MyMath.getAngleDifference(359, 1, Boolean.TRUE), DELTA);
+        Assert.assertEquals(-358, MyMath.getAngleDifference(359, 1, Boolean.FALSE), DELTA);
+    }
+}


### PR DESCRIPTION
New classes:
* `MyMathTest`: unit test class for `MyMath`, more specifically for its new `getAngleDifference` method
* `SampleAnimateToWithOrientation`: demo around the new `Boolean pClockwise` parameter of `MapController.animateTo`, to be found in "More Samples / Events / Animate To With Orientation"

Impacted classes:
* `MapController`: created a new version of method `animateTo` that includes the new "clockwise" parameter; fixed minor omissions
* `MyMath`: created method `cleanPositiveAngle` that returns the same angle modulo 360 degrees between 0 and 360; create method `getAngleDifference` as a helper to know which way one should go between two angles
* `SampleFactory`: included the new `SampleAnimateToWithOrientation` demo

Impacted interface:
* `IMapController`: added the new version of method `animateTo` that includes the new "clockwise" parameter