### PR TITLE
feature/#1278 - using a Semaphore when accessing online tile sources

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/OnlineTileSourceBase.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/OnlineTileSourceBase.java
@@ -1,20 +1,13 @@
 package org.osmdroid.tileprovider.tilesource;
 
+import java.util.concurrent.Semaphore;
+
 public abstract class OnlineTileSourceBase extends BitmapTileSourceBase {
 
 	private final String mBaseUrls[];
+	private final Semaphore mSemaphore;
 
-	/**
-	 * Constructor
-	 * @param aName a human-friendly name for this tile source
-	 
-	 * @param aZoomMinLevel the minimum zoom level this tile source can provide
-	 * @param aZoomMaxLevel the maximum zoom level this tile source can provide
-	 * @param aTileSizePixels the tile size in pixels this tile source provides
-	 * @param aImageFilenameEnding the file name extension used when constructing the filename
-	 * @param aBaseUrl the base url(s) of the tile server used when constructing the url to download the tiles
-	 */
-	public OnlineTileSourceBase(final String aName, 
+	public OnlineTileSourceBase(final String aName,
 			final int aZoomMinLevel, final int aZoomMaxLevel, final int aTileSizePixels,
 			final String aImageFilenameEnding, final String[] aBaseUrl) {
 
@@ -23,22 +16,36 @@ public abstract class OnlineTileSourceBase extends BitmapTileSourceBase {
 
 	}
 
-	/**
-	 * Constructor
-	 * @param aName a human-friendly name for this tile source
-
-	 * @param aZoomMinLevel the minimum zoom level this tile source can provide
-	 * @param aZoomMaxLevel the maximum zoom level this tile source can provide
-	 * @param aTileSizePixels the tile size in pixels this tile source provides
-	 * @param aImageFilenameEnding the file name extension used when constructing the filename
-	 * @param aBaseUrl the base url(s) of the tile server used when constructing the url to download the tiles
-	 */
 	public OnlineTileSourceBase(final String aName,
 								final int aZoomMinLevel, final int aZoomMaxLevel, final int aTileSizePixels,
 								final String aImageFilenameEnding, final String[] aBaseUrl, String copyyright) {
-		super(aName, aZoomMinLevel, aZoomMaxLevel, aTileSizePixels,
-			aImageFilenameEnding, copyyright);
-		mBaseUrls = aBaseUrl;
+		this(aName, aZoomMinLevel, aZoomMaxLevel, aTileSizePixels,
+				aImageFilenameEnding, aBaseUrl, copyyright, 0);
+	}
+
+	/**
+	 * @since 6.1.0
+	 * @param pName a human-friendly name for this tile source
+	 * @param pZoomMinLevel the minimum zoom level this tile source can provide
+	 * @param pZoomMaxLevel the maximum zoom level this tile source can provide
+	 * @param pTileSizePixels the tile size in pixels this tile source provides
+	 * @param pImageFilenameEnding the file name extension used when constructing the filename
+	 * @param pBaseUrl the base url(s) of the tile server used when constructing the url to download the tiles
+	 * @param pCopyright the source copyright
+	 * @param pMaxConcurrent the maximum number of concurrent downloads
+	 */
+	public OnlineTileSourceBase(final String pName,
+								final int pZoomMinLevel, final int pZoomMaxLevel, final int pTileSizePixels,
+								final String pImageFilenameEnding, final String[] pBaseUrl, final String pCopyright,
+								final int pMaxConcurrent) {
+		super(pName, pZoomMinLevel, pZoomMaxLevel, pTileSizePixels,
+				pImageFilenameEnding, pCopyright);
+		mBaseUrls = pBaseUrl;
+		if (pMaxConcurrent > 0) {
+			mSemaphore = new Semaphore(pMaxConcurrent, true);
+		} else {
+			mSemaphore = null;
+		}
 	}
 
 	public abstract String getTileURLString(final long pMapTileIndex);
@@ -48,5 +55,25 @@ public abstract class OnlineTileSourceBase extends BitmapTileSourceBase {
 	 */
 	public String getBaseUrl() {
 		return mBaseUrls[random.nextInt(mBaseUrls.length)];
+	}
+
+	/**
+	 * @since 6.1.0
+	 */
+	public void acquire() throws InterruptedException{
+		if (mSemaphore == null) {
+			return;
+		}
+		mSemaphore.acquire();
+	}
+
+	/**
+	 * @since 6.1.0
+	 */
+	public void release() {
+		if (mSemaphore == null) {
+			return;
+		}
+		mSemaphore.release();
 	}
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/TileSourceFactory.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/TileSourceFactory.java
@@ -101,6 +101,7 @@ public class TileSourceFactory {
 					"https://a.tile.openstreetmap.org/",
 					"https://b.tile.openstreetmap.org/",
 					"https://c.tile.openstreetmap.org/" },"© OpenStreetMap contributors", 2);
+	// max concurrent thread number is 2 (cf. https://operations.osmfoundation.org/policies/tiles/)
 
 	public static final OnlineTileSourceBase PUBLIC_TRANSPORT = new XYTileSource(
 			"OSMPublicTransport", 0, 17, 256, ".png",

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/TileSourceFactory.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/TileSourceFactory.java
@@ -100,7 +100,7 @@ public class TileSourceFactory {
 			0, 19, 256, ".png", new String[] {
 					"https://a.tile.openstreetmap.org/",
 					"https://b.tile.openstreetmap.org/",
-					"https://c.tile.openstreetmap.org/" },"© OpenStreetMap contributors");
+					"https://c.tile.openstreetmap.org/" },"© OpenStreetMap contributors", 2);
 
 	public static final OnlineTileSourceBase PUBLIC_TRANSPORT = new XYTileSource(
 			"OSMPublicTransport", 0, 17, 256, ".png",

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/XYTileSource.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/XYTileSource.java
@@ -7,15 +7,6 @@ import org.osmdroid.util.MapTileIndex;
  */
 public class XYTileSource extends OnlineTileSourceBase {
 
-	/**
-	 *
-	 * @param aName this is used for caching purposes, make sure it is consistent and unique
-	 * @param aZoomMinLevel
-	 * @param aZoomMaxLevel
-	 * @param aTileSizePixels
-	 * @param aImageFilenameEnding
-	 * @param aBaseUrl
-	 */
 	public XYTileSource(final String aName, final int aZoomMinLevel,
 			final int aZoomMaxLevel, final int aTileSizePixels, final String aImageFilenameEnding,
 			final String[] aBaseUrl) {
@@ -26,8 +17,19 @@ public class XYTileSource extends OnlineTileSourceBase {
 	public XYTileSource(final String aName, final int aZoomMinLevel,
 						final int aZoomMaxLevel, final int aTileSizePixels, final String aImageFilenameEnding,
 						final String[] aBaseUrl, final String copyright) {
+		this(aName, aZoomMinLevel, aZoomMaxLevel, aTileSizePixels,
+			aImageFilenameEnding, aBaseUrl, copyright, 0);
+	}
+
+	/**
+	 * @since 6.1.0
+	 * @param aName this is used for caching purposes, make sure it is consistent and unique
+	 */
+	public XYTileSource(final String aName, final int aZoomMinLevel,
+						final int aZoomMaxLevel, final int aTileSizePixels, final String aImageFilenameEnding,
+						final String[] aBaseUrl, final String copyright, final int pMaxConcurrent) {
 		super(aName, aZoomMinLevel, aZoomMaxLevel, aTileSizePixels,
-			aImageFilenameEnding, aBaseUrl,copyright);
+				aImageFilenameEnding, aBaseUrl,copyright, pMaxConcurrent);
 	}
 
 	@Override


### PR DESCRIPTION
Impacted classes:
* `MapTileDownloader`: added an "acquire/release" mechanism in method `TileLoader.downloadTile`; gentle refactoring
* `OnlineTileSourceBase`: creation of a new constructor with the max concurrent parameter; added a `Semaphore` member; added methods `acquire` and `release` in order to implement the semaphore mechanism
* `TileSourceFactory`: added the parameter of maximum 2 concurrent accesses for tile source `MAPNIK`
* `XYTileSource`: creation of a new constructor with the max concurrent parameter; gentle refactoring