### PR TITLE
Bug/#1299 2 - partial rollback of the custom zoom buttons

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/StarterMapFragment.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/StarterMapFragment.java
@@ -318,3 +318,4 @@ public class StarterMapFragment extends Fragment implements OpenStreetMapConstan
     // return this.mMapView.onTrackballEvent(event);
     // }
 }
+

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/StarterMapFragment.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/StarterMapFragment.java
@@ -27,7 +27,6 @@ import org.osmdroid.samplefragments.SampleFactory;
 import org.osmdroid.tileprovider.tilesource.ITileSource;
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
 import org.osmdroid.util.GeoPoint;
-import org.osmdroid.views.CustomZoomButtonsController;
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.overlay.CopyrightOverlay;
 import org.osmdroid.views.overlay.MinimapOverlay;
@@ -170,9 +169,6 @@ public class StarterMapFragment extends Fragment implements OpenStreetMapConstan
         mRotationGestureOverlay.setEnabled(true);
         mMapView.getOverlays().add(this.mRotationGestureOverlay);
 
-
-        //built in zoom controls
-        mMapView.getZoomController().setVisibility(CustomZoomButtonsController.Visibility.SHOW_AND_FADEOUT);
 
         //needed for pinch zooms
         mMapView.setMultiTouchControls(true);

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samples/SampleWithTilesOverlayAndCustomTileSource.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samples/SampleWithTilesOverlayAndCustomTileSource.java
@@ -87,3 +87,4 @@ public class SampleWithTilesOverlayAndCustomTileSource extends Activity {
 	// Inner and Anonymous Classes
 	// ===========================================================
 }
+

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samples/SampleWithTilesOverlayAndCustomTileSource.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samples/SampleWithTilesOverlayAndCustomTileSource.java
@@ -4,7 +4,6 @@ import org.osmdroid.tileprovider.MapTileProviderBasic;
 import org.osmdroid.tileprovider.tilesource.ITileSource;
 import org.osmdroid.tileprovider.tilesource.XYTileSource;
 import org.osmdroid.util.GeoPoint;
-import org.osmdroid.views.CustomZoomButtonsController;
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.overlay.TilesOverlay;
 
@@ -44,7 +43,6 @@ public class SampleWithTilesOverlayAndCustomTileSource extends Activity {
 		mMapView.setTilesScaledToDpi(true);
 		rl.addView(mMapView, new RelativeLayout.LayoutParams(LayoutParams.FILL_PARENT,
 				LayoutParams.FILL_PARENT));
-		mMapView.getZoomController().setVisibility(CustomZoomButtonsController.Visibility.SHOW_AND_FADEOUT);
 
 		// zoom to the netherlands
 		mMapView.getController().setZoom(7.);

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
@@ -1894,3 +1894,4 @@ public class MapView extends ViewGroup implements IMapView,
 		mDestroyModeOnDetach = pOnDetach;
 	}
 }
