### PR TITLE
feature/#1480 - new method PolyOverlayWithIW.setDowngradePixelSizes

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleShapeFile.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleShapeFile.java
@@ -117,7 +117,7 @@ public class SampleShapeFile extends SampleMapEventListener {
                     for (final Overlay item : folder) {
                         if (item instanceof PolyOverlayWithIW) {
                             final PolyOverlayWithIW poly = (PolyOverlayWithIW)item;
-                            poly.setDowngradeMaximumPixelSize(20);
+                            poly.setDowngradePixelSizes(50, 25);
                             poly.setDowngradeDisplay(true);
                             final Paint paint = poly.getOutlinePaint();
                             paint.setStyle(Paint.Style.STROKE);

--- a/osmdroid-android/src/main/java/org/osmdroid/util/ListPointAccepter.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/ListPointAccepter.java
@@ -1,0 +1,55 @@
+package org.osmdroid.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A {@link PointAccepter} that builds a {@link List} of {@link PointL} as a list of long, long
+ * @since 6.2.0
+ * @author Fabrice Fontaine
+ */
+
+public class ListPointAccepter implements PointAccepter{
+
+    private final List<Long> mList = new ArrayList<>();
+    private final PointL mLatestPoint = new PointL();
+    private final boolean mRemoveConsecutiveDuplicates;
+    private boolean mFirst;
+
+    public ListPointAccepter(final boolean pRemoveConsecutiveDuplicates) {
+        mRemoveConsecutiveDuplicates = pRemoveConsecutiveDuplicates;
+    }
+
+    public List<Long> getList() {
+        return mList;
+    }
+
+    @Override
+    public void init() {
+        mList.clear();
+        mFirst = true;
+    }
+
+    @Override
+    public void add(long pX, long pY) {
+        if (!mRemoveConsecutiveDuplicates) {
+            mList.add(pX);
+            mList.add(pY);
+            return;
+        }
+        if (mFirst) {
+            mFirst = false;
+            mList.add(pX);
+            mList.add(pY);
+            mLatestPoint.set(pX, pY);
+        } else if (mLatestPoint.x != pX || mLatestPoint.y != pY) {
+            mList.add(pX);
+            mList.add(pY);
+            mLatestPoint.set(pX, pY);
+        }
+    }
+
+    @Override
+    public void end() {
+    }
+}


### PR DESCRIPTION
If the poly is smaller (in pixels) than size1, draw a precomputed simplified list of segments.
If it's even smaller (than size2), draw even faster the poly as a rectangle.
Of course this is only optional; the default being to always display the regular poly.
The demo is included in `SampleShapeFile`, and the important methods here are `setDowngradeDisplay` and `setDowngradePixelSizes`.

New class:
* `ListPointAccepter`: a `PointAccepter` that builds a `List` of `PointL` as a list of long, long

Impacted classes:
* `LinearRing`: new members `mProjectedWidth` and `mProjectedHeight`; new method `computeDowngradePointList` that computes the list of points of a polyline that would be the projection of the GeoPoints on a centered size*size square; new method `resetPrecomputations`
* `PolyOverlayWithIW`: implemented the "fast draw of a list of segments" as less downgraded than a rectangle; new member `float[] mDowngradeSegments`; new method `isVisible(Paint)`; method `setDowngradePixelSizes` replaced `setDowngradeMaximumPixelSize`; minor refactoring
* `SampleShapeFile`: now using the new `PolyOverlayWithIW.setDowngradePixelSizes` method