### PR TITLE
feature/#1294_2 - new MapView.setMapCenterOffset method

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleFactory.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleFactory.java
@@ -37,6 +37,7 @@ import org.osmdroid.samplefragments.data.SampleRace;
 import org.osmdroid.samplefragments.data.SampleSimpleFastPointOverlay;
 import org.osmdroid.samplefragments.data.SampleSimpleLocation;
 import org.osmdroid.samplefragments.events.SampleAnimateToWithOrientation;
+import org.osmdroid.samplefragments.events.SampleMapCenterOffset;
 import org.osmdroid.samplefragments.tileproviders.SampleTileStates;
 import org.osmdroid.samplefragments.data.SampleWithMinimapItemizedOverlayWithFocus;
 import org.osmdroid.samplefragments.data.SampleWithMinimapItemizedOverlayWithScale;
@@ -305,6 +306,7 @@ public final class SampleFactory implements ISampleFactory {
         mSamples.add(SampleTileStates.class);
         mSamples.add(SampleAnimateToWithOrientation.class);
         mSamples.add(SampleMapSnapshot.class);
+        mSamples.add(SampleMapCenterOffset.class);
     }
 
     public void addSample(Class<? extends BaseSampleFragment> clz) {

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleMapSnapshot.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleMapSnapshot.java
@@ -144,7 +144,7 @@ public class SampleMapSnapshot extends BaseSampleFragment {
                     });
                 }
             }, MapSnapshot.INCLUDE_FLAG_UPTODATE, mapTileProvider, mOverlays,
-                    new Projection(zoom, mMapSize, mMapSize, pDataRegion.getBox().getCenterWithDateLine(), 0, true, true));
+                    new Projection(zoom, mMapSize, mMapSize, pDataRegion.getBox().getCenterWithDateLine(), 0, true, true, 0, 0));
             mMapSnapshots.put(key, mapSnapshot);
             new Thread(mapSnapshot).start(); // TODO use AsyncTask, Executors instead?
         }

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/events/SampleMapCenterOffset.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/events/SampleMapCenterOffset.java
@@ -1,0 +1,135 @@
+package org.osmdroid.samplefragments.events;
+
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.drawable.Drawable;
+
+import org.osmdroid.R;
+import org.osmdroid.util.GeoPoint;
+import org.osmdroid.views.Projection;
+import org.osmdroid.views.overlay.Marker;
+import org.osmdroid.views.overlay.Overlay;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Timer;
+import java.util.TimerTask;
+
+/**
+ * @author Fabrice Fontaine
+ * @since 6.1.1
+ */
+public class SampleMapCenterOffset extends SampleMapEventListener {
+
+	private final int mOffsetX = 0;
+	private final int mOffsetY = 200;
+	private final Paint mPaint = new Paint();
+
+	private int mIndex;
+	private Timer t = new Timer();
+	private boolean alive = true;
+	private final List<GeoPoint> mList = new ArrayList<>();
+
+	@Override
+	public String getSampleTitle() {
+		return "Animate To with Map Center Offset";
+	}
+
+	@Override
+	public void addOverlays() {
+		super.addOverlays();
+
+		final Drawable drawable = getResources().getDrawable(R.drawable.marker_default);
+
+		mList.add(new GeoPoint(38.8977, -77.0365));  // white house
+		mList.add(new GeoPoint(38.8719, -77.0563));  // pentagon
+		mList.add(new GeoPoint(38.8895, -77.0353));  // washington monument
+
+		for (final GeoPoint geoPoint : mList) {
+			final Marker startMarker = new Marker(mMapView);
+			startMarker.setPosition(geoPoint);
+			startMarker.setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM);
+			startMarker.setIcon(drawable);
+			mMapView.getOverlays().add(startMarker);
+		}
+
+		mPaint.setColor(Color.RED);
+		mPaint.setStrokeWidth(5);
+
+		mMapView.getOverlays().add(new Overlay() {
+
+			@Override
+			public void draw(Canvas pCanvas, Projection pProjection) {
+				mMapView.getProjection().save(pCanvas, false, true);
+				final float centerX = pCanvas.getWidth() / 2f;
+				final float centerY = pCanvas.getHeight() / 2f;
+				pCanvas.drawLine(centerX, centerY, centerX + mOffsetX, centerY + mOffsetY, mPaint);
+				mMapView.getProjection().restore(pCanvas, true);
+			}
+		});
+
+		mMapView.setMapCenterOffset(mOffsetX, mOffsetY);
+		mMapView.post(new Runnable() {
+			@Override
+			public void run() {
+				show();
+			}
+		});
+	}
+
+	@Override
+	public void onResume() {
+		super.onResume();
+		alive=true;
+		//some explanation here.
+		//we using a timer task with a delayed start up to move the map around. during CI tests
+		//this fragment can crash the app if you navigate away from the fragment before the initial fire
+		final TimerTask task = new TimerTask() {
+			@Override
+			public void run() {
+				runTask();
+			}
+		};
+
+		t = new Timer();
+		t.schedule(task, 4000, 4000);
+	}
+
+	@Override
+	public void onPause() {
+		super.onPause();
+		alive = false;
+		if (t != null)
+			t.cancel();
+		t = null;
+	}
+
+
+	private void runTask() {
+		if (!alive)
+			return;
+		if (getActivity() == null) {
+			return;
+		}
+		getActivity().runOnUiThread(new Runnable() {
+			@Override
+			public void run() {
+				if (mMapView == null || getActivity() == null) {
+					return;
+				}
+				show();
+			}
+		});
+	}
+
+	private void show() {
+		show(mIndex ++);
+	}
+
+	private void show(final int pIndex) {
+		final double zoom = 12.5;
+		final GeoPoint geoPoint = mList.get(pIndex % mList.size());
+		mMapView.getController().animateTo(geoPoint, zoom, null);
+	}
+}

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
@@ -186,6 +186,14 @@ public class MapView extends ViewGroup implements IMapView,
 	 */
 	private boolean mDestroyModeOnDetach = true;
 
