### PR TITLE
Avoid Zoom Buttons to Cancel Follow Location State.

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/views/CustomZoomButtonsController.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/CustomZoomButtonsController.java
@@ -182,14 +182,11 @@ public class CustomZoomButtonsController {
 		return false;
 	}
 
-  public boolean isHandling(final MotionEvent pMotionEvent) {
-		if (mAlpha01 == 0) return false;
-    return mDisplay.isTouchedRotated(pMotionEvent, true)
-        || mDisplay.isTouchedRotated(pMotionEvent, false);
-  }
-
 	private boolean isTouched(final MotionEvent pMotionEvent) {
-		if (mAlpha01 == 0 || checkJustActivated() ) {
+		if (mAlpha01 == 0 ) {
+      return false;
+    }
+    if ( checkJustActivated() ) {
 			return false;
 		}
 		if (mDisplay.isTouchedRotated(pMotionEvent, true)) {

--- a/osmdroid-android/src/main/java/org/osmdroid/views/CustomZoomButtonsController.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/CustomZoomButtonsController.java
@@ -182,11 +182,14 @@ public class CustomZoomButtonsController {
 		return false;
 	}
 
+  public boolean isHandling(final MotionEvent pMotionEvent) {
+		if (mAlpha01 == 0) return false;
+    return mDisplay.isTouchedRotated(pMotionEvent, true)
+        || mDisplay.isTouchedRotated(pMotionEvent, false);
+  }
+
 	private boolean isTouched(final MotionEvent pMotionEvent) {
-		if (mAlpha01 == 0) {
-			return false;
-		}
-		if (checkJustActivated()) {
+		if (mAlpha01 == 0 || checkJustActivated() ) {
 			return false;
 		}
 		if (mDisplay.isTouchedRotated(pMotionEvent, true)) {

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
@@ -1119,6 +1119,10 @@ public class MapView extends ViewGroup implements IMapView,
 		// Get rotated event for some touch listeners.
 		MotionEvent rotatedEvent = rotateTouchEvent(event);
 
+    if ( mZoomController != null && mZoomController.onSingleTapConfirmed(rotatedEvent)) {
+      return true;
+    }
+
 		try {
 			if (super.dispatchTouchEvent(event)) {
 				if (Configuration.getInstance().isDebugMapView()) {
@@ -1619,13 +1623,9 @@ public class MapView extends ViewGroup implements IMapView,
 
 		@Override
 		public boolean onSingleTapConfirmed(final MotionEvent e) {
-			if (mZoomController != null && mZoomController.onSingleTapConfirmed(e)) {
-				return true;
-			}
 			if (MapView.this.getOverlayManager().onSingleTapConfirmed(e, MapView.this)) {
 				return true;
 			}
-
 			return false;
 		}
 	}

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/mylocation/MyLocationNewOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/mylocation/MyLocationNewOverlay.java
@@ -26,7 +26,6 @@ import org.osmdroid.views.Projection;
 import org.osmdroid.views.overlay.IOverlayMenuProvider;
 import org.osmdroid.views.overlay.Overlay;
 import org.osmdroid.views.overlay.Overlay.Snappable;
-import org.osmdroid.views.CustomZoomButtonsController;
 
 import java.util.LinkedList;
 
@@ -296,10 +295,7 @@ public class MyLocationNewOverlay extends Overlay implements IMyLocationConsumer
 	@Override
 	public boolean onTouchEvent(final MotionEvent event, final MapView mapView) {
 		if (event.getAction() == MotionEvent.ACTION_DOWN && enableAutoStop) {
-      CustomZoomButtonsController zoomController = mapView.getZoomController();
-      if ( zoomController != null && !zoomController.isHandling(event) ) {
-        this.disableFollowLocation();
-      }
+      this.disableFollowLocation();
 		} else if (event.getAction() == MotionEvent.ACTION_MOVE && isFollowLocationEnabled()) {
 			return true;  // prevent the pan
 		}

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/mylocation/MyLocationNewOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/mylocation/MyLocationNewOverlay.java
@@ -26,6 +26,7 @@ import org.osmdroid.views.Projection;
 import org.osmdroid.views.overlay.IOverlayMenuProvider;
 import org.osmdroid.views.overlay.Overlay;
 import org.osmdroid.views.overlay.Overlay.Snappable;
+import org.osmdroid.views.CustomZoomButtonsController;
 
 import java.util.LinkedList;
 
@@ -295,7 +296,10 @@ public class MyLocationNewOverlay extends Overlay implements IMyLocationConsumer
 	@Override
 	public boolean onTouchEvent(final MotionEvent event, final MapView mapView) {
 		if (event.getAction() == MotionEvent.ACTION_DOWN && enableAutoStop) {
-			this.disableFollowLocation();
+      CustomZoomButtonsController zoomController = mapView.getZoomController();
+      if ( zoomController != null && !zoomController.isHandling(event) ) {
+        this.disableFollowLocation();
+      }
 		} else if (event.getAction() == MotionEvent.ACTION_MOVE && isFollowLocationEnabled()) {
 			return true;  // prevent the pan
 		}


### PR DESCRIPTION
As a user of my own app I find it completely annoying, that everytime I use a (permanent) **zoom** button the state of **followLocation** is canceled. 

This is a slightly hacky solution to solve this issue: `CustomZoomButtonsController` and `MyLocationNewOverlay` interact now.

Note:
- I think in long term (code separation, etc.) it might be nicer to have zoom buttons an overlay itself, but I just got my issue solved. 
- I thought, there was a bug for it, but I failed to find it ...

Developed and tested on todays (6.1.3) snapshot.