### PR TITLE
Bing map upgrade authentication and tile URL to https

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/bing/BingMapTileSource.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/bing/BingMapTileSource.java
@@ -54,7 +54,7 @@ public class BingMapTileSource extends QuadTreeTileSource implements IStyledTile
     private static final String FILENAME_ENDING = ".jpeg";
 
     // URL used to get imageryData. It is requested in order to get tiles url patterns
-    private static final String BASE_URL_PATTERN = "https://dev.virtualearth.net/REST/V1/Imagery/Metadata/%s?mapVersion=v1&output=json&key=%s";
+    private static final String BASE_URL_PATTERN = "https://dev.virtualearth.net/REST/V1/Imagery/Metadata/%s?mapVersion=v1&output=json&uriScheme=https&key=%s";
 
     /**
      * Bing Map key set by user.

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/bing/BingMapTileSource.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/bing/BingMapTileSource.java
@@ -54,7 +54,7 @@ public class BingMapTileSource extends QuadTreeTileSource implements IStyledTile
     private static final String FILENAME_ENDING = ".jpeg";
 
     // URL used to get imageryData. It is requested in order to get tiles url patterns
-    private static final String BASE_URL_PATTERN = "http://dev.virtualearth.net/REST/V1/Imagery/Metadata/%s?mapVersion=v1&output=json&key=%s";
+    private static final String BASE_URL_PATTERN = "https://dev.virtualearth.net/REST/V1/Imagery/Metadata/%s?mapVersion=v1&output=json&key=%s";
 
     /**
      * Bing Map key set by user.


### PR DESCRIPTION
The Bing maps authentication URL that is used for sending the application's Bing Maps Key to Microsoft was still using unencrypted HTTP, instead of HTTPS. 

I have verified that the URL via HTTPS works as expected, it was correctly returning a valid response using my personal Bing Maps key for the imagery-set "Road".