### PR TITLE
bug/#1122 - removed confusion about long press in itemized overlay samples

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleMilitaryIconsItemizedIcons.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleMilitaryIconsItemizedIcons.java
@@ -41,8 +41,6 @@ public class SampleMilitaryIconsItemizedIcons extends BaseSampleFragment {
      // Fields
      // ===========================================================
      private ItemizedOverlayWithFocus<OverlayItem> itemOverlay;
-     private RotationGestureOverlay mRotationGestureOverlay;
-     private OverlayItem overlayItem;
      private List<Drawable> icons = new ArrayList<>(4);
 
      @Override
@@ -86,7 +84,7 @@ public class SampleMilitaryIconsItemizedIcons extends BaseSampleFragment {
                                          context,
                                          "Item '" + item.getTitle() + "' (index=" + index
                                                  + ") got long pressed", Toast.LENGTH_LONG).show();
-                                 return false;
+                                 return true;
                             }
                        }, context);
                itemOverlay.setFocusItemsOnTap(true);
@@ -97,6 +95,7 @@ public class SampleMilitaryIconsItemizedIcons extends BaseSampleFragment {
 
                mMapView.getOverlays().add(itemOverlay);
 
+               final RotationGestureOverlay mRotationGestureOverlay;
                mRotationGestureOverlay = new RotationGestureOverlay(mMapView);
                mRotationGestureOverlay.setEnabled(false);
                mMapView.getOverlays().add(mRotationGestureOverlay);
@@ -110,7 +109,7 @@ public class SampleMilitaryIconsItemizedIcons extends BaseSampleFragment {
           }
 
           // Zoom and center on the focused item.
-          mMapView.getController().setZoom(3);
+          mMapView.getController().setZoom(3.);
           IGeoPoint geoPoint = itemOverlay.getFocusedItem().getPoint();
           mMapView.getController().animateTo(geoPoint);
 
@@ -170,6 +169,7 @@ public class SampleMilitaryIconsItemizedIcons extends BaseSampleFragment {
           for (int i = 0; i < count; i++) {
                double random_lon = (Math.random() * 360) - 180;
                double random_lat = (Math.random() * 180) - 90;
+               final OverlayItem overlayItem;
                overlayItem = new OverlayItem("A random point", "SampleDescription", new GeoPoint(random_lat,
                        random_lon));
                int index = (int) (Math.random() * (icons.size()));

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleWithMinimapItemizedOverlayWithFocus.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleWithMinimapItemizedOverlayWithFocus.java
@@ -41,9 +41,6 @@ public class SampleWithMinimapItemizedOverlayWithFocus extends BaseSampleFragmen
 	// Fields
 	// ===========================================================
 
-	private ItemizedOverlayWithFocus<OverlayItem> mMyLocationOverlay;
-	private RotationGestureOverlay mRotationGestureOverlay;
-
 	@Override
 	public String getSampleTitle() {
 		return TITLE;
@@ -65,6 +62,7 @@ public class SampleWithMinimapItemizedOverlayWithFocus extends BaseSampleFragmen
 		final Context context = getActivity();
 
 		/* Itemized Overlay */
+		final ItemizedOverlayWithFocus<OverlayItem> mMyLocationOverlay;
 		{
 			/* Create a static ItemizedOverlay showing some Markers on various cities. */
 			final ArrayList<OverlayItem> items = new ArrayList<>();
@@ -97,7 +95,7 @@ public class SampleWithMinimapItemizedOverlayWithFocus extends BaseSampleFragmen
 									context,
 									"Item '" + item.getTitle() + "' (index=" + index
 											+ ") got long pressed", Toast.LENGTH_LONG).show();
-							return false;
+							return true;
 						}
 					}, context);
 			mMyLocationOverlay.setFocusItemsOnTap(true);
@@ -111,6 +109,7 @@ public class SampleWithMinimapItemizedOverlayWithFocus extends BaseSampleFragmen
 
 			mMapView.getOverlays().add(mMyLocationOverlay);
 
+			final RotationGestureOverlay mRotationGestureOverlay;
 			mRotationGestureOverlay = new RotationGestureOverlay(mMapView);
 			mRotationGestureOverlay.setEnabled(false);
 			mMapView.getOverlays().add(mRotationGestureOverlay);

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleWithMinimapItemizedOverlayWithScale.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleWithMinimapItemizedOverlayWithScale.java
@@ -4,6 +4,7 @@ package org.osmdroid.samplefragments.data;
 import java.util.ArrayList;
 
 import org.osmdroid.samplefragments.BaseSampleFragment;
+import org.osmdroid.views.MapView;
 import org.osmdroid.views.overlay.gestures.RotationGestureOverlay;
 import org.osmdroid.api.IGeoPoint;
 import org.osmdroid.util.GeoPoint;
@@ -38,9 +39,6 @@ public class SampleWithMinimapItemizedOverlayWithScale extends BaseSampleFragmen
 	// Fields
 	// ===========================================================
 
-	private ItemizedOverlayWithFocus<OverlayItem> iconOverlay;
-	private RotationGestureOverlay mRotationGestureOverlay;
-
 	@Override
 	public String getSampleTitle() {
 		return TITLE;
@@ -59,23 +57,24 @@ public class SampleWithMinimapItemizedOverlayWithScale extends BaseSampleFragmen
 		final Context context = getActivity();
 
 		/* Itemized Overlay */
+		final ItemizedOverlayWithFocus<OverlayItem> iconOverlay;
 		{
 			/* Create a static ItemizedOverlay showing some Markers on various cities. */
 			final ArrayList<OverlayItem> items = new ArrayList<>();
                for (int i=0; i < 5000; i++){
-                    double random_lon=(Math.random() * 360) -180;
-                    double random_lat = (Math.random() * 180) - 90;
+                    double random_lon= MapView.getTileSystem().getRandomLongitude(Math.random());
+                    double random_lat = MapView.getTileSystem().getRandomLatitude(Math.random());
                          items.add(new OverlayItem("A random point", "SampleDescription", new GeoPoint(random_lat,
                                    random_lon))); 
                }
 			items.add(new OverlayItem("Berlin", "This is a relatively short SampleDescription.",
-					new GeoPoint(52518333, 13408333))); // Berlin
+					new GeoPoint(52.518333, 13.408333))); // Berlin
 			items.add(new OverlayItem(
 					"Washington",
 					"This SampleDescription is a pretty long one. Almost as long as a the great wall in china.",
-					new GeoPoint(38895000, -77036667))); // Washington
-			items.add(new OverlayItem("San Francisco", "SampleDescription", new GeoPoint(37779300,
-					-122419200))); // San Francisco
+					new GeoPoint(38.895000, -77.036667))); // Washington
+			items.add(new OverlayItem("San Francisco", "SampleDescription", new GeoPoint(37.779300,
+					-122.419200))); // San Francisco
 
 			/* OnTapListener for the Markers, shows a simple Toast. */
 			iconOverlay = new ItemizedOverlayWithFocus<>(items,
@@ -95,7 +94,7 @@ public class SampleWithMinimapItemizedOverlayWithScale extends BaseSampleFragmen
 									context,
 									"Item '" + item.getTitle() + "' (index=" + index
 											+ ") got long pressed", Toast.LENGTH_LONG).show();
