### PR TITLE
bug/#1407 - simplified "speech balloon" demo

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleSpeechBalloon.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleSpeechBalloon.java
@@ -14,8 +14,6 @@ import org.osmdroid.views.overlay.SpeechBalloonOverlay;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Timer;
-import java.util.TimerTask;
 
 /**
  * Demo around the new {@link SpeechBalloonOverlay} feature
@@ -23,6 +21,12 @@ import java.util.TimerTask;
  * @author Fabrice Fontaine
  */
 public class SampleSpeechBalloon extends BaseSampleFragment {
+
+    private final List<GeoPoint> mGeoPoints = new ArrayList<>();
+    private final Paint mBackground = new Paint();
+    private final Paint mForeground = new Paint();
+    private final Paint mDragBackground = new Paint();
+    private final Paint mDragForeground = new Paint();
 
     @Override
     public String getSampleTitle() {
@@ -93,43 +97,13 @@ public class SampleSpeechBalloon extends BaseSampleFragment {
             @Override
             public void run() {
                 mMapView.zoomToBoundingBox(boundingBox, false, 50);
-                displayNext();
             }
         });
     }
-
-    private int mIndex;
-
-    private void displayNext() {
-        if (mIndex >= mPOIs.size()) {
-            return;
-        }
-        addToDisplay(mPOIs.get(mIndex ++));
-        getActivity().runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                mMapView.invalidate();
-            }
-        });
-        final Timer timer = new Timer();
-        timer.schedule(new TimerTask() {
-            @Override
-            public void run() {
-                displayNext();
-            }
-        }, 350);
-    }
-
-    private final List<GeoPoint> mGeoPoints = new ArrayList<>();
-    private final List<POI> mPOIs = new ArrayList<>();
-    private final Paint mBackground = new Paint();
-    private final Paint mForeground = new Paint();
-    private final Paint mDragBackground = new Paint();
-    private final Paint mDragForeground = new Paint();
 
     private void add(final POI pPOI) {
         mGeoPoints.add(pPOI.mGeoPoint);
-        mPOIs.add(pPOI);
+        addToDisplay(pPOI);
     }
 
     private void addToDisplay(final POI pPOI) {

--- a/osmdroid-android/src/main/java/org/osmdroid/util/MyMath.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/MyMath.java
@@ -162,6 +162,7 @@ public class MyMath implements MathConstants {
 	/**
 	 * @since 6.1.1
 	 * Computes the point of a circle from its center, its radius and the angle
+	 * @param pAngle clockwise angle, in radian, value 0 being 3 o'clock
 	 */
 	public static void computeCirclePoint(final long pCenterX, final long pCenterY, final double pRadius,
 										  final double pAngle, final PointL pOutput) {


### PR DESCRIPTION
Impacted classes:
* `MyMath`: unrelated new precision in the javadoc of method `computeCirclePoint`
* `SampleSpeechBalloon`: removed all the `Timer` feature, which was irrelevant for the very demo and caused crashes in the demo app; minor refactoring