### PR TITLE
bug/#1316 - CacheManager little bug fix regarding bulk download support check timing

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/cachemanager/CacheManager.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/cachemanager/CacheManager.java
@@ -102,11 +102,6 @@ public class CacheManager {
         mTileWriter = pWriter;
         mMinZoomLevel = pMinZoomLevel;
         mMaxZoomLevel = pMaxZoomLevel;
-        if (pTileSource instanceof OnlineTileSourceBase) {
-            if (!((OnlineTileSourceBase) pTileSource).getTileSourcePolicy().acceptsBulkDownload()) {
-                throw new TileSourcePolicyException("This online tile source doesn't support bulk download");
-            }
-        }
     }
 
     /**
@@ -844,6 +839,9 @@ public class CacheManager {
             @Override
             public boolean preCheck() {
                 if (mTileSource instanceof OnlineTileSourceBase) {
+                    if (!((OnlineTileSourceBase) mTileSource).getTileSourcePolicy().acceptsBulkDownload()) {
+                        throw new TileSourcePolicyException("This online tile source doesn't support bulk download");
+                    }
                     return true;
                 } else {
                     Log.e(IMapView.LOGTAG, "TileSource is not an online tile source");


### PR DESCRIPTION
Impacted class:
* `CacheManager`: the "supports bulk download?" check is now performed only for download actions