### PR TITLE
feature/#1418 - custom zoom refactoring while removing the old standard zoom controllers

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/bugtestfragments/WeathForceActivity.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/bugtestfragments/WeathForceActivity.java
@@ -95,7 +95,6 @@ public class WeathForceActivity extends BaseActivity implements LocationListener
         mLocationOverlay.enableFollowLocation();
         mLocationOverlay.enableMyLocation();
         this.mMapView.getOverlayManager().add(mLocationOverlay);
-        mMapView.setBuiltInZoomControls(true);
         mMapView.setMultiTouchControls(true);
         mMapView.setTilesScaledToDpi(true);
     }

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/AsyncTaskDemoFragment.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/AsyncTaskDemoFragment.java
@@ -69,7 +69,6 @@ public class AsyncTaskDemoFragment extends BaseSampleFragment {
             }
         }, DEFAULT_INACTIVITY_DELAY_IN_MILLISECS));
 
-        mMapView.setBuiltInZoomControls(true);
         mMapView.setMultiTouchControls(true);
         mMapView.setTilesScaledToDpi(true);
 

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/layouts/SampleSplitScreen.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/layouts/SampleSplitScreen.java
@@ -53,7 +53,6 @@ public class SampleSplitScreen extends BaseSampleFragment implements MapListener
         mMapView2.setTileSource(new MapBoxTileSource(getContext()));
         mMapView2.setMapListener(this);
 
-        mMapView2.setBuiltInZoomControls(true);
         mMapView2.setMultiTouchControls(true);
         mMapView2.setTilesScaledToDpi(true);
     }

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/layouts/rec/CustomRecycler.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/layouts/rec/CustomRecycler.java
@@ -113,7 +113,6 @@ public class CustomRecycler extends RecyclerView.Adapter<CustomRecycler.ViewHold
 
             Info dat = data.get(position);
             MapViewHolder Indicador = (MapViewHolder) viewHolder;
-            Indicador.mapaShow.setBuiltInZoomControls(true);
             Indicador.mapaShow.setMultiTouchControls(true);
             Indicador.mapaShow.setClickable(false);
 

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/location/SampleFollowMe.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/location/SampleFollowMe.java
@@ -70,7 +70,6 @@ public class SampleFollowMe extends BaseSampleFragment implements LocationListen
 
         mMapView.getController().setZoom(15);
         mMapView.setTilesScaledToDpi(true);
-        mMapView.setBuiltInZoomControls(true);
         mMapView.setMultiTouchControls(true);
         mMapView.setFlingEnabled(true);
         mMapView.getOverlays().add(this.mLocationOverlay);

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/location/SampleHeadingCompassUp.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/location/SampleHeadingCompassUp.java
@@ -63,7 +63,6 @@ public class SampleHeadingCompassUp extends BaseSampleFragment implements Locati
         overlay.setEnableAutoStop(false);
         overlay.enableFollowLocation();
         overlay.enableMyLocation();
-        mMapView.setBuiltInZoomControls(true);
         this.mMapView.getOverlayManager().add(overlay);
     }
 

--- a/osmdroid-android/src/main/java/org/osmdroid/views/CustomZoomButtonsController.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/CustomZoomButtonsController.java
@@ -182,20 +182,20 @@ public class CustomZoomButtonsController {
 		return false;
 	}
 