+

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
@@ -50,6 +50,7 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Scroller;
+import android.widget.ZoomButtonsController;
 
 /**
  * This is the primary view for osmdroid. <br><br>
@@ -90,6 +91,8 @@ public class MapView extends ViewGroup implements IMapView,
 
 	private final MapController mController;
 
+	private final ZoomButtonsController mOldZoomController;
+	private boolean mEnableOldZoomController;
 	private final CustomZoomButtonsController mZoomController;
 
 
@@ -198,10 +201,10 @@ public class MapView extends ViewGroup implements IMapView,
 					  MapTileProviderBase tileProvider,
 					  final Handler tileRequestCompleteHandler, final AttributeSet attrs, boolean hardwareAccelerated) {
 		super(context, attrs);
-		setWillNotDraw(false); // in order to use onDraw instead of dispatchDraw; better for "invalidate"
 		if(isInEditMode()){ 	//fix for edit mode in the IDE
 			mTileRequestCompleteHandler=null;
 			mController=null;
+            mOldZoomController=null;
 			mZoomController=null;
 			mScroller=null;
 			mGestureDetector=null;
@@ -230,6 +233,12 @@ public class MapView extends ViewGroup implements IMapView,
 		this.mMapOverlay = new TilesOverlay(mTileProvider, context, horizontalMapRepetitionEnabled, verticalMapRepetitionEnabled);
 		mOverlayManager = new DefaultOverlayManager(mMapOverlay);
 
+		if (isInEditMode()) {
+			mOldZoomController = null;
+		} else {
+			mOldZoomController = new ZoomButtonsController(this);
+			mOldZoomController.setOnZoomListener(new MapViewZoomListener());
+		}
 		mZoomController = new CustomZoomButtonsController(this);
 		mZoomController.setOnZoomListener(new MapViewZoomListener());
 		checkZoomButtons();
@@ -245,7 +254,8 @@ public class MapView extends ViewGroup implements IMapView,
 		if (Configuration.getInstance().isMapViewRecyclerFriendly())
 		if (Build.VERSION.SDK_INT >= 16)
 			this.setHasTransientState(true);
-		mZoomController.setVisibility(CustomZoomButtonsController.Visibility.SHOW_AND_FADEOUT);
+
+		setBuiltInZoomControls(true);
 	}
 
 	/**
@@ -1042,6 +1052,7 @@ public class MapView extends ViewGroup implements IMapView,
 	public void onDetach() {
 		this.getOverlayManager().onDetach(this);
 		mTileProvider.detach();
+		mOldZoomController.setVisible(false);
 		if (mZoomController != null) {
 			mZoomController.onDetach();
 		}
@@ -1089,6 +1100,10 @@ public class MapView extends ViewGroup implements IMapView,
 
 		if (Configuration.getInstance().isDebugMapView()) {
 			Log.d(IMapView.LOGTAG,"dispatchTouchEvent(" + event + ")");
+		}
+
+		if (mOldZoomController.isVisible() && mOldZoomController.onTouch(this, event)) {
+			return true;
 		}
 
 		// Get rotated event for some touch listeners.
@@ -1207,7 +1222,7 @@ public class MapView extends ViewGroup implements IMapView,
 	}
 
 	@Override
-	public void onDraw(final Canvas c) {
+	protected void dispatchDraw(final Canvas c) {
 		final long startMs = System.currentTimeMillis();
 
 		// Reset the projection
@@ -1226,6 +1241,7 @@ public class MapView extends ViewGroup implements IMapView,
 			if (mZoomController != null) {
 				mZoomController.draw(c);
 			}
+			super.dispatchDraw(c);
 		}catch (Exception ex){
 			//for edit mode
 			Log.e(IMapView.LOGTAG, "error dispatchDraw, probably in edit mode", ex);
@@ -1379,9 +1395,13 @@ public class MapView extends ViewGroup implements IMapView,
 	 */
 	@Deprecated
 	public void setBuiltInZoomControls(final boolean on) {
+		this.mEnableOldZoomController = on;
+		this.checkZoomButtons();
+		/*
 		getZoomController().setVisibility(
 				on ? CustomZoomButtonsController.Visibility.SHOW_AND_FADEOUT
 						: CustomZoomButtonsController.Visibility.NEVER);
+						*/
 	}
 
 	public void setMultiTouchControls(final boolean on) {
@@ -1490,6 +1510,7 @@ public class MapView extends ViewGroup implements IMapView,
 				return true;
 			}
 
+			mOldZoomController.setVisible(mEnableOldZoomController);
 			if (mZoomController != null) {
 				mZoomController.activate();
 			}
@@ -1599,7 +1620,7 @@ public class MapView extends ViewGroup implements IMapView,
 		}
 	}
 
-	private class MapViewZoomListener implements CustomZoomButtonsController.OnZoomListener {
+	private class MapViewZoomListener implements CustomZoomButtonsController.OnZoomListener, ZoomButtonsController.OnZoomListener {
 		@Override
 		public void onZoom(final boolean zoomIn) {
 			if (zoomIn) {
@@ -1855,6 +1876,7 @@ public class MapView extends ViewGroup implements IMapView,
 	 * @since 6.1.0
 	 */
 	public CustomZoomButtonsController getZoomController() {
+		setBuiltInZoomControls(false);
 		return mZoomController;
 	}
 


### PR DESCRIPTION
We temporarily roll back to the standard Android zoom buttons, as the default zoom controller.
If a developer wants to switch to the new custom zoom buttons, `mMapView.getZoomController()` must explicitly be called, in something like `mMapView.getZoomController().setVisibility(CustomZoomButtonsController.Visibility.SHOW_AND_FADEOUT)`.

Impacted classes:
* `MapView`: partial roll back to the standard Android zoom controller - the custom zoom controller is still there, but is silent (default behavior)
* `SampleWithTilesOverlayAndCustomTileSource`: removed a useless zoom control code (which is already the default mode)
* `StarterMapFragment`: removed a useless zoom control code (which is already the default mode)

[actually, a desperate attempt to PR a code that github just ignored]