### PR TITLE
bug/#1416 - additional zoom check before tile download

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleFactory.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/SampleFactory.java
@@ -94,6 +94,7 @@ import org.osmdroid.samplefragments.tileproviders.SampleAssetsOnly;
 import org.osmdroid.samplefragments.tileproviders.SampleAssetsOnlyRepetitionModes;
 import org.osmdroid.samplefragments.tileproviders.SampleOfflineGemfOnly;
 import org.osmdroid.samplefragments.tileproviders.SampleOfflineOnly;
+import org.osmdroid.samplefragments.tileproviders.SampleUnreachableOnlineTiles;
 import org.osmdroid.samplefragments.tileproviders.SampleVeryHighZoomLevel;
 import org.osmdroid.samplefragments.tilesources.SampleBingHybrid;
 import org.osmdroid.samplefragments.tilesources.SampleBingRoad;
@@ -315,6 +316,7 @@ public final class SampleFactory implements ISampleFactory {
         mSamples.add(SampleSpeechBalloon.class);
         mSamples.add(SampleMapCenterOffset.class);
         mSamples.add(SampleSnappable.class);
+        mSamples.add(SampleUnreachableOnlineTiles.class);
     }
 
     public void addSample(Class<? extends BaseSampleFragment> clz) {

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/tileproviders/SampleUnreachableOnlineTiles.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/tileproviders/SampleUnreachableOnlineTiles.java
@@ -1,0 +1,54 @@
+package org.osmdroid.samplefragments.tileproviders;
+
+import org.osmdroid.samplefragments.BaseSampleFragment;
+import org.osmdroid.tileprovider.tilesource.OnlineTileSourceBase;
+import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
+import org.osmdroid.tileprovider.tilesource.TileSourcePolicy;
+import org.osmdroid.tileprovider.tilesource.XYTileSource;
+import org.osmdroid.util.GeoPoint;
+
+/**
+ * Demo checking if the zoom restriction for tiles is correctly applied
+ * We actually download MAPNIK tiles but only for zoom levels 14 and 15
+ * @author Fabrice Fontaine
+ * @since 6.1.3
+ */
+public class SampleUnreachableOnlineTiles extends BaseSampleFragment {
+
+    private static final int ZOOM_MIN = 14;
+    private static final int ZOOM_MAX = 15;
+
+    /**
+     * cf. {@link TileSourceFactory#MAPNIK}
+     */
+    private static final OnlineTileSourceBase MAPNIK_FOR_TESTS = new XYTileSource("Mapnik",
+            ZOOM_MIN, ZOOM_MAX, 256, ".png", new String[] {
+            "https://a.tile.openstreetmap.org/",
+            "https://b.tile.openstreetmap.org/",
+            "https://c.tile.openstreetmap.org/" },"© OpenStreetMap contributors",
+            new TileSourcePolicy(2,
+                    TileSourcePolicy.FLAG_NO_BULK
+                            | TileSourcePolicy.FLAG_NO_PREVENTIVE
+                            | TileSourcePolicy.FLAG_USER_AGENT_MEANINGFUL
+                            | TileSourcePolicy.FLAG_USER_AGENT_NORMALIZED
+            ));
+
+    @Override
+    public String getSampleTitle() {
+        return "Zoom Restricted Online Tiles (" + ZOOM_MIN + "-" + ZOOM_MAX + ")";
+    }
+
+    @Override
+    protected void addOverlays() {
+        super.addOverlays();
+
+        mMapView.setTileSource(MAPNIK_FOR_TESTS);
+        mMapView.post(new Runnable() {
+            @Override
+            public void run() {
+                mMapView.getController().setZoom(ZOOM_MIN * 1f);
+                mMapView.setExpectedCenter(new GeoPoint(45.7597, 4.8422)); // Lyon, France
+            }
+        });
+    }
+}

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTilePreCache.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTilePreCache.java
@@ -122,7 +122,7 @@ public class MapTilePreCache {
                         }
                     }
                 }
-                final Drawable drawable = provider.getTileLoader().loadTile(pMapTileIndex);
+                final Drawable drawable = provider.getTileLoader().loadTileIfReachable(pMapTileIndex);
                 if (drawable == null) {
                     continue;
                 }

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileApproximater.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileApproximater.java
@@ -180,7 +180,7 @@ public class MapTileApproximater extends MapTileModuleProviderBase {
                 MapTileIndex.getX(pMapTileIndex) >> pZoomDiff,
                 MapTileIndex.getY(pMapTileIndex) >> pZoomDiff);
         try {
-            final Drawable srcDrawable = pProvider.getTileLoader().loadTile(srcTile);
+            final Drawable srcDrawable = pProvider.getTileLoader().loadTileIfReachable(srcTile);
             if (!(srcDrawable instanceof BitmapDrawable)) {
                 return null;
             }


### PR DESCRIPTION
New class:
* `SampleUnreachableOnlineTiles`: demo checking if the zoom restriction for tiles is correctly applied, to be found under "More Samples / Tileproviders / Zoom Restricted Online Tiles (14-15)"

Impacted classes:
* `MapTileApproximater`: called new method `TileLoader.loadTileIfReachable` instead of `TileLoader.loadTile`
* `MapTileModuleProviderBase`: new method `isTileReachable`; new method `TileLoader.loadTileIfReachable`, to be called instead of direct calls to `TileLoader.loadTile`
* `MapTilePreCache`: called new method `TileLoader.loadTileIfReachable` instead of `TileLoader.loadTile`
* `SampleFactory`: added new demo `SampleUnreachableOnlineTiles`