### PR TITLE
bug/#1287 - Android 9 - handling "http only" (not "httpS") tile providers

### DIFF
--- a/OpenStreetMapViewer/src/main/AndroidManifest.xml
+++ b/OpenStreetMapViewer/src/main/AndroidManifest.xml
@@ -41,6 +41,7 @@
         android:largeHeap="true"
         android:icon="@drawable/icon"
         android:theme="@style/Theme.AppCompat.NoActionBar"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:label="@string/app_name">
 
         <!-- Bing maps tile users:

--- a/OpenStreetMapViewer/src/main/res/xml/network_security_config.xml
+++ b/OpenStreetMapViewer/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">dev.virtualearth.net</domain>
+    </domain-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">tiles.wmflabs.org</domain>
+    </domain-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">tile.cloudmade.com</domain>
+    </domain-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">openptmap.org</domain>
+    </domain-config>
+</network-security-config>

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/TileSourceFactory.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/TileSourceFactory.java
@@ -132,15 +132,15 @@ public class TileSourceFactory {
 
 	public static final OnlineTileSourceBase FIETS_OVERLAY_NL = new XYTileSource("Fiets",
 			3, 18, 256, ".png",
-			new String[] { "http://overlay.openstreetmap.nl/openfietskaart-overlay/" },"© OpenStreetMap contributors");
+			new String[] { "https://overlay.openstreetmap.nl/openfietskaart-overlay/" },"© OpenStreetMap contributors");
 
 	public static final OnlineTileSourceBase BASE_OVERLAY_NL = new XYTileSource("BaseNL",
 			0, 18, 256, ".png",
-			new String[] { "http://overlay.openstreetmap.nl/basemap/" });
+			new String[] { "https://overlay.openstreetmap.nl/basemap/" });
 
 	public static final OnlineTileSourceBase ROADS_OVERLAY_NL = new XYTileSource("RoadsNL",
 			0, 18, 256, ".png",
-			new String[] { "http://overlay.openstreetmap.nl/roads/" },"© OpenStreetMap contributors");
+			new String[] { "https://overlay.openstreetmap.nl/roads/" },"© OpenStreetMap contributors");
      
      public static final OnlineTileSourceBase HIKEBIKEMAP = new XYTileSource("HikeBikeMap",
 			 0, 18, 256, ".png",
@@ -153,7 +153,7 @@ public class TileSourceFactory {
 	 * @sunce 5.6.2
 	 */
 	public static final OnlineTileSourceBase OPEN_SEAMAP = new XYTileSource("OpenSeaMap",
-			3,18,256,".png", new String[] { "http://tiles.openseamap.org/seamark/"}, "OpenSeaMap");
+			3,18,256,".png", new String[] { "https://tiles.openseamap.org/seamark/"}, "OpenSeaMap");
 
      
      public static final OnlineTileSourceBase USGS_TOPO = new OnlineTileSourceBase("USGS National Map Topo",  0, 15, 256, "",
@@ -177,29 +177,31 @@ public class TileSourceFactory {
 	 * @since 5.6.2
 	 */
 	public static final OnlineTileSourceBase ChartbundleWAC = new XYTileSource("ChartbundleWAC", 4, 12, 256, ".png?type=google",
-		new String[]{"http://wms.chartbundle.com/tms/v1.0/wac/"}, "chartbundle.com");
+		new String[]{"https://wms.chartbundle.com/tms/v1.0/wac/"}, "chartbundle.com");
 
 	/**
 	 * Chart Bundle US Aeronautical Charts Enroute High
 	 * @since 5.6.2
 	 */
 	public static final OnlineTileSourceBase ChartbundleENRH = new XYTileSource("ChartbundleENRH", 4, 12, 256, ".png?type=google",
-		new String[]{"http://wms.chartbundle.com/tms/v1.0/enrh/", "chartbundle.com"});
+		new String[]{"https://wms.chartbundle.com/tms/v1.0/enrh/", "chartbundle.com"});
 	/**
 	 * Chart Bundle US Aeronautical Charts Enroute Low
 	 * @since 5.6.2
 	 */
 	public static final OnlineTileSourceBase ChartbundleENRL = new XYTileSource("ChartbundleENRL", 4, 12, 256, ".png?type=google",
-		new String[]{"http://wms.chartbundle.com/tms/v1.0/enrl/", "chartbundle.com"});
+		new String[]{"https://wms.chartbundle.com/tms/v1.0/enrl/", "chartbundle.com"});
 
 	/**
 	 * Open Topo Maps https://opentopomap.org
 	 * @since 5.6.2
 	 */
-	public static final OnlineTileSourceBase OpenTopo= new XYTileSource("OpenTopoMap", 0, 19, 256, ".png",
-		new String[]{"https://opentopomap.org/"}, "Kartendaten: © OpenStreetMap-Mitwirkende, SRTM | Kartendarstellung: © OpenTopoMap (CC-BY-SA)");
-
-
+	public static final OnlineTileSourceBase OpenTopo= new XYTileSource("OpenTopoMap", 0, 17, 256, ".png",
+			new String[]{
+					"https://a.tile.opentopomap.org/",
+					"https://b.tile.opentopomap.org/",
+					"https://c.tile.opentopomap.org/"},
+			"Kartendaten: © OpenStreetMap-Mitwirkende, SRTM | Kartendarstellung: © OpenTopoMap (CC-BY-SA)");
 
 	private static List<ITileSource> mTileSources;
 	static {


### PR DESCRIPTION
Impacted files:
* `OpenStreetMapViewer:AndroidManifest.xml`: added a reference to new config file `res/xml/network_security_config.xml`
* `OpenStreetMapViewer:res/xml/network_security_config.xml`: whitelisting of "http only" (and not "httpS") tile providers
* `osmdroid:TileSourceFactory`: whenever possible, switched the "http" tile providers into "https"