### PR TITLE
feature/#1346 - new ScaleDiskOverlay class

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleMarker.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleMarker.java
@@ -1,14 +1,20 @@
 package org.osmdroid.samplefragments.data;
 
+import android.graphics.Color;
+import android.graphics.Paint;
 import android.graphics.drawable.Drawable;
+import android.util.DisplayMetrics;
 import android.widget.Toast;
 
 import org.osmdroid.R;
 import org.osmdroid.samplefragments.BaseSampleFragment;
 import org.osmdroid.util.BoundingBox;
 import org.osmdroid.util.GeoPoint;
+import org.osmdroid.util.constants.GeoConstants;
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.overlay.Marker;
+import org.osmdroid.views.overlay.ScaleBarOverlay;
+import org.osmdroid.views.overlay.ScaleDiskOverlay;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,10 +39,66 @@ public class SampleMarker extends BaseSampleFragment {
     public void addOverlays(){
         super.addOverlays();
 
+        final GeoPoint whiteHouse = new GeoPoint(38.8977, -77.0365);
+        final GeoPoint pentagon = new GeoPoint(38.8719, -77.0563);
+        final GeoPoint washington = new GeoPoint(38.8895, -77.0353);
+
+        final DisplayMetrics displayMetrics = getContext().getResources().getDisplayMetrics();
+
+        final ScaleDiskOverlay scaleDiskOverlayWhiteHouse = new ScaleDiskOverlay(getContext(), whiteHouse, 2000, GeoConstants.UnitOfMeasure.foot);
+        final Paint circlePaint = new Paint();
+        circlePaint.setColor(Color.rgb(128, 128, 128));
+        circlePaint.setStyle(Paint.Style.STROKE);
+        circlePaint.setStrokeWidth(2);
+        scaleDiskOverlayWhiteHouse.setCirclePaint2(circlePaint);
+        final Paint diskPaint = new Paint();
+        diskPaint.setColor(Color.argb(128, 128, 128, 128));
+        diskPaint.setStyle(Paint.Style.FILL_AND_STROKE);
+        scaleDiskOverlayWhiteHouse.setCirclePaint1(diskPaint);
+        final Paint textPaint = new Paint();
+        textPaint.setAntiAlias(true);
+        textPaint.setColor(Color.BLACK);
+        textPaint.setTextSize(10 * displayMetrics.density);
+        scaleDiskOverlayWhiteHouse.setTextPaint(textPaint);
+        scaleDiskOverlayWhiteHouse.setLabelOffsetBottom((int) (-2 * displayMetrics.density));
+        scaleDiskOverlayWhiteHouse.setLabelOffsetTop((int) (2 * displayMetrics.density));
+        scaleDiskOverlayWhiteHouse.setLabelOffsetLeft((int) (2 * displayMetrics.density));
+        scaleDiskOverlayWhiteHouse.setLabelOffsetRight((int) (-2 * displayMetrics.density));
+        scaleDiskOverlayWhiteHouse.setDisplaySizeMin(100);
+        scaleDiskOverlayWhiteHouse.setDisplaySizeMax(800);
+        mMapView.getOverlays().add(scaleDiskOverlayWhiteHouse);
+
+        final ScaleDiskOverlay scaleDiskOverlayPentagon = new ScaleDiskOverlay(getContext(), pentagon, 1, GeoConstants.UnitOfMeasure.statuteMile);
+        final Paint diskPaint2 = new Paint();
+        diskPaint2.setColor(Color.argb(32, 255, 0, 0));
+        diskPaint2.setStyle(Paint.Style.FILL);
+        scaleDiskOverlayPentagon.setCirclePaint1(diskPaint2);
+        final Paint textPaint2 = new Paint();
+        textPaint2.setAntiAlias(true);
+        textPaint2.setColor(Color.RED);
+        textPaint2.setTextSize(20 * displayMetrics.density);
+        scaleDiskOverlayPentagon.setTextPaint(textPaint2);
+        scaleDiskOverlayPentagon.setLabelOffsetTop((int) (2 * displayMetrics.density));
+        scaleDiskOverlayPentagon.setDisplaySizeMin(100);
+        scaleDiskOverlayPentagon.setDisplaySizeMax(800);
+        mMapView.getOverlays().add(scaleDiskOverlayPentagon);
+
+        final ScaleDiskOverlay scaleDiskOverlayWashington = new ScaleDiskOverlay(getContext(), washington, 2000, GeoConstants.UnitOfMeasure.foot);
+        final Paint circlePaint2 = new Paint();
+        circlePaint2.setColor(Color.CYAN);
+        circlePaint2.setStyle(Paint.Style.STROKE);
+        circlePaint2.setStrokeWidth(2);
+        scaleDiskOverlayWashington.setCirclePaint2(circlePaint2);
+        scaleDiskOverlayWashington.setDisplaySizeMin(100);
+        scaleDiskOverlayWashington.setDisplaySizeMax(800);
+        mMapView.getOverlays().add(scaleDiskOverlayWashington);
+
+        mMapView.getOverlays().add(new ScaleBarOverlay(mMapView));
+
         final List<GeoPoint> points = new ArrayList<>();
         final Drawable drawable = getResources().getDrawable(R.drawable.marker_default);
 
-        GeoPoint startPoint = new GeoPoint(38.8977, -77.0365);  //white house
+        GeoPoint startPoint = new GeoPoint(whiteHouse);
         points.add(startPoint);
         Marker startMarker = new Marker(mMapView);
         startMarker.setPosition(startPoint);
@@ -47,7 +109,7 @@ public class SampleMarker extends BaseSampleFragment {
         startMarker.setSubDescription("1600 Pennsylvania Ave NW, Washington, DC 20500");
         mMapView.getOverlays().add(startMarker);
 
-        startPoint = new GeoPoint(38.8719, -77.0563);
+        startPoint = new GeoPoint(pentagon);
         points.add(startPoint);
         startMarker = new Marker(mMapView);
         startMarker.setPosition(startPoint);
@@ -65,9 +127,7 @@ public class SampleMarker extends BaseSampleFragment {
         });
         mMapView.getOverlays().add(startMarker);
 
-
-
-        startPoint = new GeoPoint(38.8895, -77.0353);
+        startPoint = new GeoPoint(washington);
         points.add(startPoint);
         startMarker = new Marker(mMapView);
         startMarker.setPosition(startPoint);

--- a/osmdroid-android/src/main/java/org/osmdroid/util/constants/GeoConstants.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/constants/GeoConstants.java
@@ -1,16 +1,46 @@
 // Created by plusminus on 17:41:55 - 16.10.2008
 package org.osmdroid.util.constants;
 
+import org.osmdroid.library.R;
+
 public interface GeoConstants {
 	// ===========================================================
 	// Final Fields
 	// ===========================================================
 
-	public static final int RADIUS_EARTH_METERS = 6378137; // http://en.wikipedia.org/wiki/Earth_radius#Equatorial_radius
-	public static final double METERS_PER_STATUTE_MILE = 1609.344; // http://en.wikipedia.org/wiki/Mile
-	public static final double METERS_PER_NAUTICAL_MILE = 1852; // http://en.wikipedia.org/wiki/Nautical_mile
-	public static final double FEET_PER_METER = 3.2808399; // http://en.wikipedia.org/wiki/Feet_%28unit_of_length%29
-	public static final int EQUATORCIRCUMFENCE = (int) (2 * Math.PI * RADIUS_EARTH_METERS);
+	int RADIUS_EARTH_METERS = 6378137; // http://en.wikipedia.org/wiki/Earth_radius#Equatorial_radius
+	double METERS_PER_STATUTE_MILE = 1609.344; // http://en.wikipedia.org/wiki/Mile
+	double METERS_PER_NAUTICAL_MILE = 1852; // http://en.wikipedia.org/wiki/Nautical_mile
+	double FEET_PER_METER = 3.2808399; // http://en.wikipedia.org/wiki/Feet_%28unit_of_length%29
+	@Deprecated
+	int EQUATORCIRCUMFENCE = (int) (2 * Math.PI * RADIUS_EARTH_METERS);
+
+	/**
+	 * @since 6.1.1
+	 */
+	enum UnitOfMeasure {
+		meter(1, R.string.format_distance_only_meter),
+		kilometer(1000, R.string.format_distance_only_kilometer),
+		statuteMile(GeoConstants.METERS_PER_STATUTE_MILE, R.string.format_distance_only_mile),
+		nauticalMile(GeoConstants.METERS_PER_NAUTICAL_MILE, R.string.format_distance_only_nautical_mile),
+		foot(1 / GeoConstants.FEET_PER_METER, R.string.format_distance_only_foot);
+
+		private final double mConversionFactorToMeters;
+		private final int mStringResId;
+
+		UnitOfMeasure(final double pConversionFactorToMeters, final int pStringResId) {
+			mConversionFactorToMeters = pConversionFactorToMeters;
+			mStringResId = pStringResId;
+		}
+
+		public double getConversionFactorToMeters() {
+			return mConversionFactorToMeters;
+		}
+
+		public int getStringResId() {
+			return mStringResId;
+		}
+	}
 
 	// ===========================================================
 	// Methods

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/ScaleBarOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/ScaleBarOverlay.java
@@ -666,30 +666,30 @@ public class ScaleBarOverlay extends Overlay implements GeoConstants {
 		default:
 		case metric:
 			if (meters >= 1000 * 5) {
-                return getScaleString(R.string.format_distance_kilometers, "%.0f", meters / 1000);
+                return getConvertedScaleString(meters, UnitOfMeasure.kilometer, "%.0f");
 			} else if (meters >= 1000 / 5) {
-				return getScaleString(R.string.format_distance_kilometers, "%.1f", meters / 1000);
+				return getConvertedScaleString(meters, UnitOfMeasure.kilometer, "%.1f");
 			} else if (meters >= 20){
-                return getScaleString(R.string.format_distance_meters, "%.0f", meters);
+                return getConvertedScaleString(meters, UnitOfMeasure.meter, "%.0f");
 			} else {
-				return getScaleString(R.string.format_distance_meters, "%.2f", meters);
+				return getConvertedScaleString(meters, UnitOfMeasure.meter, "%.2f");
 			}
 		case imperial:
 			if (meters >= METERS_PER_STATUTE_MILE * 5) {
-				return getScaleString(R.string.format_distance_miles, "%.0f", meters / METERS_PER_STATUTE_MILE);
+				return getConvertedScaleString(meters, UnitOfMeasure.statuteMile, "%.0f");
 
 			} else if (meters >= METERS_PER_STATUTE_MILE / 5) {
-				return getScaleString(R.string.format_distance_miles, "%.1f", meters / METERS_PER_STATUTE_MILE);
+				return getConvertedScaleString(meters, UnitOfMeasure.statuteMile, "%.1f");
 			} else {
-				return getScaleString(R.string.format_distance_feet, "%.0f", meters * FEET_PER_METER);
+				return getConvertedScaleString(meters, UnitOfMeasure.foot, "%.0f");
 			}
 		case nautical:
 			if (meters >= METERS_PER_NAUTICAL_MILE * 5) {
-				return getScaleString(R.string.format_distance_nautical_miles, "%.0f", meters / METERS_PER_NAUTICAL_MILE);
+				return getConvertedScaleString(meters, UnitOfMeasure.nauticalMile, "%.0f");
 			} else if (meters >= METERS_PER_NAUTICAL_MILE / 5) {
-				return getScaleString(R.string.format_distance_nautical_miles, "%.1f", meters / METERS_PER_NAUTICAL_MILE);
+				return getConvertedScaleString(meters, UnitOfMeasure.nauticalMile, "%.1f");
 			} else {
-				return getScaleString(R.string.format_distance_feet, "%.0f", meters * FEET_PER_METER);
+				return getConvertedScaleString(meters, UnitOfMeasure.foot, "%.0f");
 			}
 		}
 	}
@@ -706,8 +706,25 @@ public class ScaleBarOverlay extends Overlay implements GeoConstants {
 	/**
 	 * @since 6.0.0
 	 */
-	private String getScaleString(final int pStringResId, final String pFormat, final double pValue) {
-		return context.getResources().getString(pStringResId, String.format(Locale.getDefault(), pFormat, pValue));
+	private String getConvertedScaleString(final double pMeters,
+										   final GeoConstants.UnitOfMeasure pConversion,
+										   final String pFormat) {
+		return getScaleString(
+				context,
+				String.format(Locale.getDefault(), pFormat,
+						pMeters / pConversion.getConversionFactorToMeters()),
+				pConversion);
+	}
+
+	/**
+	 * @since 6.1.1
+	 */
+	public static String getScaleString(final Context pContext,
+										final String pValue,
+										final GeoConstants.UnitOfMeasure pUnitOfMeasure) {
+		return pContext.getString(
+				R.string.format_distance_value_unit,
+				pValue, pContext.getString(pUnitOfMeasure.getStringResId()));
 	}
 
 	/**

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/ScaleDiskOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/ScaleDiskOverlay.java
@@ -1,0 +1,175 @@
+package org.osmdroid.views.overlay;
+
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Point;
+import android.graphics.Rect;
+
+import org.osmdroid.util.GeoPoint;
+import org.osmdroid.util.constants.GeoConstants;
+import org.osmdroid.views.Projection;
+
+import java.util.Locale;
+
+/**
+ * ScaleDiskOverlay displays a disk of a given radius (distance) around a GeoPoint
+ * @since 6.1.1
+ * @author Fabrice Fontaine
+ */
+public class ScaleDiskOverlay extends Overlay {
+
+	private final Point mPixelCenter = new Point();
+	private final Rect mLabelRect = new Rect();
+
+	private final GeoPoint mGeoCenter;
+	private final double mMeters;
+	private final String mLabel;
+
+	private Paint mCirclePaint1;
+	private Paint mCirclePaint2;
+	private Paint mTextPaint;
+
+	private Integer mLabelOffsetTop;
+	private Integer mLabelOffsetBottom;
+	private Integer mLabelOffsetLeft;
+	private Integer mLabelOffsetRight;
+
+	private int mDisplaySizeMin;
+	private int mDisplaySizeMax;
+
+	public ScaleDiskOverlay(final Context pContext,
+							final GeoPoint pGeoCenter,
+							final int pValue, final GeoConstants.UnitOfMeasure pUnitOfMeasure) {
+		mGeoCenter = pGeoCenter;
+		mMeters = pValue * pUnitOfMeasure.getConversionFactorToMeters();
+		mLabel = ScaleBarOverlay.getScaleString(
+				pContext,
+				String.format(Locale.getDefault(), "%d", pValue), pUnitOfMeasure);
+	}
+
+	/**
+	 * Circle Paint 1 setter (typically for a disk)
+	 * Can be null; will be used before Circle Paint 2
+	 */
+	public void setCirclePaint1(final Paint pPaint) {
+		mCirclePaint1 = pPaint;
+	}
+
+	/**
+	 * Circle Paint 2 setter (typically for a circle)
+	 * Can be null; will be used after Circle Paint 1
+	 */
+	public void setCirclePaint2(final Paint pPaint) {
+		mCirclePaint2 = pPaint;
+	}
+
+	/**
+	 * Label Paint setter (null means no label will be displayed)
+	 */
+	public void setTextPaint(final Paint pPaint) {
+		mTextPaint = pPaint;
+	}
+
+	/**
+	 * Label offset setter for top (null means no label on top)
+	 */
+	public void setLabelOffsetTop(final Integer pValue) {
+		mLabelOffsetTop = pValue;
+	}
+
+	/**
+	 * Label offset setter for bottom (null means no label on bottom)
+	 */
+	public void setLabelOffsetBottom(final Integer pValue) {
+		mLabelOffsetBottom = pValue;
+	}
+
+	/**
+	 * Label offset setter for left (null means no label on left)
+	 */
+	public void setLabelOffsetLeft(final Integer pValue) {
+		mLabelOffsetLeft = pValue;
+	}
+
+	/**
+	 * Label offset setter for right (null means no label on right)
+	 */
+	public void setLabelOffsetRight(final Integer pValue) {
+		mLabelOffsetRight = pValue;
+	}
+
+	/**
+	 * Minimum display size setter (<= 0 means no minimum)
+	 */
+	public void setDisplaySizeMin(final int pValue) {
+		mDisplaySizeMin = pValue;
+	}
+
+	/**
+	 * Maximum display size setter (<= 0 means no maximum)
+	 */
+	public void setDisplaySizeMax(final int pValue) {
+		mDisplaySizeMax = pValue;
+	}
+
+	@Override
+	public void draw(final Canvas pCanvas, final Projection pProjection) {
+		pProjection.toPixels(mGeoCenter, mPixelCenter);
+		final int x = mPixelCenter.x;
+		final int y = mPixelCenter.y;
+		final int radius = (int) pProjection.metersToPixels(
+				(float) mMeters, mGeoCenter.getLatitude(), pProjection.getZoomLevel());
+		if (mDisplaySizeMin > 0 && 2 * radius < mDisplaySizeMin) {
+			return;
+		}
+		if (mDisplaySizeMax > 0 && 2 * radius > mDisplaySizeMax) {
+			return;
+		}
+		if (mCirclePaint1 != null) {
+			pCanvas.drawCircle(x, y, radius, mCirclePaint1);
+		}
+		if (mCirclePaint2 != null) {
+			pCanvas.drawCircle(x, y, radius, mCirclePaint2);
+		}
+		if (mTextPaint != null) {
+			mTextPaint.getTextBounds(mLabel, 0, mLabel.length(), mLabelRect);
+			if (mLabelOffsetTop != null) {
+				final int offsetX = getOffsetX();
+				final int offsetY = -radius + getOffsetY(mLabelOffsetTop);
+				pCanvas.drawText(mLabel, x + offsetX, y + offsetY, mTextPaint);
+			}
+			if (mLabelOffsetLeft != null) {
+				final int offsetX = -radius + getOffsetX(mLabelOffsetLeft);
+				final int offsetY = getOffsetY();
+				pCanvas.drawText(mLabel, x + offsetX, y + offsetY, mTextPaint);
+			}
+			if (mLabelOffsetBottom != null) {
+				final int offsetX = getOffsetX();
+				final int offsetY = radius + getOffsetY(mLabelOffsetBottom);
+				pCanvas.drawText(mLabel, x + offsetX, y + offsetY, mTextPaint);
+			}
+			if (mLabelOffsetRight != null) {
+				final int offsetX = radius + getOffsetX(mLabelOffsetRight);
+				final int offsetY = getOffsetY();
+				pCanvas.drawText(mLabel, x + offsetX, y + offsetY, mTextPaint);
+			}
+		}
+	}
+
+	private int getOffsetX() {
+		return -mLabelRect.width() / 2;
+	}
+
+	private int getOffsetY() {
+		return 0;
+	}
+
+	private int getOffsetX(final int pOffsetX) {
+		return pOffsetX + (pOffsetX >= 0 ? 0 : -mLabelRect.width());
+	}
+
+	private int getOffsetY(final int pOffsetY) {
+		return pOffsetY + (pOffsetY >= 0 ? -mLabelRect.top : -mLabelRect.bottom);
+	}
+}

--- a/osmdroid-android/src/main/res/values/strings.xml
+++ b/osmdroid-android/src/main/res/values/strings.xml
@@ -28,4 +28,12 @@
 
     <string name="compass">Compass</string>
 
+    <string name="format_distance_only_meter">m</string>
+    <string name="format_distance_only_kilometer">km</string>
+    <string name="format_distance_only_mile">mi</string>
+    <string name="format_distance_only_nautical_mile">nm</string>
+    <string name="format_distance_only_foot">ft</string>
+
+    <string name="format_distance_value_unit">%1$s %2$s</string>
+
 </resources>


### PR DESCRIPTION
A demo can be found in the "More Samples / Data / Marker" demo.

New class:
* `ScaleDiskOverlay`: displays a disk of a given radius (distance) around a GeoPoint

Impacts:
* `GeoConstants`: added `enum UnitOfMeasure`; gently refactored
* `ScaleBarOverlay`: refactored the display of scale text, in order to be reused in `ScaleDiskOverlay`
* `strings.xml`: created `format_distance_only_%` and `format_distance_value_unit`
* `SampleMarker`: added a `ScaleDiskOverlay` for each POI