### PR TITLE
fix for osmdroid broken ci system: update gradle download url to https

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-bin.zip


### PR DESCRIPTION
The server services.gradle.org does no longer allow non-https downloads (see https://blog.gradle.org/decommissioning-http).

According to the gradle blog entry we are currently in the phase "November 14th, 2019 | Disable HTTP for 24 hours and permanently drop support for TLSv1."

Therefore it is required to update the gradle url to https.