### PR TITLE
bug/#1280 - possibility to draw Polylines using Path

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/bugtestfragments/Bug382Crash.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/bugtestfragments/Bug382Crash.java
@@ -39,9 +39,9 @@ public class Bug382Crash extends BaseSampleFragment {
 
         polygon = new Polygon(mMapView);
         polygon.setPoints(geoPoints.subList(0, 3));
-        polygon.setFillColor(0x96FF8200);
-        polygon.setStrokeColor(Color.RED);
-        polygon.setStrokeWidth(4);
+        polygon.getFillPaint().setColor(0x96FF8200);
+        polygon.getOutlinePaint().setColor(Color.RED);
+        polygon.getOutlinePaint().setStrokeWidth(4);
         polygon.setInfoWindow(new BasicInfoWindow(R.layout.bonuspack_bubble, mMapView));
         polygon.setTitle("Polygon tapped!");
         mMapView.getOverlays().add(polygon);
@@ -49,8 +49,8 @@ public class Bug382Crash extends BaseSampleFragment {
 
         polyline = new Polyline(mMapView);
         polyline.setPoints(geoPoints.subList(3, 6));
-        polyline.setColor(Color.YELLOW);
-        polyline.setWidth(8);
+        polyline.getOutlinePaint().setColor(Color.YELLOW);
+        polyline.getOutlinePaint().setStrokeWidth(8);
         polyline.setInfoWindow(new BasicInfoWindow(R.layout.bonuspack_bubble, mMapView));
         polyline.setTitle("Polyline tapped!");
         mMapView.getOverlays().add(polyline);

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleFactory.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleFactory.java
@@ -36,6 +36,7 @@ import org.osmdroid.samplefragments.data.SampleOsmPath;
 import org.osmdroid.samplefragments.data.SampleRace;
 import org.osmdroid.samplefragments.data.SampleSimpleFastPointOverlay;
 import org.osmdroid.samplefragments.data.SampleSimpleLocation;
+import org.osmdroid.samplefragments.drawing.SampleDrawPolylineAsPath;
 import org.osmdroid.samplefragments.events.SampleAnimateToWithOrientation;
 import org.osmdroid.samplefragments.tileproviders.SampleTileStates;
 import org.osmdroid.samplefragments.data.SampleWithMinimapItemizedOverlayWithFocus;
@@ -230,6 +231,7 @@ public final class SampleFactory implements ISampleFactory {
         mSamples.add(SampleMyLocationWithClick.class);
         //48
         mSamples.add(SampleDrawPolyline.class);
+        mSamples.add(SampleDrawPolylineAsPath.class);
         //49
         mSamples.add(RecyclerCardView.class);
         //50

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/HeatMap.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/HeatMap.java
@@ -289,19 +289,19 @@ public class HeatMap extends BaseSampleFragment implements MapListener, Runnable
     private Overlay createPolygon(BoundingBox key, Integer value, int redthreshold, int orangethreshold) {
         Polygon polygon = new Polygon(mMapView);
         if (value < orangethreshold)
-            polygon.setFillColor(Color.parseColor(alpha + yellow));
+            polygon.getFillPaint().setColor(Color.parseColor(alpha + yellow));
         else if (value < redthreshold)
-            polygon.setFillColor(Color.parseColor(alpha + orange));
+            polygon.getFillPaint().setColor(Color.parseColor(alpha + orange));
         else if (value >= redthreshold)
-            polygon.setFillColor(Color.parseColor(alpha + red));
+            polygon.getFillPaint().setColor(Color.parseColor(alpha + red));
         else {
             //no polygon
         }
-        polygon.setStrokeColor(polygon.getFillColor());
+        polygon.getOutlinePaint().setColor(polygon.getFillPaint().getColor());
 
         //if you set this to something like 20f and have a low alpha setting,
         // you'll end with a gaussian blur like effect
-        polygon.setStrokeWidth(0f);
+        polygon.getOutlinePaint().setStrokeWidth(0f);
         List<GeoPoint> pts = new ArrayList<GeoPoint>();
         pts.add(new GeoPoint(key.getLatNorth(), key.getLonWest()));
         pts.add(new GeoPoint(key.getLatNorth(), key.getLonEast()));

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleMilestonesNonRepetitive.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleMilestonesNonRepetitive.java
@@ -85,7 +85,7 @@ public class SampleMilestonesNonRepetitive extends SampleMapEventListener {
         }
         final BoundingBox boundingBox = BoundingBox.fromGeoPoints(capitals);
         polyline.setPoints(capitals);
-        polyline.setColor(Color.TRANSPARENT);
+        polyline.getOutlinePaint().setColor(Color.TRANSPARENT);
         final List<MilestoneManager> managers = new ArrayList<>();
         final MilestoneMeterDistanceSliceLister slicerForPath = new MilestoneMeterDistanceSliceLister();
         managers.add(getAnimatedPathManager(slicerForPath));

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleOsmPath.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleOsmPath.java
@@ -81,7 +81,7 @@ public class SampleOsmPath extends BaseSampleFragment implements MapListener {
 		Polyline line = new Polyline(mMapView);
 		line.setTitle("Central Park, NYC");
 		line.setSubDescription(Polyline.class.getCanonicalName());
-		line.setWidth(20f);
+		line.getOutlinePaint().setStrokeWidth(20f);
 		List<GeoPoint> pts = new ArrayList<>();
 		//here, we create a polygon, note that you need 5 points in order to make a closed polygon (rectangle)
 
@@ -123,9 +123,9 @@ public class SampleOsmPath extends BaseSampleFragment implements MapListener {
 		Polygon polygon = new Polygon(mMapView);
 		polygon.setTitle("This is a polygon");
 		polygon.setSubDescription(Polygon.class.getCanonicalName());
-		polygon.setFillColor(Color.RED);
+		polygon.getFillPaint().setColor(Color.RED);
 		polygon.setVisible(true);
-		polygon.setStrokeColor(Color.BLACK);
+		polygon.getOutlinePaint().setColor(Color.BLACK);
 		polygon.setInfoWindow(new BasicInfoWindow(R.layout.bonuspack_bubble, mMapView));
 
 
@@ -144,7 +144,7 @@ public class SampleOsmPath extends BaseSampleFragment implements MapListener {
 		line = new Polyline(mMapView);
 		line.setTitle("TEST");
 		line.setSubDescription(Polyline.class.getCanonicalName());
-		line.setWidth(20f);
+		line.getOutlinePaint().setStrokeWidth(20f);
 		pts = new ArrayList<>();
 		//here, we create a polygon, note that you need 5 points in order to make a closed polygon (rectangle)
 

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleRace.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleRace.java
@@ -75,10 +75,10 @@ public class SampleRace extends BaseSampleFragment {
         super.addOverlays();
 
         final Polyline line = new Polyline(mMapView);
-        line.setColor(COLOR_POLYLINE_STATIC);
-        line.setWidth(LINE_WIDTH_BIG);
+        line.getOutlinePaint().setColor(COLOR_POLYLINE_STATIC);
+        line.getOutlinePaint().setStrokeWidth(LINE_WIDTH_BIG);
         line.setPoints(mGeoPoints);
-        line.getPaint().setStrokeCap(Paint.Cap.ROUND);
+        line.getOutlinePaint().setStrokeCap(Paint.Cap.ROUND);
         final List<MilestoneManager> managers = new ArrayList<>();
         final MilestoneMeterDistanceSliceLister slicerForPath = new MilestoneMeterDistanceSliceLister();
         final Bitmap bitmap = BitmapFactory.decodeResource(getResources(), org.osmdroid.library.R.drawable.next);

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/drawing/CustomPaintingSurface.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/drawing/CustomPaintingSurface.java
@@ -44,7 +44,8 @@ public class CustomPaintingSurface extends View {
     public enum Mode{
         Polyline,
         Polygon,
-        PolygonHole
+        PolygonHole,
+        PolylineAsPath
     }
     protected boolean withArrows=false;
     private Bitmap  mBitmap;
@@ -128,15 +129,17 @@ public class CustomPaintingSurface extends View {
                 //only plot a line unless there's at least one item
                 switch (drawingMode) {
                     case Polyline:
-                        final int color = Color.BLACK;
-                        Polyline line = new Polyline(map);
+                    case PolylineAsPath:
+                        final boolean asPath = drawingMode == Mode.PolylineAsPath;
+                        final int color = Color.argb(100, 100, 100, 100);
+                        final Polyline line = new Polyline(map, asPath);
                         line.setInfoWindow(
                                 new BasicInfoWindow(org.osmdroid.library.R.layout.bonuspack_bubble, map));
-                        line.setColor(color);
-                        line.setTitle("This is a polyline");
+                        line.getOutlinePaint().setColor(color);
+                        line.setTitle("This is a polyline" + (asPath ? " as Path" : ""));
                         line.setPoints(geoPoints);
                         line.showInfoWindow();
-                        line.getPaint().setStrokeCap(Paint.Cap.ROUND);
+                        line.getOutlinePaint().setStrokeCap(Paint.Cap.ROUND);
                         //example below
                         /*
                         line.setOnClickListener(new Polyline.OnClickListener() {
@@ -173,7 +176,7 @@ public class CustomPaintingSurface extends View {
                         Polygon polygon = new Polygon(map);
                         polygon.setInfoWindow(
                                 new BasicInfoWindow(org.osmdroid.library.R.layout.bonuspack_bubble, map));
-                        polygon.setFillColor(Color.argb(75, 255,0,0));
+                        polygon.getFillPaint().setColor(Color.argb(75, 255,0,0));
                         polygon.setPoints(geoPoints);
                         polygon.setTitle("A sample polygon");
                         polygon.showInfoWindow();

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/drawing/SampleDrawPolylineAsPath.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/drawing/SampleDrawPolylineAsPath.java
@@ -1,0 +1,26 @@
+package org.osmdroid.samplefragments.drawing;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+/**
+ * @since 6.1.0
+ * @author Fabrice Fontaine
+ */
+
+public class SampleDrawPolylineAsPath extends SampleDrawPolyline {
+
+    @Override
+    public String getSampleTitle() {
+        return "Draw a polyline on screen as Path";
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        final View result = super.onCreateView(inflater, container, savedInstanceState);
+        paint.setMode(CustomPaintingSurface.Mode.PolylineAsPath);
+        return result;
+    }
+}

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/events/MarkerDrag.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/events/MarkerDrag.java
@@ -45,8 +45,8 @@ public class MarkerDrag extends BaseSampleFragment {
         OnMarkerDragListenerDrawer() {
             mTrace = new ArrayList<GeoPoint>(100);
             mPolyline = new Polyline(mMapView);
-            mPolyline.setColor(0xAA0000FF);
-            mPolyline.setWidth(2.0f);
+            mPolyline.getOutlinePaint().setColor(0xAA0000FF);
+            mPolyline.getOutlinePaint().setStrokeWidth(2.0f);
             mPolyline.setGeodesic(true);
             mMapView.getOverlays().add(mPolyline);
         }

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/events/SampleZoomToBounding.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/events/SampleZoomToBounding.java
@@ -69,9 +69,9 @@ public class SampleZoomToBounding extends BaseSampleFragment implements View.OnC
         btnCache.setOnClickListener(this);
         btnCache.setText("Zoom to bounds");
 
-        polygon.setStrokeColor(Color.parseColor("#990000FF"));
-        polygon.setStrokeWidth(2);
-        polygon.setFillColor(Color.parseColor("#330000FF"));
+        polygon.getOutlinePaint().setColor(Color.parseColor("#990000FF"));
+        polygon.getOutlinePaint().setStrokeWidth(2);
+        polygon.getFillPaint().setColor(Color.parseColor("#330000FF"));
         mMapView.getOverlays().add(polygon);
 
         return root;

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/milstd2525/MilStdMultipointOverlay.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/milstd2525/MilStdMultipointOverlay.java
@@ -152,10 +152,10 @@ public class MilStdMultipointOverlay extends Overlay {
                             }
                             line.setPoints(geoPoints);
                             if (info.getLineColor() != null)
-                                line.setStrokeColor(info.getLineColor().toInt());
+                                line.getOutlinePaint().setColor(info.getLineColor().toInt());
                             if (info.getFillColor() != null)
-                                line.setFillColor(info.getFillColor().toInt());
-                            line.setStrokeWidth(flot.getLineWidth());
+                                line.getFillPaint().setColor(info.getFillColor().toInt());
+                            line.getOutlinePaint().setStrokeWidth(flot.getLineWidth());
                             line.setId(id);
                             line.setTitle(name);
                             line.setSubDescription(description);
@@ -176,11 +176,11 @@ public class MilStdMultipointOverlay extends Overlay {
                             }
                             line.setPoints(geoPoints);
                             if (info.getLineColor() != null)
-                                line.setColor(info.getLineColor().toInt());
+                                line.getOutlinePaint().setColor(info.getLineColor().toInt());
                             line.setGeodesic(true);
                             line.setId(id);
                             line.setTitle(name);
-                            line.setWidth(flot.getLineWidth());
+                            line.getOutlinePaint().setStrokeWidth(flot.getLineWidth());
                             line.setSubDescription(description);
                             line.setSnippet(symbolCode);
                             line.setVisible(true);
@@ -205,12 +205,12 @@ public class MilStdMultipointOverlay extends Overlay {
                             }
                             line.setPoints(geoPoints);
                             if (info.getLineColor() != null)
-                                line.setStrokeColor(info.getLineColor().toInt());
+                                line.getOutlinePaint().setColor(info.getLineColor().toInt());
                             if (info.getFillColor() != null)
-                                line.setFillColor(info.getFillColor().toInt());
+                                line.getFillPaint().setColor(info.getFillColor().toInt());
                             line.setId(id);
                             line.setTitle(name);
-                            line.setStrokeWidth(flot.getLineWidth());
+                            line.getOutlinePaint().setStrokeWidth(flot.getLineWidth());
                             line.setSubDescription(description);
                             line.setSnippet(symbolCode);
                             line.setVisible(true);
@@ -225,9 +225,9 @@ public class MilStdMultipointOverlay extends Overlay {
                                 geoPoints.add(new GeoPoint(p.getY(), p.getX()));
                             }
                             line.setPoints(geoPoints);
-                            line.setWidth(flot.getLineWidth());
+                            line.getOutlinePaint().setStrokeWidth(flot.getLineWidth());
                             if (info.getLineColor() != null)
-                                line.setColor(info.getLineColor().toInt());
+                                line.getOutlinePaint().setColor(info.getLineColor().toInt());
                             line.setGeodesic(true);
                             line.setVisible(true);
                             lastOverlay.getItems().add(line);

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/LinearRing.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/LinearRing.java
@@ -60,11 +60,15 @@ class LinearRing{
 	private boolean mGeodesic = false;
 
 	/**
+	 * @since 6.1.0
+	 */
+	private final boolean mClosed;
+
+	/**
 	 * Dedicated to `Path`
 	 */
 	public LinearRing(final Path pPath) {
-		mPath = pPath;
-		mPointAccepter = new PathBuilder(pPath);
+		this(pPath, true);
 	}
 
 	/**
@@ -74,6 +78,16 @@ class LinearRing{
 	public LinearRing(final LineBuilder pLineBuilder) {
 		mPath = null;
 		mPointAccepter = pLineBuilder;
+		mClosed = false;
+	}
+
+	/**
+	 * @since 6.1.0
+	 */
+	public LinearRing(final Path pPath, final boolean pClosed) {
+		mPath = pPath;
+		mPointAccepter = new PathBuilder(pPath);
+		mClosed = pClosed;
 	}
 
 	void clearPath() {
@@ -194,9 +208,11 @@ class LinearRing{
 			getBestOffset(pProjection, offset);
 		}
 		mSegmentClipper.init();
-		clipAndStore(pProjection, offset, true, pStorePoints, mSegmentClipper);
+		clipAndStore(pProjection, offset, mClosed, pStorePoints, mSegmentClipper);
 		mSegmentClipper.end();
-		mPath.close();
+		if (mClosed) {
+		    mPath.close();
+        }
 		return offset;
 	}
 

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/PolyOverlayWithIW.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/PolyOverlayWithIW.java
@@ -1,0 +1,233 @@
+package org.osmdroid.views.overlay;
+
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Path;
+
+import org.osmdroid.util.GeoPoint;
+import org.osmdroid.util.PointL;
+import org.osmdroid.views.MapView;
+import org.osmdroid.views.Projection;
+import org.osmdroid.views.overlay.infowindow.InfoWindow;
+import org.osmdroid.views.overlay.milestones.MilestoneManager;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Repository of common methods for Polyline and Polygon
+ * @author Fabrice Fontaine
+ * @since 6.1.0
+ */
+public abstract class PolyOverlayWithIW extends OverlayWithIW {
+
+	protected LinearRing mOutline;
+	protected List<LinearRing> mHoles = new ArrayList<>();
+	protected final Paint mOutlinePaint = new Paint();
+	protected Paint mFillPaint;
+	private List<MilestoneManager> mMilestoneManagers = new ArrayList<>();
+	private GeoPoint mInfoWindowLocation;
+
+	private final LineDrawer mLineDrawer;
+	protected final Path mPath;
+	protected float mDensity = 1.0f;
+	protected List<GeoPoint> mOriginalPoints = new ArrayList<>();
+
+	protected PolyOverlayWithIW(final MapView pMapView, final boolean pUsePath, final boolean pClosePath) {
+		super();
+		if (pMapView != null) {
+			setInfoWindow(pMapView.getRepository().getDefaultPolylineInfoWindow());
+			mDensity = pMapView.getContext().getResources().getDisplayMetrics().density;
+		}
+		if (pUsePath) {
+			mPath = new Path();
+			mLineDrawer = null;
+			mOutline = new LinearRing(mPath, pClosePath);
+		} else {
+			mPath = null;
+			mLineDrawer = new LineDrawer(256);
+			mOutline = new LinearRing(mLineDrawer);
+			////mOutline.clearPath();
+			mLineDrawer.setPaint(mOutlinePaint);
+		}
+	}
+
+	public void setVisible(boolean visible){
+		setEnabled(visible);
+	}
+
+	public boolean isVisible(){
+		return isEnabled();
+	}
+
+	/**
+	 * @return the Paint used for the outline. This allows to set advanced Paint settings.
+	 */
+	public Paint getOutlinePaint(){
+		return mOutlinePaint;
+	}
+
+	/**
+	 * @return the Paint used for the filling. This allows to set advanced Paint settings.
+	 */
+	protected Paint getFillPaint() {
+		return mFillPaint;
+	}
+
+	/**
+	 * Sets whether to draw each segment of the line as a geodesic or not.
+	 * Warning: it takes effect only if set before setting the points in the Polyline.
+	 */
+	public void setGeodesic(boolean geodesic) {
+		mOutline.setGeodesic(geodesic);
+	}
+
+	public boolean isGeodesic() {
+		return mOutline.isGeodesic();
+	}
+
+	/**
+	 * Set the InfoWindow to be used.
+	 * Default is a BasicInfoWindow, with the layout named "bonuspack_bubble".
+	 * You can use this method either to use your own layout, or to use your own sub-class of InfoWindow.
+	 * If you don't want any InfoWindow to open, you can set it to null.
+	 */
+	public void setInfoWindow(InfoWindow infoWindow){
+		if (mInfoWindow != null){
+			if (mInfoWindow.getRelatedObject()==this)
+				mInfoWindow.setRelatedObject(null);
+		}
+		mInfoWindow = infoWindow;
+	}
+
+	/**
+	 * Show the infowindow, if any. It will be opened either at the latest location, if any,
+	 * or to a default location computed by setDefaultInfoWindowLocation method.
+	 * Note that you can manually set this location with: setInfoWindowLocation
+	 */
+	public void showInfoWindow() {
+		if (mInfoWindow != null && mInfoWindowLocation != null)
+			mInfoWindow.open(this, mInfoWindowLocation, 0, 0);
+	}
+
+	/**
+	 * Sets the info window anchor point to a geopoint location
+	 */
+	public void setInfoWindowLocation(GeoPoint location) {
+		mInfoWindowLocation = location;
+	}
+
+	/**
+	 * @return the geopoint location where the infowindow should point at.
+	 * Doesn't matter if the infowindow is currently opened or not.
+	 */
+	public GeoPoint getInfoWindowLocation() {
+		return mInfoWindowLocation;
+	}
+
+	public void setMilestoneManagers(final List<MilestoneManager> pMilestoneManagers) {
+		if (pMilestoneManagers == null) {
+			if (mMilestoneManagers.size() > 0) {
+				mMilestoneManagers.clear();
+			}
+		} else {
+			mMilestoneManagers = pMilestoneManagers;
+		}
+	}
+
+	/**
+	 * @return aggregate distance (in meters)
+	 */
+	public double getDistance() {
+		return mOutline.getDistance();
+	}
+
+	/** Internal method used to ensure that the infowindow will have a default position in all cases,
+	 * so that the user can call showInfoWindow even if no tap occured before.
+	 * Currently, set the position on the center of the polygon bounding box.
+	 */
+	protected void setDefaultInfoWindowLocation() {
+		int s = mOutline.getPoints().size();
+		if (s == 0){
+			mInfoWindowLocation = new GeoPoint(0.0, 0.0);
+			return;
+		}
+		//TODO: as soon as the polygon bounding box will be a class member, don't compute it again here.
+		mInfoWindowLocation = mOutline.getCenter(null);
+	}
+
+	@Override
+	public void draw(final Canvas pCanvas, final Projection pProjection) {
+		if (mPath != null) {
+			drawWithPath(pCanvas, pProjection);
+		} else {
+			drawWithLines(pCanvas, pProjection);
+		}
+	}
+
+	private void drawWithPath(final Canvas pCanvas, final Projection pProjection) {
+		mPath.rewind();
+
+		mOutline.setClipArea(pProjection);
+		final PointL offset = mOutline.buildPathPortion(pProjection, null, mMilestoneManagers.size() > 0);
+		for (final MilestoneManager milestoneManager : mMilestoneManagers) {
+			milestoneManager.init();
+			milestoneManager.setDistances(mOutline.getDistances());
+			for (final PointL point : mOutline.getPointsForMilestones()) {
+				milestoneManager.add(point.x, point.y);
+			}
+			milestoneManager.end();
+		}
+
+		if (mHoles != null) {
+			for (final LinearRing hole : mHoles) {
+				hole.setClipArea(pProjection);
+				hole.buildPathPortion(pProjection, offset, mMilestoneManagers.size() > 0);
+			}
+			mPath.setFillType(Path.FillType.EVEN_ODD); //for correct support of holes
+		}
+
+		if (mFillPaint != null) {
+			pCanvas.drawPath(mPath, mFillPaint);
+		}
+		pCanvas.drawPath(mPath, mOutlinePaint);
+
+		for (final MilestoneManager milestoneManager : mMilestoneManagers) {
+			milestoneManager.draw(pCanvas);
+		}
+
+		if (isInfoWindowOpen() && mInfoWindow!=null && mInfoWindow.getRelatedObject() == this) {
+			mInfoWindow.draw();
+		}
+	}
+
+	private void drawWithLines(final Canvas pCanvas, final Projection pProjection) {
+		mLineDrawer.setCanvas(pCanvas);
+		mOutline.setClipArea(pProjection);
+		mOutline.buildLinePortion(pProjection, mMilestoneManagers.size() > 0);
+		for (final MilestoneManager milestoneManager : mMilestoneManagers) {
+			milestoneManager.init();
+			milestoneManager.setDistances(mOutline.getDistances());
+			for (final PointL point : mOutline.getPointsForMilestones()) {
+				milestoneManager.add(point.x, point.y);
+			}
+			milestoneManager.end();
+		}
+
+		for (final MilestoneManager milestoneManager : mMilestoneManagers) {
+			milestoneManager.draw(pCanvas);
+		}
+		if (isInfoWindowOpen() && mInfoWindow!=null && mInfoWindow.getRelatedObject() == this) {
+			mInfoWindow.draw();
+		}
+	}
+
+	@Override
+	public void onDetach(MapView mapView) {
+		mOutline = null;
+		mHoles.clear();
+		mMilestoneManagers.clear();
+		mOriginalPoints = null;
+		onDestroy();
+	}
+}

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polygon.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polygon.java
@@ -1,9 +1,7 @@
 package org.osmdroid.views.overlay;
 
-import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
-import android.graphics.Path;
 import android.graphics.RectF;
 import android.graphics.Region;
 import android.view.MotionEvent;
@@ -11,11 +9,8 @@ import android.view.MotionEvent;
 import org.osmdroid.api.IGeoPoint;
 import org.osmdroid.util.BoundingBox;
 import org.osmdroid.util.GeoPoint;
-import org.osmdroid.util.PointL;
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.Projection;
-import org.osmdroid.views.overlay.infowindow.InfoWindow;
-import org.osmdroid.views.overlay.milestones.MilestoneManager;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,17 +29,9 @@ import java.util.List;
  * @author M.Kergall: transformation from PathOverlay to Polygon
  * @see <a href="http://developer.android.com/reference/com/google/android/gms/maps/model/Polygon.html">Google Maps Polygon</a>
  */
-public class Polygon extends OverlayWithIW {
+public class Polygon extends PolyOverlayWithIW {
 
-	private final Path mPath = new Path(); //Path drawn is kept for click detection
-	private LinearRing mOutline = new LinearRing(mPath);
-	private ArrayList<LinearRing> mHoles = new ArrayList<>();
 	protected OnClickListener mOnClickListener;
-	/** Paint settings. */
-	private Paint mFillPaint;
-	private Paint mOutlinePaint;
-	private List<MilestoneManager> mMilestoneManagers = new ArrayList<>();
-	private GeoPoint mInfoWindowLocation;
 
 	// ===========================================================
 	// Constructors
@@ -55,13 +42,10 @@ public class Polygon extends OverlayWithIW {
 	}
 
 	public Polygon(MapView mapView) {
-		if (mapView != null) {
-			setInfoWindow(mapView.getRepository().getDefaultPolygonInfoWindow());
-		}
+		super(mapView, true, true);
 		mFillPaint = new Paint();
 		mFillPaint.setColor(Color.TRANSPARENT);
 		mFillPaint.setStyle(Paint.Style.FILL);
-		mOutlinePaint = new Paint();
 		mOutlinePaint.setColor(Color.BLACK);
 		mOutlinePaint.setStrokeWidth(10.0f);
 		mOutlinePaint.setStyle(Paint.Style.STROKE);
@@ -72,22 +56,28 @@ public class Polygon extends OverlayWithIW {
 	// Getter & Setter
 	// ===========================================================
 
-
+	/**
+	 * @deprecated Use {@link #getFillPaint()} instead
+	 */
+	@Deprecated
 	public int getFillColor() {
 		return mFillPaint.getColor();
 	}
 
+	/**
+	 * @deprecated Use {@link #getOutlinePaint()} instead
+	 */
+	@Deprecated
 	public int getStrokeColor() {
 		return mOutlinePaint.getColor();
 	}
 
+	/**
+	 * @deprecated Use {@link #getOutlinePaint()} instead
+	 */
+	@Deprecated
 	public float getStrokeWidth() {
 		return mOutlinePaint.getStrokeWidth();
-	}
-
-	/** @return the Paint used for the outline. This allows to set advanced Paint settings. */
-	public Paint getOutlinePaint(){
-		return mOutlinePaint;
 	}
 
 	/**
@@ -95,15 +85,7 @@ public class Polygon extends OverlayWithIW {
 	 * @since 6.0.2
 	 */
 	public Paint getFillPaint() {
-		return mFillPaint;
-	}
-
-	public void setGeodesic(boolean geodesic) {
-		mOutline.setGeodesic(geodesic);
-	}
-
-	public boolean isGeodesic() {
-		return mOutline.isGeodesic();
+		return super.getFillPaint(); // public instead of protected
 	}
 
 	/**
@@ -117,36 +99,28 @@ public class Polygon extends OverlayWithIW {
 		return mOutline.getPoints();
 	}
 
-	public boolean isVisible(){
-		return isEnabled();
-	}
-
+	/**
+	 * @deprecated Use {@link #getFillPaint()} instead
+	 */
+	@Deprecated
 	public void setFillColor(final int fillColor) {
 		mFillPaint.setColor(fillColor);
 	}
 
+	/**
+	 * @deprecated Use {@link #getOutlinePaint()} instead
+	 */
+	@Deprecated
 	public void setStrokeColor(final int color) {
 		mOutlinePaint.setColor(color);
 	}
 
+	/**
+	 * @deprecated Use {@link #getOutlinePaint()} instead
+	 */
+	@Deprecated
 	public void setStrokeWidth(final float width) {
 		mOutlinePaint.setStrokeWidth(width);
-	}
-
-	public void setVisible(boolean visible){
-		setEnabled(visible);
-	}
-
-	/** Set the InfoWindow to be used.
-	 * Default is a BasicInfoWindow, with the layout named "bonuspack_bubble".
-	 * You can use this method either to use your own layout, or to use your own sub-class of InfoWindow.
-	 * If you don't want any InfoWindow to open, you can set it to null. */
-	public void setInfoWindow(InfoWindow infoWindow){
-		if (mInfoWindow != null){
-			if (mInfoWindow.getRelatedObject()==this)
-				mInfoWindow.setRelatedObject(null);
-		}
-		mInfoWindow = infoWindow;
 	}
 
 	/**
@@ -238,50 +212,7 @@ public class Polygon extends OverlayWithIW {
 		return points;
 	}
 	
-	@Override public void draw(Canvas canvas, Projection pj) {
-
-		mPath.rewind();
-
-		mOutline.setClipArea(pj);
-		final PointL offset = mOutline.buildPathPortion(pj, null, mMilestoneManagers.size() > 0);
-		for (final MilestoneManager milestoneManager : mMilestoneManagers) {
-			milestoneManager.init();
-			milestoneManager.setDistances(mOutline.getDistances());
-			for (final PointL point : mOutline.getPointsForMilestones()) {
-				milestoneManager.add(point.x, point.y);
-			}
-			milestoneManager.end();
-		}
-
-		for (LinearRing hole:mHoles){
-			hole.setClipArea(pj);
-			hole.buildPathPortion(pj, offset, mMilestoneManagers.size() > 0);
-		}
-		mPath.setFillType(Path.FillType.EVEN_ODD); //for correct support of holes
-
-		canvas.drawPath(mPath, mFillPaint);
-		canvas.drawPath(mPath, mOutlinePaint);
-
-		for (final MilestoneManager milestoneManager : mMilestoneManagers) {
-			milestoneManager.draw(canvas);
-		}
-
-		if (isInfoWindowOpen() && mInfoWindow!=null && mInfoWindow.getRelatedObject()==this) {
-			mInfoWindow.draw();
-		}
-	}
-
-	/**
-	 * Show the infowindow, if any. It will be opened either at the latest location, if any,
-	 * or to a default location computed by setDefaultInfoWindowLocation method.
-	 * Note that you can manually set this location with: setInfoWindowLocation
-	 */
-	public void showInfoWindow(){
-		if (mInfoWindow != null && mInfoWindowLocation != null)
-			mInfoWindow.open(this, mInfoWindowLocation, 0, 0);
-	}
-	
-	/** Important note: this function returns correct results only if the Polygon has been drawn before, 
+	/** Important note: this function returns correct results only if the Polygon has been drawn before,
 	 * and if the MapView positioning has not changed. 
 	 * @param event
 	 * @return true if the Polygon contains the event position. 
@@ -319,56 +250,9 @@ public class Polygon extends OverlayWithIW {
 			return tapped;
 	}
 
-	/**
-	 * @return the geopoint location where the infowindow should point at.
-	 * Doesn't matter if the infowindow is currently opened or not.
-	 * @since 6.0.0
-	 */
-	public GeoPoint getInfoWindowLocation() {
-		return mInfoWindowLocation;
-	}
-
-	/** Internal method used to ensure that the infowindow will have a default position in all cases,
-	 * so that the user can call showInfoWindow even if no tap occured before.
-	 * Currently, set the position on the center of the polygon bounding box.
-	 */
-	protected void setDefaultInfoWindowLocation() {
-		int s = mOutline.getPoints().size();
-		if (s == 0){
-			mInfoWindowLocation = new GeoPoint(0.0, 0.0);
-			return;
-		}
-		//TODO: as soon as the polygon bounding box will be a class member, don't compute it again here.
-		mInfoWindowLocation = mOutline.getCenter(null);
-	}
-
-	/**
-	 * Sets the info window anchor point to a geopoint location
-	 * @since 6.0.0
-	 * @param location
-	 */
-	public void setInfoWindowLocation(GeoPoint location) {
-		mInfoWindowLocation = location;
-	}
-
 	@Override public void onDetach(MapView mapView) {
-		mOutline=null;
-		mHoles.clear();
-		mMilestoneManagers.clear();
-		onDestroy();
-	}
-
-	/**
-	 * @since 6.0.0
-	 */
-	public void setMilestoneManagers(final List<MilestoneManager> pMilestoneManagers) {
-		if (pMilestoneManagers == null) {
-			if (mMilestoneManagers.size() > 0) {
-				mMilestoneManagers.clear();
-			}
-		} else {
-			mMilestoneManagers = pMilestoneManagers;
-		}
+		super.onDetach(mapView);
+		mOnClickListener = null;
 	}
 
 	//-- Polygon events listener interfaces ------------------------------------
@@ -392,13 +276,5 @@ public class Polygon extends OverlayWithIW {
 	 */
 	public void setOnClickListener(OnClickListener listener) {
 		mOnClickListener = listener;
-	}
-
-	/**
-	 * @since 6.0.3
-	 * @return aggregate distance (in meters)
-	 */
-	public double getDistance() {
-		return mOutline.getDistance();
 	}
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polyline.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polyline.java
@@ -1,16 +1,12 @@
 package org.osmdroid.views.overlay;
 
-import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.view.MotionEvent;
 
 import org.osmdroid.util.GeoPoint;
-import org.osmdroid.util.PointL;
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.Projection;
-import org.osmdroid.views.overlay.infowindow.InfoWindow;
-import org.osmdroid.views.overlay.milestones.MilestoneManager;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,16 +22,9 @@ import java.util.List;
  * @author M.Kergall
  * @see <a href="http://developer.android.com/reference/com/google/android/gms/maps/model/Polyline.html">Google Maps Polyline</a>
  */
-public class Polyline extends OverlayWithIW {
+public class Polyline extends PolyOverlayWithIW {
 
-    private final Paint mPaint = new Paint();
-    private final LineDrawer mLineDrawer = new LineDrawer(256);
-    private LinearRing mOutline = new LinearRing(mLineDrawer);
-    private List<MilestoneManager> mMilestoneManagers = new ArrayList<>();
     protected OnClickListener mOnClickListener;
-    private GeoPoint mInfoWindowLocation;
-    private float mDensity = 1.0f;
-    private ArrayList<GeoPoint> mOriginalPoints = new ArrayList<>();
 
     /**
      * If MapView is not provided, infowindow popup will not function unless you set it yourself.
@@ -48,70 +37,73 @@ public class Polyline extends OverlayWithIW {
      * If MapView is null, infowindow popup will not function unless you set it yourself.
      */
     public Polyline(MapView mapView) {
-        if (mapView != null) {
-            setInfoWindow(mapView.getRepository().getDefaultPolylineInfoWindow());
-            mDensity = mapView.getContext().getResources().getDisplayMetrics().density;
-        }
+        this(mapView, false);
+    }
+
+    /**
+     * @since 6.1.0
+     * @param pUsePath true if you want the drawing to use Path instead of Canvas.drawLines
+     *                 Not recommended in all cases, given the performances.
+     *                 Useful though if you want clean alpha vertices
+     *                 cf. https://github.com/osmdroid/osmdroid/issues/1280
+     */
+    public Polyline(final MapView pMapView, final boolean pUsePath) {
+        super(pMapView, pUsePath, false);
         //default as defined in Google API:
-        this.mPaint.setColor(Color.BLACK);
-        this.mPaint.setStrokeWidth(10.0f);
-        this.mPaint.setStyle(Paint.Style.STROKE);
-        mPaint.setAntiAlias(true);
-        mOutline.clearPath();
-        mLineDrawer.setPaint(mPaint);
+        mOutlinePaint.setColor(Color.BLACK);
+        mOutlinePaint.setStrokeWidth(10.0f);
+        mOutlinePaint.setStyle(Paint.Style.STROKE);
+        mOutlinePaint.setAntiAlias(true);
     }
 
     /**
      * @return a copy of the points.
      */
     public ArrayList<GeoPoint> getPoints() {
-        ArrayList<GeoPoint> result = new ArrayList(mOriginalPoints.size());
+        ArrayList<GeoPoint> result = new ArrayList<>(mOriginalPoints.size());
         for (GeoPoint p:mOriginalPoints)
             result.add(p);
         return result;
     }
 
+    /**
+     * @deprecated Use {{@link #getOutlinePaint()}} instead
+     */
+    @Deprecated
     public int getColor() {
-        return mPaint.getColor();
+        return mOutlinePaint.getColor();
     }
 
+    /**
+     * @deprecated Use {{@link #getOutlinePaint()}} instead
+     */
+    @Deprecated
     public float getWidth() {
-        return mPaint.getStrokeWidth();
+        return mOutlinePaint.getStrokeWidth();
     }
 
     /**
-     * @return the Paint used. This allows to set advanced Paint settings.
+     * @deprecated Use {{@link #getOutlinePaint()}} instead
      */
+    @Deprecated
     public Paint getPaint() {
-        return mPaint;
-    }
-
-    public boolean isVisible() {
-        return isEnabled();
+        return getOutlinePaint();
     }
 
     /**
-     * Sets whether to draw each segment of the line as a geodesic or not.
-     * Warning: it takes effect only if set before setting the points in the Polyline.
+     * @deprecated Use {{@link #getOutlinePaint()}} instead
      */
-    public void setGeodesic(boolean geodesic) {
-        mOutline.setGeodesic(geodesic);
-    }
-
-    public boolean isGeodesic() {
-        return mOutline.isGeodesic();
-    }
-
+    @Deprecated
     public void setColor(int color) {
-        mPaint.setColor(color);
+        mOutlinePaint.setColor(color);
     }
 
+    /**
+     * @deprecated Use {{@link #getOutlinePaint()}} instead
+     */
+    @Deprecated
     public void setWidth(float width) {
-        mPaint.setStrokeWidth(width);
-    }
-
-    public void setVisible(boolean visible) {
-        setEnabled(visible);
+        mOutlinePaint.setStrokeWidth(width);
     }
 
     public void setOnClickListener(OnClickListener listener) {
@@ -143,29 +135,6 @@ public class Polyline extends OverlayWithIW {
         mOutline.addPoint(p);
     }
 
-    @Override
-    public void draw(final Canvas canvas, final Projection pj) {
-
-        mLineDrawer.setCanvas(canvas);
-        mOutline.setClipArea(pj);
-        mOutline.buildLinePortion(pj, mMilestoneManagers.size() > 0);
-        for (final MilestoneManager milestoneManager : mMilestoneManagers) {
-            milestoneManager.init();
-            milestoneManager.setDistances(mOutline.getDistances());
-            for (final PointL point : mOutline.getPointsForMilestones()) {
-                milestoneManager.add(point.x, point.y);
-            }
-            milestoneManager.end();
-        }
-
-        for (final MilestoneManager milestoneManager : mMilestoneManagers) {
-            milestoneManager.draw(canvas);
-        }
-        if (isInfoWindowOpen() && mInfoWindow!=null && mInfoWindow.getRelatedObject()==this) {
-            mInfoWindow.draw();
-        }
-    }
-
     /**
      * Detection is done is screen coordinates.
      *
@@ -189,35 +158,11 @@ public class Polyline extends OverlayWithIW {
         return mOutline.getCloseTo(point, tolerance, mapView.getProjection(), false);
     }
 
-    /**
-     * Set the InfoWindow to be used.
-     * Default is a BasicInfoWindow, with the layout named "bonuspack_bubble".
-     * You can use this method either to use your own layout, or to use your own sub-class of InfoWindow.
-     * If you don't want any InfoWindow to open, you can set it to null.
-     */
-    public void setInfoWindow(InfoWindow infoWindow) {
-        if (mInfoWindow != null){
-            if (mInfoWindow.getRelatedObject()==this)
-                mInfoWindow.setRelatedObject(null);
-        }
-        mInfoWindow = infoWindow;
-    }
-
-    /**
-     * Show the infowindow, if any. It will be opened either at the latest location, if any,
-     * or to a default location computed by setDefaultInfoWindowLocation method.
-     * Note that you can manually set this location with: setInfoWindowLocation
-     */
-    public void showInfoWindow() {
-        if (mInfoWindow != null && mInfoWindowLocation != null)
-            mInfoWindow.open(this, mInfoWindowLocation, 0, 0);
-    }
-
     @Override
     public boolean onSingleTapConfirmed(final MotionEvent event, final MapView mapView) {
         final Projection pj = mapView.getProjection();
         GeoPoint eventPos = (GeoPoint) pj.fromPixels((int) event.getX(), (int) event.getY());
-        double tolerance = mPaint.getStrokeWidth() * mDensity;
+        double tolerance = mOutlinePaint.getStrokeWidth() * mDensity;
         final GeoPoint closest = getCloseTo(eventPos, tolerance, mapView);
         if (closest != null) {
             if (mOnClickListener == null) {
@@ -229,38 +174,10 @@ public class Polyline extends OverlayWithIW {
             return false;
     }
 
-    /**
-     * @return the geopoint location where the infowindow should point at.
-     * Doesn't matter if the infowindow is currently opened or not.
-     * @since 6.0.0
-     */
-    public GeoPoint getInfoWindowLocation() {
-        return mInfoWindowLocation;
-    }
-
     /** Internal method used to ensure that the infowindow will have a default position in all cases,
      * so that the user can call showInfoWindow even if no tap occured before.
      * Currently, set the position on the "middle" point of the polyline.
      */
-    protected void setDefaultInfoWindowLocation(){
-        int s = mOriginalPoints.size();
-        if (s > 0)
-            mInfoWindowLocation = mOriginalPoints.get(s/2);
-        else
-            mInfoWindowLocation = new GeoPoint(0.0, 0.0);
-    }
-
-    /**
-     * Sets the infowindow anchor point to a geopoint location
-     * @since 6.0.0
-     * @param location
-     */
-    public void setInfoWindowLocation(GeoPoint location) {
-        mInfoWindowLocation = location;
-    }
-
-    //-- Polyline events listener interfaces ------------------------------------
-
     public interface OnClickListener {
         abstract boolean onClick(Polyline polyline, MapView mapView, GeoPoint eventPos);
     }
@@ -276,24 +193,8 @@ public class Polyline extends OverlayWithIW {
 
     @Override
     public void onDetach(MapView mapView) {
-        mOutline = null;
+        super.onDetach(mapView);
         mOnClickListener = null;
-        mMilestoneManagers.clear();
-        mOriginalPoints = null;
-        onDestroy();
-    }
-
-    /**
-     * @since 6.0.0
-     */
-    public void setMilestoneManagers(final List<MilestoneManager> pMilestoneManagers) {
-        if (pMilestoneManagers == null) {
-            if (mMilestoneManagers.size() > 0) {
-                mMilestoneManagers.clear();
-            }
-        } else {
-            mMilestoneManagers = pMilestoneManagers;
-        }
     }
 
     /**

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/gridlines/LatLonGridlineOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/gridlines/LatLonGridlineOverlay.java
@@ -130,8 +130,8 @@ public class LatLonGridlineOverlay {
 
             for (double i = sn_start_point; i <= sn_stop_point; i = i + incrementor) {
                 Polyline p = new Polyline();
-                p.setWidth(lineWidth);
-                p.setColor(lineColor);
+                p.getOutlinePaint().setStrokeWidth(lineWidth);
+                p.getOutlinePaint().setColor(lineColor);
                 List<GeoPoint> pts = new ArrayList<GeoPoint>();
 
 
@@ -164,8 +164,8 @@ public class LatLonGridlineOverlay {
 
             for (double i = we_startpoint; i <= ws_stoppoint; i = i + incrementor) {
                 Polyline p = new Polyline();
-                p.setWidth(lineWidth);
-                p.setColor(lineColor);
+                p.getOutlinePaint().setStrokeWidth(lineWidth);
+                p.getOutlinePaint().setColor(lineColor);
                 List<GeoPoint> pts = new ArrayList<GeoPoint>();
                 GeoPoint gx = new GeoPoint((double) north, i);
                 pts.add(gx);
@@ -197,8 +197,8 @@ public class LatLonGridlineOverlay {
                 //in this case western point is very positive and eastern part is very negative
                 for (double i = we_startpoint; i <= 180; i = i + incrementor) {
                     Polyline p = new Polyline();
-                    p.setWidth(lineWidth);
-                    p.setColor(lineColor);
+                    p.getOutlinePaint().setStrokeWidth(lineWidth);
+                    p.getOutlinePaint().setColor(lineColor);
                     List<GeoPoint> pts = new ArrayList<GeoPoint>();
                     GeoPoint gx = new GeoPoint((double) north, i);
                     pts.add(gx);
@@ -215,8 +215,8 @@ public class LatLonGridlineOverlay {
                 }
                 for (double i = -180; i <= ws_stoppoint; i = i + incrementor) {
                     Polyline p = new Polyline();
-                    p.setWidth(lineWidth);
-                    p.setColor(lineColor);
+                    p.getOutlinePaint().setStrokeWidth(lineWidth);
+                    p.getOutlinePaint().setColor(lineColor);
                     List<GeoPoint> pts = new ArrayList<GeoPoint>();
                     GeoPoint gx = new GeoPoint((double) north, i);
                     pts.add(gx);

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/gridlines/LatLonGridlineOverlay2.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/gridlines/LatLonGridlineOverlay2.java
@@ -172,8 +172,8 @@ public class LatLonGridlineOverlay2 extends Overlay {
 
             for (double i = sn_start_point; i <= sn_stop_point; i = i + incrementor) {
                 Polyline p = new Polyline();
-                p.setWidth(mLineWidth);
-                p.setColor(mLineColor);
+                p.getOutlinePaint().setStrokeWidth(mLineWidth);
+                p.getOutlinePaint().setColor(mLineColor);
                 List<GeoPoint> pts = new ArrayList<GeoPoint>();
 
 
@@ -204,8 +204,8 @@ public class LatLonGridlineOverlay2 extends Overlay {
 
             for (double i = we_startpoint; i <= ws_stoppoint; i = i + incrementor) {
                 Polyline p = new Polyline();
-                p.setWidth(mLineWidth);
-                p.setColor(mLineColor);
+                p.getOutlinePaint().setStrokeWidth(mLineWidth);
+                p.getOutlinePaint().setColor(mLineColor);
                 List<GeoPoint> pts = new ArrayList<GeoPoint>();
                 GeoPoint gx = new GeoPoint((double) north, i);
                 pts.add(gx);
@@ -233,8 +233,8 @@ public class LatLonGridlineOverlay2 extends Overlay {
                 //in this case western point is very positive and eastern part is very negative
                 for (double i = we_startpoint; i <= 180; i = i + incrementor) {
                     Polyline p = new Polyline();
-                    p.setWidth(mLineWidth);
-                    p.setColor(mLineColor);
+                    p.getOutlinePaint().setStrokeWidth(mLineWidth);
+                    p.getOutlinePaint().setColor(mLineColor);
                     List<GeoPoint> pts = new ArrayList<GeoPoint>();
                     GeoPoint gx = new GeoPoint((double) north, i);
                     pts.add(gx);
@@ -247,8 +247,8 @@ public class LatLonGridlineOverlay2 extends Overlay {
                 }
                 for (double i = -180; i <= ws_stoppoint; i = i + incrementor) {
                     Polyline p = new Polyline();
-                    p.setWidth(mLineWidth);
-                    p.setColor(mLineColor);
+                    p.getOutlinePaint().setStrokeWidth(mLineWidth);
+                    p.getOutlinePaint().setColor(mLineColor);
                     List<GeoPoint> pts = new ArrayList<GeoPoint>();
                     GeoPoint gx = new GeoPoint((double) north, i);
                     pts.add(gx);

--- a/osmdroid-geopackage/src/main/java/org/osmdroid/gpkg/overlay/OsmMapShapeConverter.java
+++ b/osmdroid-geopackage/src/main/java/org/osmdroid/gpkg/overlay/OsmMapShapeConverter.java
@@ -209,9 +209,9 @@ public class OsmMapShapeConverter {
         Polyline line = new Polyline();
         if (polylineOptions!=null) {
             line.setTitle(polylineOptions.getTitle());
-            line.setColor(polylineOptions.getColor());
+            line.getOutlinePaint().setColor(polylineOptions.getColor());
             line.setGeodesic(polylineOptions.isGeodesic());
-            line.setWidth(polylineOptions.getWidth());
+            line.getOutlinePaint().setStrokeWidth(polylineOptions.getWidth());
             line.setSubDescription(polygonOptions.getSubtitle());
         }
 
@@ -274,9 +274,9 @@ public class OsmMapShapeConverter {
         newPoloygon.setHoles(holes);
 
         if (polygonOptions!=null){
-            newPoloygon.setFillColor(polygonOptions.getFillColor());
-            newPoloygon.setStrokeColor(polygonOptions.getStrokeColor());
-            newPoloygon.setStrokeWidth(polygonOptions.getStrokeWidth());
+            newPoloygon.getFillPaint().setColor(polygonOptions.getFillColor());
+            newPoloygon.getOutlinePaint().setColor(polygonOptions.getStrokeColor());
+            newPoloygon.getOutlinePaint().setStrokeWidth(polygonOptions.getStrokeWidth());
             newPoloygon.setTitle(polygonOptions.getTitle());
         }
 
@@ -726,10 +726,10 @@ public class OsmMapShapeConverter {
         polygon1.setPoints(pts);
         polygon1.getHoles().addAll(holes);
         if (options!=null) {
-            polygon1.setFillColor(options.getFillColor());
+            polygon1.getFillPaint().setColor(options.getFillColor());
             polygon1.setTitle(options.getTitle());
-            polygon1.setStrokeColor(options.getStrokeColor());
-            polygon1.setStrokeWidth(options.getStrokeWidth());
+            polygon1.getOutlinePaint().setColor(options.getStrokeColor());
+            polygon1.getOutlinePaint().setStrokeWidth(options.getStrokeWidth());
             polygon1.setSubDescription(options.getSubtitle());
             polygon1.setInfoWindow(new BasicInfoWindow(R.layout.bonuspack_bubble, map));
 
@@ -753,10 +753,10 @@ public class OsmMapShapeConverter {
         org.osmdroid.views.overlay.Polygon polygon, PolygonOptions options) {
 
         if (options!=null) {
-            polygon.setFillColor(options.getFillColor());
+            polygon.getFillPaint().setColor(options.getFillColor());
             polygon.setTitle(options.getTitle());
-            polygon.setStrokeColor(options.getStrokeColor());
-            polygon.setStrokeWidth(options.getStrokeWidth());
+            polygon.getOutlinePaint().setColor(options.getStrokeColor());
+            polygon.getOutlinePaint().setStrokeWidth(options.getStrokeWidth());
             polygon.setSubDescription(options.getSubtitle());
             polygon.setInfoWindow(new BasicInfoWindow(R.layout.bonuspack_bubble, map));
 


### PR DESCRIPTION
New classes:
* `PolyOverlayWithIW`: extending `OverlayWithIW`, extended by both `Polyline` and `Polygon` given the number of common methods
* `SampleDrawPolylineAsPath`: sample similar to `SampleDrawPolyline`, but where `Polyline`s are drawing in the "path" mode (and not in the "lines" mode)

Impacted classes:
* `CustomPaintingSurface`: created mode `PolylineAsPath`; put alpha in the color in order to see the vertices for `Polyline`s
* `LinearRing`: added the `boolean` member `mClosed` in order to make both `Polyline` and `Polygon` draw using a `Path`; new constructor for `Path` with a `boolean pClosed` parameter; taking into account the `mClosed` member when building the `Path`
* `SampleFactory`: added `SampleDrawPolylineAsPath` just after `SampleDrawPolyline`
* `Polygon`: now extends new class `PolyOverlayWithIW`
* `Polyline`: now extends new class `PolyOverlayWithIW`

Impacted classes - slightly unrelated refactoring regarding `Paint`s:
* `Bug382Crash`
* `HeatMap`
* `LatLonGridlineOverlay`
* `LatLonGridlineOverlay2`
* `MarkerDrag`
* `MilStdMultipointOverlay`
* `OsmMapShapeConverter`
* `SampleMilestonesNonRepetitive`
* `SampleOsmPath`
* `SampleRace`
* `SampleZoomToBounding`