+	/**
+	 * @since 6.1.1
+	 * The map center used to be projected into the screen center.
+	 * Now we have a possible offset from the screen center; default offset is [0, 0].
+	 */
+	private int mMapCenterOffsetX;
+	private int mMapCenterOffsetY;
+
 	// ===========================================================
 	// Constructors
 	// ===========================================================
@@ -553,7 +561,8 @@ public class MapView extends ViewGroup implements IMapView,
 				nextZoom, getWidth(), getHeight(),
 				center,
 				getMapOrientation(),
-				isHorizontalMapRepetitionEnabled(), isVerticalMapRepetitionEnabled());
+				isHorizontalMapRepetitionEnabled(), isVerticalMapRepetitionEnabled(),
+				getMapCenterOffsetX(), getMapCenterOffsetY());
 		final Point point = new Point();
 		final double longitude = pBoundingBox.getCenterLongitude();
 		projection.toPixels(new GeoPoint(pBoundingBox.getActualNorth(), longitude), point);
@@ -1893,6 +1902,28 @@ public class MapView extends ViewGroup implements IMapView,
 	 */
 	public void setDestroyMode(final boolean pOnDetach) {
 		mDestroyModeOnDetach = pOnDetach;
+	}
+
+	/**
+	 * @since 6.1.1
+	 */
+	public int getMapCenterOffsetX() {
+		return mMapCenterOffsetX;
+	}
+
+	/**
+	 * @since 6.1.1
+	 */
+	public int getMapCenterOffsetY() {
+		return mMapCenterOffsetY;
+	}
+
+	/**
+	 * @since 6.1.1
+	 */
+	public void setMapCenterOffset(final int pMapCenterOffsetX, final int pMapCenterOffsetY) {
+		mMapCenterOffsetX = pMapCenterOffsetX;
+		mMapCenterOffsetY = pMapCenterOffsetY;
 	}
 }
 

