### PR TITLE
feature/#1467 - Simplifying the list of consecutive points for Path

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/util/SideOptimizationPointAccepter.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/SideOptimizationPointAccepter.java
@@ -1,0 +1,150 @@
+package org.osmdroid.util;
+
+/**
+ * {@link PointAccepter} that simplifies the list of consecutive points with the same X or Y.
+ * One goal is to have faster Path rendering.
+ * As we clip the Path with a rectangle, additional segments are created by {@link SegmentClipper}.
+ * When most of the Polygon is out of the screen, many consecutive segments are on the same side
+ * of the clip rectangle (e.g. same X or same Y). Do we need to render all those segments? No.
+ * We can simplify this list of consecutive segments into a tiny list of maximum 3 segments.
+ * And that makes the Path rendering much faster.
+ * @author Fabrice Fontaine
+ * @since 6.2.0
+ */
+
+public class SideOptimizationPointAccepter implements PointAccepter {
+
+    private static final int STATUS_DIFFERENT   = 0;
+    private static final int STATUS_SAME_X      = 1;
+    private static final int STATUS_SAME_Y      = 2;
+
+    private final PointL mLatestPoint = new PointL();
+    private final PointL mStartPoint = new PointL();
+    private final PointAccepter mPointAccepter;
+    private boolean mFirst;
+    private long mMin;
+    private long mMax;
+    private int mStatus;
+
+    /**
+     * We optimize on top of another {@link PointAccepter}
+     */
+    public SideOptimizationPointAccepter(final PointAccepter pPointAccepter) {
+        mPointAccepter = pPointAccepter;
+    }
+
+    @Override
+    public void init() {
+        mFirst = true;
+        mStatus = STATUS_DIFFERENT;
+        mPointAccepter.init();
+    }
+
+    @Override
+    public void add(final long pX, final long pY) {
+        if (mFirst) {
+            mFirst = false;
+            addToAccepter(pX, pY);
+            mLatestPoint.set(pX, pY);
+            return;
+        }
+        if (mLatestPoint.x == pX && mLatestPoint.y == pY) {
+            return;
+        }
+        if (mLatestPoint.x == pX) {
+            if (mStatus == STATUS_SAME_X) {
+                if (mMin > pY) {
+                    mMin = pY;
+                }
+                if (mMax < pY) {
+                    mMax = pY;
+                }
+            } else {
+                flushSides();
+                mStatus = STATUS_SAME_X;
+                mStartPoint.set(mLatestPoint);
+                mMin = Math.min(pY, mLatestPoint.y);
+                mMax = Math.max(pY, mLatestPoint.y);
+            }
+        } else if (mLatestPoint.y == pY) {
+            if (mStatus == STATUS_SAME_Y) {
+                if (mMin > pX) {
+                    mMin = pX;
+                }
+                if (mMax < pX) {
+                    mMax = pX;
+                }
+            } else {
+                flushSides();
+                mStatus = STATUS_SAME_Y;
+                mStartPoint.set(mLatestPoint);
+                mMin = Math.min(pX, mLatestPoint.x);
+                mMax = Math.max(pX, mLatestPoint.x);
+            }
+        } else {
+            flushSides();
+            addToAccepter(pX, pY);
+        }
+        mLatestPoint.set(pX, pY);
+    }
+
+    @Override
+    public void end() {
+        flushSides();
+        mPointAccepter.end();
+    }
+
+    /**
+     * Flushing the side (same X or same Y) computed so far
+     */
+    private void flushSides() {
+        final long segmentMin;
+        final long segmentMax;
+        switch (mStatus) {
+            case STATUS_DIFFERENT:
+                break;
+            case STATUS_SAME_X:
+                final long x = mStartPoint.x;
+                if (mStartPoint.y <= mLatestPoint.y) {
+                    segmentMin = mStartPoint.y;
+                    segmentMax = mLatestPoint.y;
+                } else {
+                    segmentMin = mLatestPoint.y;
+                    segmentMax = mStartPoint.y;
+                }
+                if (mMin < segmentMin) {
+                    addToAccepter(x, mMin);
+                }
+                if (mMax > segmentMax) {
+                    addToAccepter(x, mMax);
+                }
+                addToAccepter(x, mLatestPoint.y);
+                break;
+            case STATUS_SAME_Y:
+                final long y = mStartPoint.y;
+                if (mStartPoint.x <= mLatestPoint.x) {
+                    segmentMin = mStartPoint.x;
+                    segmentMax = mLatestPoint.x;
+                } else {
+                    segmentMin = mLatestPoint.x;
+                    segmentMax = mStartPoint.x;
+                }
+                if (mMin < segmentMin) {
+                    addToAccepter(mMin, y);
+                }
+                if (mMax > segmentMax) {
+                    addToAccepter(mMax, y);
+                }
+                addToAccepter(mLatestPoint.x, y);
+                break;
+        }
+        mStatus = STATUS_DIFFERENT;
+    }
+
+    /**
+     * Actually adding the point to the embedded {@link PointAccepter}
+     */
+    private void addToAccepter(final long pX, final long pY) {
+        mPointAccepter.add(pX, pY);
+    }
+}

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/LinearRing.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/LinearRing.java
@@ -13,6 +13,7 @@ import org.osmdroid.util.PathBuilder;
 import org.osmdroid.util.PointAccepter;
 import org.osmdroid.util.PointL;
 import org.osmdroid.util.SegmentClipper;
