### PR TITLE
Fix #1322: ItemizedOverlayWithFocus crash when very long description having no space

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/ItemizedOverlayWithFocus.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/ItemizedOverlayWithFocus.java
@@ -284,14 +284,15 @@ public class ItemizedOverlayWithFocus<Item extends OverlayItem> extends Itemized
 			final float charwidth = widths[i];
 
 			if (itemDescription.charAt(i) == '\n') {
-				sb.append(itemDescription.subSequence(lastStop, i));
-				lastStop = i;
+				sb.append(itemDescription.subSequence(lastStop, i + 1));
+				lastStop = i + 1;
 				maxWidth = Math.max(maxWidth, curLineWidth);
 				curLineWidth = 0;
+				lastwhitespace = lastStop;
+				continue;
 			} else if (curLineWidth + charwidth > DESCRIPTION_MAXWIDTH) {
-				if (lastStop == lastwhitespace) {
-					i--;
-				} else {
+				boolean noSpace = lastStop == lastwhitespace;
+				if (!noSpace) {
 					i = lastwhitespace;
 				}
 
@@ -301,6 +302,11 @@ public class ItemizedOverlayWithFocus<Item extends OverlayItem> extends Itemized
 				lastStop = i;
 				maxWidth = Math.max(maxWidth, curLineWidth);
 				curLineWidth = 0;
+				lastwhitespace = lastStop;
+				if (noSpace) {
+					i--;
+					continue;
+				}
 			}
 
 			curLineWidth += charwidth;


### PR DESCRIPTION
I also handle newline + wrap.
Extra test cases I used:

```java
        String description1 = "Line1\nLine2\nLine3\nLine4\nLine5\nLine6\nLine7\nLine8\nLine9\nLine10\nLine11\nLine12\nLine13\nLine14\nLine15";
        String description2 = "Line01 Line02 Line03 Line04 Line05 Line06 Line07 Line08 Line09 Line10 Line11 "
                + "Line12 Line13 Line14 Line15 Line16 Line17 Line18 Line19 Line20 Line21 Line22 Line23";
        String description5 = "Line1Line2Line3Line4Line5Line6Line7Line8Line9Line10Line11Line12Line13Line14Line15line16line17line18line19line20line21line22line23line24line25line26line27line28line29line30";
        String description6 = "01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789";
        String description7 =
                "BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC"
            +   "BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC"
            +   "BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC";
        String description3 = "0123456789012345678901234567890123456789012345678912345678901234"
                + "0123456789012345678901234567890123456789012345678912345678901234"
                + "0123456789012345678901234567890123456789012345678912345678901234";
        String description4 = "Line1\nLine2\n\nLine3\nLine4\n"
                + "BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC01234567890123456789012345678901234567890123456789123456789012340123456789012345678901234567890123456789012345678912345678901234";
```