--- a/osmdroid-android/src/main/java/org/osmdroid/views/Projection.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/Projection.java
@@ -61,6 +61,12 @@ public class Projection implements IProjection {
 
 	private final TileSystem mTileSystem;
 
+	/**
+	 * @since 6.1.1
+	 */
+	private final int mMapCenterOffsetX;
+	private final int mMapCenterOffsetY;
+
 	Projection(MapView mapView) {
 		this(
 				mapView.getZoomLevelDouble(), mapView.getIntrinsicScreenRect(null),
@@ -68,7 +74,9 @@ public class Projection implements IProjection {
 				mapView.getMapScrollX(), mapView.getMapScrollY(),
 				mapView.getMapOrientation(),
 				mapView.isHorizontalMapRepetitionEnabled(), mapView.isVerticalMapRepetitionEnabled(),
-				mapView.getTileSystem());
+				MapView.getTileSystem(),
+				mapView.getMapCenterOffsetX(),
+				mapView.getMapCenterOffsetY());
 	}
 
 	/**
@@ -79,11 +87,14 @@ public class Projection implements IProjection {
 			final GeoPoint pCenter,
 			final long pScrollX, final long pScrollY,
 			final float pOrientation,
-			boolean horizontalWrapEnabled, boolean verticalWrapEnabled,
-			final TileSystem pTileSystem) {
+			final boolean pHorizontalWrapEnabled, final boolean pVerticalWrapEnabled,
+			final TileSystem pTileSystem,
+			final int pMapCenterOffsetX, final int pMapCenterOffsetY) {
+		mMapCenterOffsetX = pMapCenterOffsetX;
+		mMapCenterOffsetY = pMapCenterOffsetY;
 		mZoomLevelProjection = pZoomLevel;
-		this.horizontalWrapEnabled = horizontalWrapEnabled;
-		this.verticalWrapEnabled = verticalWrapEnabled;
+		horizontalWrapEnabled = pHorizontalWrapEnabled;
+		verticalWrapEnabled = pVerticalWrapEnabled;
 		mTileSystem = pTileSystem;
 		mMercatorMapSize = TileSystem.MapSize(mZoomLevelProjection);
 		mTileSize = TileSystem.getTileSize(mZoomLevelProjection);
@@ -106,14 +117,16 @@ public class Projection implements IProjection {
 			final double pZoomLevel, final int pWidth, final int pHeight,
 			final GeoPoint pCenter,
 			final float pOrientation,
-			final boolean pHorizontalWrapEnabled, final boolean pVerticalWrapEnabled) {
+			final boolean pHorizontalWrapEnabled, final boolean pVerticalWrapEnabled,
+			final int pMapCenterOffsetX, final int pMapCenterOffsetY) {
 		this(
 				pZoomLevel, new Rect(0, 0, pWidth, pHeight),
 				pCenter,
 				0, 0,
 				pOrientation,
 				pHorizontalWrapEnabled, pVerticalWrapEnabled,
-				MapView.getTileSystem());
+				MapView.getTileSystem(),
+				pMapCenterOffsetX, pMapCenterOffsetY);
 	}
 
 	/**
@@ -125,7 +138,8 @@ public class Projection implements IProjection {
 				mCurrentCenter, 0, 0,
 				mOrientation,
 				horizontalWrapEnabled, verticalWrapEnabled,
-				mTileSystem);
+				mTileSystem,
+				0, 0); // 0 looks like the most relevant value
 	}
 
 	public double getZoomLevel() {
@@ -584,14 +598,14 @@ public class Projection implements IProjection {
 	 * @since 6.0.0
 	 */
 	public int getScreenCenterX() {
-		return (mIntrinsicScreenRectProjection.right + mIntrinsicScreenRectProjection.left) / 2;
+		return (mIntrinsicScreenRectProjection.right + mIntrinsicScreenRectProjection.left) / 2 + mMapCenterOffsetX;
 	}
 
 	/**
 	 * @since 6.0.0
 	 */
 	public int getScreenCenterY() {
-		return (mIntrinsicScreenRectProjection.bottom + mIntrinsicScreenRectProjection.top) / 2;
+		return (mIntrinsicScreenRectProjection.bottom + mIntrinsicScreenRectProjection.top) / 2 + mMapCenterOffsetY;
 	}
 
 	/**
@@ -655,10 +669,7 @@ public class Projection implements IProjection {
 	private void refresh() {
 		// of course we could write mIntrinsicScreenRectProjection.centerX() and centerY()
 		// but we should keep writing it that way (cf. ProjectionTest)
-		fromPixels(
-				(mIntrinsicScreenRectProjection.left + mIntrinsicScreenRectProjection.right) / 2,
-				(mIntrinsicScreenRectProjection.top + mIntrinsicScreenRectProjection.bottom) / 2,
-				mCurrentCenter);
+		fromPixels(getScreenCenterX(), getScreenCenterY(), mCurrentCenter);
 		IGeoPoint neGeoPoint = fromPixels(
 				mIntrinsicScreenRectProjection.right, mIntrinsicScreenRectProjection.top, null, true);
 		final TileSystem tileSystem = org.osmdroid.views.MapView.getTileSystem();

--- a/osmdroid-android/src/test/java/org/osmdroid/util/ProjectionTest.java
+++ b/osmdroid-android/src/test/java/org/osmdroid/util/ProjectionTest.java
@@ -260,7 +260,8 @@ public class ProjectionTest {
                 pOffsetX, pOffsetY,
                 getRandomOrientation(),
                 true, true,
-                tileSystem);
+                tileSystem
+                , 0, 0);
     }
 
     private Projection getRandomProjection(final double pZoomLevel) {
@@ -284,7 +285,8 @@ public class ProjectionTest {
                     0L, 0L,
                     0,
                     false, false,
-                    tileSystem
+                    tileSystem,
+                    0, 0
             );
 
             final Point inputPoint = new Point(0, 0);


### PR DESCRIPTION
The map center used to be projected into the screen center.
Now we have a possible offset from the screen center; default offset is [0, 0].

New class:
* `SampleMapCenterOffset`: demo about the new `MapView.setMapCenterOffset` method - demo that can be reached at "More Samples / Events / Animate To with Map Center Offset"

Impacted classes:
* `MapView`: created `int` members `mMapCenterOffsetX` and `mMapCenterOffsetY` with getters and a common setter; used it when constructing a new related `Projection`
* `Projection`: created `final int` members `mMapCenterOffsetX` and `mMapCenterOffsetY`; added these parameters to constructors; impacted accordingly methods `getScreenCenterX` and `getScreenCenterY`; gently refactored
* `SampleFactory`: added the new `SampleMapCenterOffset` demo
* `SampleMapSnapshot`: impacted the use of a `Projection` constructor