### PR TITLE
Add optional language parameter to MapsForgeTileSource

### DIFF
--- a/osmdroid-mapsforge/src/main/java/org/osmdroid/mapsforge/MapsForgeTileSource.java
+++ b/osmdroid-mapsforge/src/main/java/org/osmdroid/mapsforge/MapsForgeTileSource.java
@@ -56,15 +56,16 @@ public class MapsForgeTileSource extends BitmapTileSourceBase {
      * @param maxZoom
      * @param tileSizePixels
      * @param file
+     * @param language
      * @param xmlRenderTheme the theme to render tiles with
      * @param hillsRenderConfig the hillshading setup to be used (can be null)
      */
-    protected MapsForgeTileSource(String cacheTileSourceName, int minZoom, int maxZoom, int tileSizePixels, File[] file, XmlRenderTheme xmlRenderTheme, MultiMapDataStore.DataPolicy dataPolicy, HillsRenderConfig hillsRenderConfig) {
+    protected MapsForgeTileSource(String cacheTileSourceName, int minZoom, int maxZoom, int tileSizePixels, File[] file, String language, XmlRenderTheme xmlRenderTheme, MultiMapDataStore.DataPolicy dataPolicy, HillsRenderConfig hillsRenderConfig) {
         super(cacheTileSourceName, minZoom, maxZoom, tileSizePixels, ".png","© OpenStreetMap contributors");
 
         mapDatabase = new MultiMapDataStore(dataPolicy);
         for (int i = 0; i < file.length; i++)
-            mapDatabase.addMapDataStore(new MapFile(file[i]), false, false);
+            mapDatabase.addMapDataStore(new MapFile(file[i], language), false, false);
 
         if (AndroidGraphicFactory.INSTANCE==null) {
             throw new RuntimeException("Must call MapsForgeTileSource.createInstance(context.getApplication()); once before MapsForgeTileSource.createFromFiles().");
@@ -127,7 +128,7 @@ public class MapsForgeTileSource extends BitmapTileSourceBase {
         int maxZoomLevel = MAX_ZOOM;
         int tileSizePixels = TILE_SIZE_PIXELS;
 
-        return new MapsForgeTileSource(InternalRenderTheme.OSMARENDER.name(), minZoomLevel, maxZoomLevel, tileSizePixels, file, InternalRenderTheme.OSMARENDER, MultiMapDataStore.DataPolicy.RETURN_ALL, null);
+        return new MapsForgeTileSource(InternalRenderTheme.OSMARENDER.name(), minZoomLevel, maxZoomLevel, tileSizePixels, file, null, InternalRenderTheme.OSMARENDER, MultiMapDataStore.DataPolicy.RETURN_ALL, null);
     }
 
     /**
@@ -148,7 +149,29 @@ public class MapsForgeTileSource extends BitmapTileSourceBase {
         int maxZoomLevel = MAX_ZOOM;
         int tileSizePixels = TILE_SIZE_PIXELS;
 
-        return new MapsForgeTileSource(themeName, minZoomLevel, maxZoomLevel, tileSizePixels, file, theme, MultiMapDataStore.DataPolicy.RETURN_ALL, null);
+        return new MapsForgeTileSource(themeName, minZoomLevel, maxZoomLevel, tileSizePixels, file, null, theme, MultiMapDataStore.DataPolicy.RETURN_ALL, null);
+    }
+
+    /**
+     * Creates a new MapsForgeTileSource from file[].
+     * <p></p>
+     * Parameters minZoom and maxZoom are obtained from the
+     * database. If they cannot be obtained from the DB, the default values as
+     * defined by this class are used, which is zoom = 3-20
+     *
+     * @param file
+     * @param language  this can be null, in which case the default language will be used
+     * @param theme     this can be null, in which case the default them will be used
+     * @param themeName when using a custom theme, this sets up the osmdroid caching correctly
+     * @return
+     */
+    public static MapsForgeTileSource createFromFiles(File[] file, String language, XmlRenderTheme theme, String themeName) {
+        //these settings are ignored and are set based on .map file info
+        int minZoomLevel = MIN_ZOOM;
+        int maxZoomLevel = MAX_ZOOM;
+        int tileSizePixels = TILE_SIZE_PIXELS;
+
+        return new MapsForgeTileSource(themeName, minZoomLevel, maxZoomLevel, tileSizePixels, file, language, theme, MultiMapDataStore.DataPolicy.RETURN_ALL, null);
     }
 
     /**
@@ -170,7 +193,7 @@ public class MapsForgeTileSource extends BitmapTileSourceBase {
         int maxZoomLevel = MAX_ZOOM;
         int tileSizePixels = TILE_SIZE_PIXELS;
 
-        return new MapsForgeTileSource(themeName, minZoomLevel, maxZoomLevel, tileSizePixels, file, theme, dataPolicy, hillsRenderConfig);
+        return new MapsForgeTileSource(themeName, minZoomLevel, maxZoomLevel, tileSizePixels, file, null, theme, dataPolicy, hillsRenderConfig);
     }
 
 

--- a/osmdroid-mapsforge/src/main/java/org/osmdroid/mapsforge/MapsForgeTileSource.java
+++ b/osmdroid-mapsforge/src/main/java/org/osmdroid/mapsforge/MapsForgeTileSource.java
@@ -52,15 +52,16 @@ public class MapsForgeTileSource extends BitmapTileSourceBase {
      * except file should be determined from the archive file. Therefore a
      * factory method is necessary.
      *
+     * @param cacheTileSourceName
      * @param minZoom
      * @param maxZoom
      * @param tileSizePixels
      * @param file
-     * @param language
      * @param xmlRenderTheme the theme to render tiles with
      * @param hillsRenderConfig the hillshading setup to be used (can be null)
+     * @param language preferred language for map labels as defined in ISO 639-1 or ISO 639-2 (can be null)
      */
-    protected MapsForgeTileSource(String cacheTileSourceName, int minZoom, int maxZoom, int tileSizePixels, File[] file, String language, XmlRenderTheme xmlRenderTheme, MultiMapDataStore.DataPolicy dataPolicy, HillsRenderConfig hillsRenderConfig) {
+    protected MapsForgeTileSource(String cacheTileSourceName, int minZoom, int maxZoom, int tileSizePixels, File[] file, XmlRenderTheme xmlRenderTheme, MultiMapDataStore.DataPolicy dataPolicy, HillsRenderConfig hillsRenderConfig, final String language) {
         super(cacheTileSourceName, minZoom, maxZoom, tileSizePixels, ".png","© OpenStreetMap contributors");
 
         mapDatabase = new MultiMapDataStore(dataPolicy);
@@ -99,6 +100,23 @@ public class MapsForgeTileSource extends BitmapTileSourceBase {
         }
     }
 
+    /**
+     * The reason this constructor is protected is because all parameters,
+     * except file should be determined from the archive file. Therefore a
+     * factory method is necessary.
+     *
+     * @param cacheTileSourceName
+     * @param minZoom
+     * @param maxZoom
+     * @param tileSizePixels
+     * @param file
+     * @param xmlRenderTheme the theme to render tiles with
+     * @param hillsRenderConfig the hillshading setup to be used (can be null)
+     */
+    protected MapsForgeTileSource(String cacheTileSourceName, int minZoom, int maxZoom, int tileSizePixels, File[] file, XmlRenderTheme xmlRenderTheme, MultiMapDataStore.DataPolicy dataPolicy, HillsRenderConfig hillsRenderConfig) {
+        this(cacheTileSourceName, minZoom, maxZoom, tileSizePixels, file, xmlRenderTheme, dataPolicy, hillsRenderConfig, null);
+    }
+
     public BoundingBox getBounds(){
         return mapDatabase.boundingBox();
     }
@@ -128,7 +146,7 @@ public class MapsForgeTileSource extends BitmapTileSourceBase {
         int maxZoomLevel = MAX_ZOOM;
         int tileSizePixels = TILE_SIZE_PIXELS;
 
-        return new MapsForgeTileSource(InternalRenderTheme.OSMARENDER.name(), minZoomLevel, maxZoomLevel, tileSizePixels, file, null, InternalRenderTheme.OSMARENDER, MultiMapDataStore.DataPolicy.RETURN_ALL, null);
+        return new MapsForgeTileSource(InternalRenderTheme.OSMARENDER.name(), minZoomLevel, maxZoomLevel, tileSizePixels, file, InternalRenderTheme.OSMARENDER, MultiMapDataStore.DataPolicy.RETURN_ALL, null, null);
     }
 
     /**
@@ -149,7 +167,7 @@ public class MapsForgeTileSource extends BitmapTileSourceBase {
         int maxZoomLevel = MAX_ZOOM;
         int tileSizePixels = TILE_SIZE_PIXELS;
 
-        return new MapsForgeTileSource(themeName, minZoomLevel, maxZoomLevel, tileSizePixels, file, null, theme, MultiMapDataStore.DataPolicy.RETURN_ALL, null);
+        return new MapsForgeTileSource(themeName, minZoomLevel, maxZoomLevel, tileSizePixels, file, theme, MultiMapDataStore.DataPolicy.RETURN_ALL, null, null);
     }
 
     /**
@@ -160,18 +178,18 @@ public class MapsForgeTileSource extends BitmapTileSourceBase {
      * defined by this class are used, which is zoom = 3-20
      *
      * @param file
-     * @param language  this can be null, in which case the default language will be used
      * @param theme     this can be null, in which case the default them will be used
      * @param themeName when using a custom theme, this sets up the osmdroid caching correctly
+     * @param language  preferred language for map labels as defined in ISO 639-1 or ISO 639-2 (can be null)
      * @return
      */
-    public static MapsForgeTileSource createFromFiles(File[] file, String language, XmlRenderTheme theme, String themeName) {
+    public static MapsForgeTileSource createFromFiles(File[] file, XmlRenderTheme theme, String themeName, final String language) {
         //these settings are ignored and are set based on .map file info
         int minZoomLevel = MIN_ZOOM;
         int maxZoomLevel = MAX_ZOOM;
         int tileSizePixels = TILE_SIZE_PIXELS;
 
-        return new MapsForgeTileSource(themeName, minZoomLevel, maxZoomLevel, tileSizePixels, file, language, theme, MultiMapDataStore.DataPolicy.RETURN_ALL, null);
+        return new MapsForgeTileSource(themeName, minZoomLevel, maxZoomLevel, tileSizePixels, file, theme, MultiMapDataStore.DataPolicy.RETURN_ALL, null, language);
     }
 
     /**
@@ -185,6 +203,7 @@ public class MapsForgeTileSource extends BitmapTileSourceBase {
      * @param theme     this can be null, in which case the default them will be used
      * @param themeName when using a custom theme, this sets up the osmdroid caching correctly
      * @param dataPolicy use this to override the default, which is "RETURN_ALL"
+     * @param hillsRenderConfig the hillshading setup to be used (can be null)
      * @return
      */
     public static MapsForgeTileSource createFromFiles(File[] file, XmlRenderTheme theme, String themeName, MultiMapDataStore.DataPolicy dataPolicy, HillsRenderConfig hillsRenderConfig) {
@@ -193,7 +212,31 @@ public class MapsForgeTileSource extends BitmapTileSourceBase {
         int maxZoomLevel = MAX_ZOOM;
         int tileSizePixels = TILE_SIZE_PIXELS;
 
-        return new MapsForgeTileSource(themeName, minZoomLevel, maxZoomLevel, tileSizePixels, file, null, theme, dataPolicy, hillsRenderConfig);
+        return new MapsForgeTileSource(themeName, minZoomLevel, maxZoomLevel, tileSizePixels, file, theme, dataPolicy, hillsRenderConfig, null);
+    }
+
+    /**
+     * Creates a new MapsForgeTileSource from file[].
+     * <p></p>
+     * Parameters minZoom and maxZoom are obtained from the
+     * database. If they cannot be obtained from the DB, the default values as
+     * defined by this class are used, which is zoom = 3-20
+     *
+     * @param file
+     * @param theme this can be null, in which case the default them will be used
+     * @param themeName when using a custom theme, this sets up the osmdroid caching correctly
+     * @param dataPolicy use this to override the default, which is "RETURN_ALL"
+     * @param hillsRenderConfig the hillshading setup to be used (can be null)
+     * @param language  preferred language for map labels as defined in ISO 639-1 or ISO 639-2 (can be null)
+     * @return
+     */
+    public static MapsForgeTileSource createFromFiles(File[] file, XmlRenderTheme theme, String themeName, MultiMapDataStore.DataPolicy dataPolicy, HillsRenderConfig hillsRenderConfig, final String language) {
+        //these settings are ignored and are set based on .map file info
+        int minZoomLevel = MIN_ZOOM;
+        int maxZoomLevel = MAX_ZOOM;
+        int tileSizePixels = TILE_SIZE_PIXELS;
+
+        return new MapsForgeTileSource(themeName, minZoomLevel, maxZoomLevel, tileSizePixels, file, theme, dataPolicy, hillsRenderConfig, language);
     }
 
 


### PR DESCRIPTION
Adds an optional language paramter to MapsForgeTileSource. This allows to set a prefered language for labels, which in most cases default to the map location's local language.

This sets one language for all map sources. Theoretically it is possible to set a prefered language per map source. I left this out for 1) simplicity and 2) because I don't see much use for this.

Fixes #1420  