### PR TITLE
bug/#1462 - removed the call to BoundingBox.overlaps that ignores rotation

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/DefaultOverlayManager.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/DefaultOverlayManager.java
@@ -176,9 +176,7 @@ public class DefaultOverlayManager extends AbstractList<Overlay> implements Over
             //#396 fix, null check
             if (overlay != null && overlay.isEnabled()) {
                 if (pMapView != null) {
-                    //don't bother attempting to draw it unless it's in view
-                    if (pMapView.getBoundingBox().overlaps(overlay.getBounds(), pMapView.getZoomLevelDouble()))
-                        overlay.draw(c, pMapView, false);
+                    overlay.draw(c, pMapView, false);
                 } else {
                     overlay.draw(c, pProjection);
                 }


### PR DESCRIPTION
Impacted class:
* `DefaultOverlayManager`: edited `onDrawHelper`