-							return false;
+							return true;
 						}
 					}, context);
 			iconOverlay.setFocusItemsOnTap(true);
@@ -103,6 +102,7 @@ public class SampleWithMinimapItemizedOverlayWithScale extends BaseSampleFragmen
 
 			mMapView.getOverlays().add(iconOverlay);
 
+			final RotationGestureOverlay mRotationGestureOverlay;
 			mRotationGestureOverlay = new RotationGestureOverlay(mMapView);
 			mRotationGestureOverlay.setEnabled(false);
 			mMapView.getOverlays().add(mRotationGestureOverlay);
@@ -113,7 +113,7 @@ public class SampleWithMinimapItemizedOverlayWithScale extends BaseSampleFragmen
 		mMapView.getOverlays().add(rotationGestureOverlay);
 
 		// Zoom and center on the focused item.
-		mMapView.getController().setZoom(5);
+		mMapView.getController().setZoom(5.);
         IGeoPoint geoPoint = iconOverlay.getFocusedItem().getPoint();
 		mMapView.getController().animateTo(geoPoint);
 

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samples/SampleWithMinimapItemizedoverlay.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samples/SampleWithMinimapItemizedoverlay.java
@@ -87,7 +87,7 @@ public class SampleWithMinimapItemizedoverlay extends Activity {
 									SampleWithMinimapItemizedoverlay.this,
 									"Item '" + item.getTitle() + "' (index=" + index
 											+ ") got long pressed", Toast.LENGTH_LONG).show();
-							return false;
+							return true;
 						}
 					}, getApplicationContext());
 			this.mMapView.getOverlays().add(this.mMyLocationOverlay);
@@ -134,7 +134,7 @@ public class SampleWithMinimapItemizedoverlay extends Activity {
 
 		// Default location and zoom level
 		IMapController mapController = mMapView.getController();
-		mapController.setZoom(5);
+		mapController.setZoom(5.);
 		GeoPoint startPoint = new GeoPoint(50.936255, 6.957779);
 		mapController.setCenter(startPoint);
 	}


### PR DESCRIPTION
Fixed the return value of `ItemizedIconOverlay.OnItemGestureListener.onItemLongPress` in the samples.
The default expected behavior is that if an item is pressed, the method should return `true`, in order to prevent other items to be potentially selected as well. This is already the case in method `onItemSingleTapUp`.
Of course, that doesn't prevent anyone to consider that `false` is the relevant return value, depending on the purpose of the app. But for the samples, `true` makes more sense.

For all the following classes, those are the changes:
* `onItemLongPress` now returns `true` when the first item is found
* minor refactoring in order to remove editor warnings

Impacted classes:
* `SampleMilitaryIconsItemizedIcons`
* `SampleWithMinimapItemizedOverlayWithFocus`
* `SampleWithMinimapItemizedOverlayWithScale`
* `SampleWithMinimapItemizedoverlay`