+import org.osmdroid.util.SideOptimizationPointAccepter;
 import org.osmdroid.util.TileSystem;
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.Projection;
@@ -102,7 +103,7 @@ class LinearRing{
 	 */
 	public LinearRing(final Path pPath, final boolean pClosed) {
 		mPath = pPath;
-		mPointAccepter = new PathBuilder(pPath);
+		mPointAccepter = new SideOptimizationPointAccepter(new PathBuilder(pPath));
 		mIntegerAccepter = null;
 		mClosed = pClosed;
 	}

--- a/osmdroid-android/src/test/java/org/osmdroid/util/SideOptimizationPointAccepterTest.java
+++ b/osmdroid-android/src/test/java/org/osmdroid/util/SideOptimizationPointAccepterTest.java
@@ -1,0 +1,154 @@
+package org.osmdroid.util;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Unit test class for {@link SideOptimizationPointAccepter}
+ * @author Fabrice Fontaine
+ * @since 6.2.0
+ */
+
+public class SideOptimizationPointAccepterTest {
+
+    class SimpleAccepter implements PointAccepter {
+
+        private final List<PointL> mList = new ArrayList<>();
+
+        public List<PointL> getList() {
+            return mList;
+        }
+
+        @Override
+        public void init() {
+            mList.clear();
+        }
+
+        @Override
+        public void add(long pX, long pY) {
+            mList.add(new PointL(pX, pY));
+        }
+
+        @Override
+        public void end() { }
+    }
+
+    @Test
+    public void testNothing() { // never consecutive points with same X or same Y
+        final long[] values = new long[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+        test(values, values);
+    }
+
+    @Test
+    public void testOneSideX() {
+        final long[] values = new long[] {
+                1, 2, 3, 4,
+                50, 6, 50, 20, 50, 4, 50, 15, 50, 18, 50, 5, // a column with X = 50
+                2, 12};
+        final long[] expected = new long[] {
+                1, 2, 3, 4,
+                50, 6, 50, 4, 50, 20, 50, 5, // the optimized version
+                2, 12};
+        test(values, expected);
+    }
+
+    @Test
+    public void testTwoSidesX() {
+        final long[] values = new long[] {
+                1, 2, 3, 4,
+                50, 6, 50, 20, 50, 4, 50, 15, 50, 18, 50, 5, // a column with X = 50
+                12, 2, 12, 78, 12, 3, 12 ,1, 12, 1, 12, 4, // a column with X = 12
+                2, 12};
+        final long[] expected = new long[] {
+                1, 2, 3, 4,
+                50, 6, 50, 4, 50, 20, 50, 5,
+                12, 2, 12, 1, 12, 78, 12, 4,
+                2, 12};
+        test(values, expected);
+    }
+
+    @Test
+    public void testOneSideY() {
+        final long[] values = new long[] {
+                0, 1, 2, 3,
+                4, 50, 6, 50, 20, 50, 4, 50, 15, 50, 18, 50, // a row with Y = 50
+                5, 2};
+        final long[] expected = new long[] {
+                0, 1, 2, 3,
+                4, 50, 20, 50, 18, 50,
+                5, 2};
+        test(values, expected);
+    }
+
+    @Test
+    public void testTwoSidesY() {
+        final long[] values = new long[] {
+                0, 1, 2, 3,
+                4, 50, 6, 50, 20, 50, 4, 50, 15, 50, 18, 50, // a row with Y = 50
+                45, 10, 16, 10, 2, 10, 14, 10, 1, 10, 8, 10, // a row with Y = 10
+                5, 2};
+        final long[] expected = new long[] {
+                0, 1, 2, 3,
+                4, 50, 20, 50, 18, 50,
+                45, 10, 1, 10, 8, 10,
+                5, 2};
+        test(values, expected);
+    }
+
+    @Test
+    public void testOneSideXManiac() {
+        final long[] values = new long[] {
+                1, 2, 3, 4,
+                50, 6, 50, 20, 50, 4, // columns with X = 50...
+                50, 15, 50, 6, 50, 23, 50, 15, 50, 6, 50, 23, 50, 15, 50, 6, 50, 23,
+                50, 15, 50, 6, 50, 23, 50, 15, 50, 6, 50, 23, 50, 15, 50, 6, 50, 23,
+                50, 15, 50, 6, 50, 23, 50, 18, 50, 5,
+                2, 12};
+        final long[] expected = new long[] {
+                1, 2, 3, 4,
+                50, 6, 50, 4, 50, 23, 50, 5,
+                2, 12};
+        test(values, expected);
+    }
+
+    @Test
+    public void testRectangle() {
+        final long[] values = new long[] {
+                1, 2, 3, 4,
+                50, 6, 50, 20, 50, 4, 50, 15, 50, 18, 50, 5, // a column with X = 50
+                4, 50, 6, 50, 20, 50, 4, 50, 15, 50, 18, 50, // a row with Y = 50
+                12, 2, 12, 78, 12, 3, 12 ,1, 12, 1, 12, 4, // a column with X = 12
+                5, 5,
+                45, 10, 16, 10, 2, 10, 14, 10, 1, 10, 8, 10, // a row with Y = 10
+                2, 12};
+        final long[] expected = new long[] {
+                1, 2, 3, 4,
+                50, 6, 50, 4, 50, 20, 50, 5,
+                4, 50, 20, 50, 18, 50,
+                12, 2, 12, 1, 12, 78, 12, 4,
+                5, 5,
+                45, 10, 1, 10, 8, 10,
+                2, 12};
+        test(values, expected);
+    }
+
+    private void test(final long[] pValues, final long[] pExpected) {
+        final SimpleAccepter simpleAccepter = new SimpleAccepter();
+        final SideOptimizationPointAccepter optim = new SideOptimizationPointAccepter(simpleAccepter);
+        optim.init();
+        for (int i = 0 ; i < pValues.length ; i += 2) {
+            optim.add(pValues[i], pValues[i+1]);
+        }
+        optim.end();
+        final List<PointL> result = simpleAccepter.getList();
+        final List<PointL> expected = new ArrayList<>();
+        for (int i = 0 ; i < pExpected.length ; i += 2) {
+            expected.add(new PointL(pExpected[i], pExpected[i+1]));
+        }
+        Assert.assertEquals(expected, result);
+    }
+}


### PR DESCRIPTION
New classes:
* `SideOptimizationPointAccepter`: `PointAccepter` that simplifies the list of consecutive points with the same X or Y
* `SideOptimizationPointAccepterTest`: Unit test class for `SideOptimizationPointAccepter`

Impacted class:
* `LinearRing`: used a `SideOptimizationPointAccepter` on top of the `PathBuilder` (which will get only a simplified point list)