### PR TITLE
bug/#1444 - setting back the correct icon bounds in ItemizedOverlay

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/bugtestfragments/BugFactory.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/bugtestfragments/BugFactory.java
@@ -32,7 +32,7 @@ public final class BugFactory implements ISampleFactory {
                 Bug512Marker.class,
                 Bug512CacheManagerWp.class,
             Bug846InfiniteRedrawLoop.class,
-            Bug1322.class,
+            Bug1322.class,Issue1444.class
         };
     }
 

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/bugtestfragments/Issue1444.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/bugtestfragments/Issue1444.java
@@ -1,0 +1,67 @@
+package org.osmdroid.bugtestfragments;
+
+import android.graphics.drawable.Drawable;
+
+import org.osmdroid.samplefragments.BaseSampleFragment;
+import org.osmdroid.util.GeoPoint;
+import org.osmdroid.views.overlay.ItemizedIconOverlay;
+import org.osmdroid.views.overlay.ItemizedOverlayWithFocus;
+import org.osmdroid.views.overlay.OverlayItem;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * created on 12/6/2019.
+ *
+ * @author Alex O'Ree
+ */
+public class Issue1444 extends BaseSampleFragment {
+
+    @Override
+    public String getSampleTitle() {
+        return "Issue 1444 stuck label with itemized icon overlay";
+    }
+
+    private List<Drawable> icons = new ArrayList<>(4);
+
+
+    @Override
+    public void addOverlays() {
+
+        super.addOverlays();
+
+        icons.add(getResources().getDrawable(org.osmdroid.R.drawable.sfgpuci));
+        icons.add(getResources().getDrawable(org.osmdroid.R.drawable.shgpuci));
+        icons.add(getResources().getDrawable(org.osmdroid.R.drawable.sngpuci));
+        icons.add(getResources().getDrawable(org.osmdroid.R.drawable.sugpuci));
+        GeoPoint myGeoPoint = new GeoPoint(32d, -74d);
+
+        OverlayItem MY_OverlayItem = new OverlayItem("1", "LABEL", "", myGeoPoint);
+        MY_OverlayItem.setMarker(icons.get(1));
+
+        ArrayList<OverlayItem> ARRAY_Of_OverlayItems = new ArrayList<>();
+        ARRAY_Of_OverlayItems.add(MY_OverlayItem);
+
+        ItemizedOverlayWithFocus<OverlayItem> myItemizedOverlayWithFocus = new ItemizedOverlayWithFocus<>(ARRAY_Of_OverlayItems,
+            new ItemizedIconOverlay.OnItemGestureListener<OverlayItem>() {
+
+                @Override
+                public boolean onItemSingleTapUp(int index, OverlayItem item) {
+                    return false;
+                }
+
+                @Override
+                public boolean onItemLongPress(int index, OverlayItem item) {
+                    return false;
+                }
+            }, getContext());
+
+        myItemizedOverlayWithFocus.setFocusItemsOnTap(true);
+        myItemizedOverlayWithFocus.setFocusedItem(0);
+        mMapView.getOverlays().add(myItemizedOverlayWithFocus);
+        mMapView.invalidate();
+
+
+    }
+}

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/ItemizedOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/ItemizedOverlay.java
@@ -41,6 +41,7 @@ public abstract class ItemizedOverlay<Item extends OverlayItem> extends Overlay 
 	private final ArrayList<Item> mInternalItemList;
 	private boolean[] mInternalItemDisplayedList;
 	private final Rect mRect = new Rect();
+	private final Rect mMarkerRect = new Rect();
 	private final Rect mOrientedMarkerRect = new Rect();
 	private final Point mCurScreenCoords = new Point();
 	protected boolean mDrawFocusedItem = true;
@@ -211,6 +212,7 @@ public abstract class ItemizedOverlay<Item extends OverlayItem> extends Overlay 
 		int y = mCurScreenCoords.y;
 
 		marker.copyBounds(mRect);
+		mMarkerRect.set(mRect);
 		mRect.offset(x, y);
 		RectL.getBounds(mRect, x, y, pProjection.getOrientation(), mOrientedMarkerRect);
 		final boolean displayed = Rect.intersects(mOrientedMarkerRect, canvas.getClipBounds());
@@ -224,6 +226,7 @@ public abstract class ItemizedOverlay<Item extends OverlayItem> extends Overlay 
 			if (pProjection.getOrientation() != 0) { // optimization: step 2/2
 				canvas.restore();
 			}
+			marker.setBounds(mMarkerRect);
 		}
 
 		return displayed;

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/ItemizedOverlayWithFocus.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/ItemizedOverlayWithFocus.java
@@ -18,6 +18,13 @@ import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
 import android.util.TypedValue;
 
+/**
+ * @deprecated see {@link Marker}
+ * it is generally recommended to use the  {@link Marker} class instead of this.
+ * While it does work and is usually maintained, the Marker class as a lot more capabilities
+ * @param <Item>
+ */
+@Deprecated
 public class ItemizedOverlayWithFocus<Item extends OverlayItem> extends ItemizedIconOverlay<Item> {
 
 	// ===========================================================


### PR DESCRIPTION
Impacted class:
* `ItemizedOverlay`: set back the correct icon bounds after they were changed for the display part