### PR TITLE
bug/#1247 - new `MapView.setDestroyMode` feature

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/StarterMapFragment.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/StarterMapFragment.java
@@ -27,6 +27,7 @@ import org.osmdroid.samplefragments.SampleFactory;
 import org.osmdroid.tileprovider.tilesource.ITileSource;
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
 import org.osmdroid.util.GeoPoint;
+import org.osmdroid.views.CustomZoomButtonsController;
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.overlay.CopyrightOverlay;
 import org.osmdroid.views.overlay.MinimapOverlay;
@@ -82,6 +83,7 @@ public class StarterMapFragment extends Fragment implements OpenStreetMapConstan
         //Note! we are programmatically construction the map view
         //be sure to handle application lifecycle correct (see note in on pause)
         mMapView = new MapView(inflater.getContext());
+        mMapView.setDestroyMode(false);
 
         mMapView.setOnGenericMotionListener(new View.OnGenericMotionListener() {
             /**
@@ -170,7 +172,7 @@ public class StarterMapFragment extends Fragment implements OpenStreetMapConstan
 
 
         //built in zoom controls
-        mMapView.setBuiltInZoomControls(true);
+        mMapView.getZoomController().setVisibility(CustomZoomButtonsController.Visibility.SHOW_AND_FADEOUT);
 
         //needed for pinch zooms
         mMapView.setMultiTouchControls(true);
@@ -218,7 +220,7 @@ public class StarterMapFragment extends Fragment implements OpenStreetMapConstan
             edit.putBoolean(PREFS_SHOW_COMPASS, mCompassOverlay.isCompassEnabled());
             this.mCompassOverlay.disableCompass();
         }
-        edit.commit();
+        edit.apply();
 
         mMapView.onPause();
         super.onPause();

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
@@ -177,6 +177,12 @@ public class MapView extends ViewGroup implements IMapView,
 	 */
 	private final Rect mRescaleScreenRect = new Rect(); // optimization
 
+	/**
+	 * @since 6.1.0
+	 * cf. https://github.com/osmdroid/osmdroid/issues/1247
+	 */
+	private boolean mDestroyModeOnDetach = true;
+
 	// ===========================================================
 	// Constructors
 	// ===========================================================
@@ -1049,6 +1055,7 @@ public class MapView extends ViewGroup implements IMapView,
 			mProjection.detach();
 		mProjection=null;
 		mRepository.onDetach();
+		mListners.clear();
 	}
 
 	@Override
@@ -1231,11 +1238,9 @@ public class MapView extends ViewGroup implements IMapView,
 
 	@Override
 	protected void onDetachedFromWindow() {
-		if (mZoomController != null) {
-			mZoomController.onDetach();
+		if (mDestroyModeOnDetach) {
+			onDetach();
 		}
-		this.onDetach();
-		this.mListners.clear();
 		super.onDetachedFromWindow();
 	}
 
@@ -1858,5 +1863,12 @@ public class MapView extends ViewGroup implements IMapView,
 	 */
 	public TilesOverlay getMapOverlay() {
 		return mMapOverlay;
+	}
+
+	/**
+	 * @since 6.1.0
+	 */
+	public void setDestroyMode(final boolean pOnDetach) {
+		mDestroyModeOnDetach = pOnDetach;
 	}
 }


### PR DESCRIPTION
So far `MapView.onDetach` was systematically called in `MapView.onDetachedFromWindow`, which could cause problems when the view was detached from the window but not to be destroyed (in rare cases).
Now we have a `boolean` that says if we should call it. The default value is `true` for code legacy reasons.

The correct way is now something like:
````java
@Override
public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {

	// ...
	mMapView.setDestroyMode(false);
}

@Override
public void onDestroyView() {
	super.onDestroyView();
	mMapView.onDetach();
}
````

Impacted classes:
* `MapView`: new `boolean` member `mDestroyModeOnDetach` with a setter; impacted method `onDetachedFromWindow` accordingly; minor refactoring
* `StarterMapFragment`: added an explicit `mMapView.setDestroyMode(false)` on the `onCreateView` method; minor refactoring