### PR TITLE
feature/osmdroid#1472 - add getters to SimpleFastPointOverlayOptions

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/simplefastpoint/SimpleFastPointOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/simplefastpoint/SimpleFastPointOverlay.java
@@ -62,6 +62,11 @@ public class SimpleFastPointOverlay extends Overlay {
         }
     }
 
+    /** @return fast point overlay options (applied to all points) */
+    public SimpleFastPointOverlayOptions getStyle() {
+        return mStyle;
+    }
+
     public interface PointAdapter extends Iterable<IGeoPoint> {
         int size();
         IGeoPoint get(int i);

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/simplefastpoint/SimpleFastPointOverlayOptions.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/simplefastpoint/SimpleFastPointOverlayOptions.java
@@ -185,4 +185,54 @@ public class SimpleFastPointOverlayOptions {
         mLabelPolicy = labelPolicy;
         return this;
     }
+
+    /* getters for the protected options, see setters for description */
+
+    public Paint getPointStyle() {
+        return mPointStyle;
+    }
+
+    public Paint getSelectedPointStyle() {
+        return mSelectedPointStyle;
+    }
+
+    public Paint getTextStyle() {
+        return mTextStyle;
+    }
+
+    public float getCircleRadius() {
+        return mCircleRadius;
+    }
+
+    public float getSelectedCircleRadius() {
+        return mSelectedCircleRadius;
+    }
+
+    public boolean isClickable() {
+        return mClickable;
+    }
+
+    public int getCellSize() {
+        return mCellSize;
+    }
+
+    public RenderingAlgorithm getAlgorithm() {
+        return mAlgorithm;
+    }
+
+    public Shape getSymbol() {
+        return mSymbol;
+    }
+
+    public LabelPolicy getLabelPolicy() {
+        return mLabelPolicy;
+    }
+
+    public int getMaxNShownLabels() {
+        return mMaxNShownLabels;
+    }
+
+    public int getMinZoomShowLabels() {
+        return mMinZoomShowLabels;
+    }
 }


### PR DESCRIPTION
and one to SimpleFastPointOverlay.  This is to facilitate deriving/customizing SimpleFastPointOverlay.drawPointAt