### PR TITLE
bug/#1265 - switching to mapsforge 0.10.0 (from 0.8.0)

### DIFF
--- a/osmdroid-mapsforge/build.gradle
+++ b/osmdroid-mapsforge/build.gradle
@@ -37,9 +37,9 @@ dependencies {
     testCompile "junit:junit:${project.property('junit.version')}"
 
     //Mapsforge rendering and database support, which is LGPL
-    compile 'org.mapsforge:mapsforge-map-android:0.8.0'
-    compile 'org.mapsforge:mapsforge-map:0.8.0'
-    compile 'org.mapsforge:mapsforge-themes:0.8.0'
+    compile 'org.mapsforge:mapsforge-map-android:0.10.0'
+    compile 'org.mapsforge:mapsforge-map:0.10.0'
+    compile 'org.mapsforge:mapsforge-themes:0.10.0'
 
     //osmdroid which is ASF licensed
     compile project(':osmdroid-android')

--- a/osmdroid-mapsforge/src/main/java/org/osmdroid/mapsforge/MapsForgeTileSource.java
+++ b/osmdroid-mapsforge/src/main/java/org/osmdroid/mapsforge/MapsForgeTileSource.java
@@ -208,9 +208,6 @@ public class MapsForgeTileSource extends BitmapTileSourceBase {
 
     public static void createInstance(Application app) {
         AndroidGraphicFactory.createInstance(app);
-
-        // see https://github.com/mapsforge/mapsforge/issues/868
-        ReadBuffer.setMaximumBufferSize(6500000);
     }
 
 


### PR DESCRIPTION
Impacted files:
* `MapsForgeTileSource.java`: removed the call to `ReadBuffer.setMaximumBufferSize` in `createInstance`
* `osmdroid-mapsforge/build.gradle`: now using version `0.10.0` of mapsforge