### PR TITLE
feature/#1289_2 - normalizing user agent and disabling preventive downloads

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/config/DefaultConfigurationProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/config/DefaultConfigurationProvider.java
@@ -2,6 +2,8 @@ package org.osmdroid.config;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import android.os.Build;
 import android.util.Log;
 
@@ -61,6 +63,11 @@ public class DefaultConfigurationProvider implements IConfigurationProvider {
     protected int mTileGCBulkSize = 20;
     protected long mTileGCBulkPauseInMillis = 500;
     protected boolean mTileDownloaderFollowRedirects = true;
+
+    /**
+     * @since 6.1.0
+     */
+    private String mNormalizedUserAgent;
 
     public DefaultConfigurationProvider(){
 
@@ -288,6 +295,8 @@ public class DefaultConfigurationProvider implements IConfigurationProvider {
     //</editor-fold>
     @Override
     public void load(Context ctx, SharedPreferences prefs) {
+        mNormalizedUserAgent = computeNormalizedUserAgent(ctx);
+
         //cache management starts here
 
         //check to see if the shared preferences is set for the tile cache
@@ -548,5 +557,30 @@ public class DefaultConfigurationProvider implements IConfigurationProvider {
     @Override
     public boolean isMapTileDownloaderFollowRedirects() {
         return mTileDownloaderFollowRedirects;
+    }
+
+    /**
+     * @since 6.1.0
+     */
+    @Override
+    public String getNormalizedUserAgent() {
+        return mNormalizedUserAgent;
+    }
+
+    /**
+     * @since 6.1.0
+     */
+    private String computeNormalizedUserAgent(final Context pContext) {
+        if (pContext == null) {
+            return null;
+        }
+        final String packageName = pContext.getPackageName();
+        try {
+            final PackageInfo packageInfo = pContext.getPackageManager().getPackageInfo(packageName, PackageManager.GET_META_DATA);
+            final int version = packageInfo.versionCode;
+            return packageName + "/" + version;
+        } catch (PackageManager.NameNotFoundException e1) {
+            return packageName;
+        }
     }
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/config/IConfigurationProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/config/IConfigurationProvider.java
@@ -431,4 +431,9 @@ public interface IConfigurationProvider {
      */
     void setMapTileDownloaderFollowRedirects(boolean value);
     boolean isMapTileDownloaderFollowRedirects();
+
+    /**
+     * @since 6.1.0
+     */
+    String getNormalizedUserAgent();
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTilePreCache.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTilePreCache.java
@@ -3,7 +3,10 @@ package org.osmdroid.tileprovider;
 import android.graphics.drawable.Drawable;
 
 import org.osmdroid.tileprovider.modules.CantContinueException;
+import org.osmdroid.tileprovider.modules.MapTileDownloader;
 import org.osmdroid.tileprovider.modules.MapTileModuleProviderBase;
+import org.osmdroid.tileprovider.tilesource.ITileSource;
+import org.osmdroid.tileprovider.tilesource.OnlineTileSourceBase;
 import org.osmdroid.util.GarbageCollector;
 import org.osmdroid.util.MapTileArea;
 import org.osmdroid.util.MapTileAreaList;
@@ -111,6 +114,14 @@ public class MapTilePreCache {
     private void search(final long pMapTileIndex) {
         for (final MapTileModuleProviderBase provider : mProviders) {
             try {
+                if (provider instanceof MapTileDownloader) {
+                    final ITileSource tileSource = ((MapTileDownloader) provider).getTileSource();
+                    if (tileSource instanceof OnlineTileSourceBase) {
+                        if (!((OnlineTileSourceBase)tileSource).getTileSourcePolicy().acceptsPreventive()) {
+                            continue;
+                        }
+                    }
+                }
                 final Drawable drawable = provider.getTileLoader().loadTile(pMapTileIndex);
                 if (drawable == null) {
                     continue;

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderBasic.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderBasic.java
@@ -120,6 +120,7 @@ public class MapTileProviderBasic extends MapTileProviderArray implements IMapTi
 		getTileCache().getPreCache().addProvider(assetsProvider);
 		getTileCache().getPreCache().addProvider(cacheProvider);
 		getTileCache().getPreCache().addProvider(archiveProvider);
+		getTileCache().getPreCache().addProvider(mDownloaderProvider);
 
 		// tiles currently being processed
 		getTileCache().getProtectedTileContainers().add(this);

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/TileDownloader.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/TileDownloader.java
@@ -49,7 +49,13 @@ public class TileDownloader {
             return null;
         }
 
-        final String userAgent = Configuration.getInstance().getUserAgentValue();
+        String userAgent = null;
+        if (pTileSource.getTileSourcePolicy().normalizesUserAgent()) {
+            userAgent = Configuration.getInstance().getNormalizedUserAgent();
+        }
+        if (userAgent == null) {
+            userAgent = Configuration.getInstance().getUserAgentValue();
+        }
         if (!pTileSource.getTileSourcePolicy().acceptsUserAgent(userAgent)) {
             Log.e(IMapView.LOGTAG,"Please configure a relevant user agent; current value is: " + userAgent);
             return null;

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/TileSourceFactory.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/TileSourceFactory.java
@@ -101,7 +101,12 @@ public class TileSourceFactory {
 					"https://a.tile.openstreetmap.org/",
 					"https://b.tile.openstreetmap.org/",
 					"https://c.tile.openstreetmap.org/" },"© OpenStreetMap contributors",
-			new TileSourcePolicy(2, false, false));
+			new TileSourcePolicy(2,
+					TileSourcePolicy.FLAG_NO_BULK
+					| TileSourcePolicy.FLAG_NO_PREVENTIVE
+					| TileSourcePolicy.FLAG_USER_AGENT_MEANINGFUL
+					| TileSourcePolicy.FLAG_USER_AGENT_NORMALIZED
+			));
 	// max concurrent thread number is 2 (cf. https://operations.osmfoundation.org/policies/tiles/)
 
 	public static final OnlineTileSourceBase PUBLIC_TRANSPORT = new XYTileSource(

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/TileSourcePolicy.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/TileSourcePolicy.java
@@ -7,6 +7,7 @@ import org.osmdroid.config.DefaultConfigurationProvider;
  * <li>the max number of concurrent downloads</li>
  * <li>if it accepts a meaningless user agent</li>
  * <li>if it accepts bulk downloads</li>
+ * <li>if the user agent must be normalized</li>
  * </ul>
  * @since 6.1.0
  * @author Fabrice Fontaine
@@ -14,30 +15,40 @@ import org.osmdroid.config.DefaultConfigurationProvider;
 public class TileSourcePolicy {
 
     /**
+     * No bulk downloads allowed
+     */
+    public static final int FLAG_NO_BULK                = 1;
+
+    /**
+     * Don't try to preventively download tiles that aren't currently displayed
+     */
+    public static final int FLAG_NO_PREVENTIVE          = 2;
+
+    /**
+     * Demands a user agent different from the default value
+     */
+    public static final int FLAG_USER_AGENT_MEANINGFUL  = 4;
+
+    /**
+     * Uses the "normalized" user agent (package name + version)
+     */
+    public static final int FLAG_USER_AGENT_NORMALIZED  = 8;
+
+    /**
      * maximum number of concurrent downloads
      */
     private final int mMaxConcurrent;
 
-    /**
-     * accepts bulk download
-     */
-    private final boolean mAcceptsBulkDownload;
-
-    /**
-     * accepts meaningless default user agent
-     */
-    private final boolean mAcceptsMeaninglessUserAgent;
+    private final int mFlags;
 
     public TileSourcePolicy() {
-        this(0, true, true);
+        this(0, 0);
     }
 
     public TileSourcePolicy(final int pMaxConcurrent,
-                            final boolean pAcceptsBulkDownload,
-                            final boolean pAcceptsMeaninglessUserAgent) {
+                            final int pFlags) {
         mMaxConcurrent = pMaxConcurrent;
-        mAcceptsBulkDownload = pAcceptsBulkDownload;
-        mAcceptsMeaninglessUserAgent = pAcceptsMeaninglessUserAgent;
+        mFlags = pFlags;
     }
 
     public int getMaxConcurrent() {
@@ -45,11 +56,23 @@ public class TileSourcePolicy {
     }
 
     public boolean acceptsBulkDownload() {
-        return mAcceptsBulkDownload;
+        return (mFlags & FLAG_NO_BULK) == 0;
+    }
+
+    private boolean acceptsMeaninglessUserAgent() {
+        return (mFlags & FLAG_USER_AGENT_MEANINGFUL) == 0;
+    }
+
+    public boolean normalizesUserAgent() {
+        return (mFlags & FLAG_USER_AGENT_NORMALIZED) != 0;
+    }
+
+    public boolean acceptsPreventive() {
+        return (mFlags & FLAG_NO_PREVENTIVE) == 0;
     }
 
     public boolean acceptsUserAgent(final String pUserAgent) {
-        if (mAcceptsMeaninglessUserAgent) {
+        if (acceptsMeaninglessUserAgent()) {
             return true;
         }
         return pUserAgent != null


### PR DESCRIPTION
… for MAPNIK

Around `TileSourcePolicy`:
* "normalized" user agent (package name + "/" + version)
* disabling preventive download

Impacted classes:
* `DefaultConfigurationProvider`: new member `String mNormalizedUserAgent` and its getter; new method `computeNormalizedUserAgent(Context)` to compute its value
* `IConfigurationProvider`: added method `String getNormalizedUserAgent()`
* `MapTilePreCache`: added a check in method `search` - if the tile source policy says "we don't try to preventively download tiles", there won't be any download attempt
* `MapTileProviderBasic`: added the `MapTileDownloader` in the pre-cache tile providers
* `TileDownloader`: in `downloadTile`, uses the normalized user agent if the tile source policy says so
* `TileSourceFactory`: edited the `TileSourcePolicy` related to MAPNIK (new parameters)
* `TileSourcePolicy`: now using `int` flags instead of `boolean`s (therefore new constructor); new methods `acceptsPreventive` and `normalizesUserAgent`