### PR TITLE
bug #1299: Zoom Button Crash in 6.1.0

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapController.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapController.java
@@ -164,7 +164,7 @@ public class MapController implements IMapController, OnFirstLayoutListener {
             }
 
             if (mCurrentAnimator != null) {
-                mCurrentAnimator.end();
+                mapAnimatorListener.onAnimationCancel(mCurrentAnimator);
             }
             mCurrentAnimator = mapAnimator;
             mapAnimator.start();


### PR DESCRIPTION
Fix for https://github.com/osmdroid/osmdroid/issues/1299

fix StackOverflow, because when zooming in with zoom buttons,
osm tries to keep the map centered to the current user location.
See: org.osmdroid.views.overlay.mylocation.MyLocationNewOverlay.onSnapToItem