-	private boolean isTouched(final MotionEvent pMotionEvent) {
+	public boolean isTouched(final MotionEvent pMotionEvent) {
 		if (mAlpha01 == 0) {
 			return false;
 		}
 		if (checkJustActivated()) {
 			return false;
 		}
-		if (mDisplay.isTouchedRotated(pMotionEvent, true)) {
+		if (mDisplay.isTouched(pMotionEvent, true)) {
 			if (mZoomInEnabled && mListener != null) {
 				mListener.onZoom(true);
 			}
 			return true;
 		}
-		if (mDisplay.isTouchedRotated(pMotionEvent, false)) {
+		if (mDisplay.isTouched(pMotionEvent, false)) {
 			if (mZoomOutEnabled && mListener != null) {
 				mListener.onZoom(false);
 			}
@@ -210,10 +210,12 @@ public class CustomZoomButtonsController {
 		void onZoom(boolean b);
 	}
 
+	@Deprecated
 	public boolean onSingleTapConfirmed(final MotionEvent pMotionEvent) {
 		return isTouched(pMotionEvent);
 	}
 
+	@Deprecated
 	public boolean onLongPress(final MotionEvent pMotionEvent) {
 		return isTouched(pMotionEvent);
 	}

--- a/osmdroid-android/src/main/java/org/osmdroid/views/CustomZoomButtonsDisplay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/CustomZoomButtonsDisplay.java
@@ -137,8 +137,8 @@ public class CustomZoomButtonsDisplay {
 				return pMapViewWidth - mMargin * mBitmapSize - mBitmapSize
 						- (mHorizontalOrVertical ? mPadding * mBitmapSize + mBitmapSize : 0);
 			case CENTER:
-				return pMapViewWidth / 2
-						- (mHorizontalOrVertical ? mPadding * mBitmapSize / 2 + mBitmapSize : mBitmapSize / 2);
+				return pMapViewWidth / 2f
+						- (mHorizontalOrVertical ? mPadding * mBitmapSize / 2 + mBitmapSize : mBitmapSize / 2f);
 		}
 		throw new IllegalArgumentException();
 	}
@@ -151,8 +151,8 @@ public class CustomZoomButtonsDisplay {
 				return pMapViewHeight - mMargin * mBitmapSize - mBitmapSize
 						- (mHorizontalOrVertical ? 0 : mPadding * mBitmapSize + mBitmapSize);
 			case CENTER:
-				return pMapViewHeight / 2
-						- (mHorizontalOrVertical ? mBitmapSize / 2 : mPadding * mBitmapSize / 2 + mBitmapSize);
+				return pMapViewHeight / 2f
+						- (mHorizontalOrVertical ? mBitmapSize / 2f : mPadding * mBitmapSize / 2 + mBitmapSize);
 		}
 		throw new IllegalArgumentException();
 	}
@@ -172,6 +172,7 @@ public class CustomZoomButtonsDisplay {
 		return pEnabled ? mZoomOutBitmapEnabled : mZoomOutBitmapDisabled;
 	}
 
+	@Deprecated
 	public boolean isTouchedRotated(final MotionEvent pMotionEvent, final boolean pInOrOut) {
 		if (mMapView.getMapOrientation() == 0) {
 			mUnrotatedPoint.set((int) pMotionEvent.getX(), (int) pMotionEvent.getY());
@@ -180,6 +181,13 @@ public class CustomZoomButtonsDisplay {
 					(int) pMotionEvent.getX(), (int) pMotionEvent.getY(), mUnrotatedPoint);
 		}
 		return isTouched(mUnrotatedPoint.x, mUnrotatedPoint.y, pInOrOut);
+	}
+
+	/**
+	 * @since 6.1.3
+	 */
+	public boolean isTouched(final MotionEvent pMotionEvent, final boolean pInOrOut) {
+		return isTouched((int) pMotionEvent.getX(), (int) pMotionEvent.getY(), pInOrOut);
 	}
 
 	private boolean isTouched(final int pEventX, final int pEventY, final boolean pInOrOut) {

--- a/osmdroid-android/src/test/java/org/osmdroid/util/GarbageCollectorTest.java
+++ b/osmdroid-android/src/test/java/org/osmdroid/util/GarbageCollectorTest.java
@@ -13,6 +13,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class GarbageCollectorTest {
 
+    /**
+     * @since 6.1.3
+     */
+    private static final long ACTION_MILLISECONDS = 500;
+
     private final AtomicInteger mCount = new AtomicInteger(0);
 
     @Test
@@ -30,10 +35,10 @@ public class GarbageCollectorTest {
         mCount.set(0);
 
         garbageCollector.gc();
-        sleep(100);
+        sleepFactor(.5);
         Assert.assertEquals(1, mCount.get());
         Assert.assertTrue(garbageCollector.isRunning());
-        sleep(500);
+        sleepFactor(2);
         Assert.assertFalse(garbageCollector.isRunning());
         Assert.assertEquals(1, mCount.get());
     }
@@ -44,18 +49,18 @@ public class GarbageCollectorTest {
         mCount.set(0);
 
         garbageCollector.gc();
-        sleep(100);
+        sleepFactor(.5);
         Assert.assertEquals(1, mCount.get());
         Assert.assertTrue(garbageCollector.isRunning());
-        sleep(500);
+        sleepFactor(2);
         Assert.assertFalse(garbageCollector.isRunning());
         Assert.assertEquals(1, mCount.get());
 
         garbageCollector.gc();
-        sleep(100);
+        sleepFactor(.5);
         Assert.assertEquals(2, mCount.get());
         Assert.assertTrue(garbageCollector.isRunning());
-        sleep(500);
+        sleepFactor(2);
         Assert.assertFalse(garbageCollector.isRunning());
         Assert.assertEquals(2, mCount.get());
     }
@@ -69,10 +74,10 @@ public class GarbageCollectorTest {
         garbageCollector.gc();
         garbageCollector.gc();
         garbageCollector.gc();
-        sleep(100);
+        sleepFactor(.5);
         Assert.assertEquals(1, mCount.get());
         Assert.assertTrue(garbageCollector.isRunning());
-        sleep(500);
+        sleepFactor(2);
         Assert.assertFalse(garbageCollector.isRunning());
         Assert.assertEquals(1, mCount.get());
     }
@@ -82,7 +87,7 @@ public class GarbageCollectorTest {
             @Override
             public void run() {
                 mCount.incrementAndGet();
-                sleep(500);
+                sleepFactor(1);
             }
         };
     }
@@ -93,5 +98,12 @@ public class GarbageCollectorTest {
         } catch(InterruptedException e) {
             //
         }
+    }
+
+    /**
+     * @since 6.1.3
+     */
+    private void sleepFactor(final double pFactor) {
+        sleep(Math.round(ACTION_MILLISECONDS * pFactor));
     }
 }


### PR DESCRIPTION
Impacted classes:
* `AsyncTaskDemoFragment`, `CustomRecycler`, `SampleFollowMe`, `SampleHeadingCompassUp`, `SampleSplitScreen`, `WeathForceActivity`: removed a useless call to now deprecated method `MapView.setBuiltInZoomControls`, which used to be the default behavior anyway
* `MapView`: removed all the references on the deprecated Android zoom controls; moved the calls to zoom control test in `dispatchTouchEvent`; deprecated method `setBuiltInZoomControls`; unrelated minor refactoring
* `CustomZoomButtonsController`: made `public` method `isTouched` which uses new method `CustomZoomButtonsDisplay.isTouched`; deprecated method `onSingleTapConfirmed` and `onLongPress`
* `CustomZoomButtonsDisplay`: deprecated method `isTouchedRotated` as we now check the touch event before applying the rotation; created method `isTouched(MotionEvent,boolean)` for the same reasons; unrelated minor refactoring