### PR TITLE
feature/#1458 - new method `PolyOverlayWithIW.usePath`

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/drawing/CustomPaintingSurface.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/drawing/CustomPaintingSurface.java
@@ -127,7 +127,8 @@ public class CustomPaintingSurface extends View {
                     case PolylineAsPath:
                         final boolean asPath = drawingMode == Mode.PolylineAsPath;
                         final int color = Color.argb(100, 100, 100, 100);
-                        final Polyline line = new Polyline(map, asPath);
+                        final Polyline line = new Polyline(map);
+                        line.usePath(true);
                         line.setInfoWindow(
                                 new BasicInfoWindow(org.osmdroid.library.R.layout.bonuspack_bubble, map));
                         line.getOutlinePaint().setColor(color);

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polygon.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polygon.java
@@ -3,15 +3,11 @@ package org.osmdroid.views.overlay;
 
 import android.graphics.Color;
 import android.graphics.Paint;
-import android.graphics.RectF;
-import android.graphics.Region;
-import android.view.MotionEvent;
 
 import org.osmdroid.api.IGeoPoint;
 import org.osmdroid.util.BoundingBox;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.MapView;
-import org.osmdroid.views.Projection;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -193,47 +189,6 @@ public class Polygon extends PolyOverlayWithIW {
 		points.add(new GeoPoint(northLat, east.getLongitude()));
 		return points;
 	}
-	
-
-
-	/** Important note: this function returns correct results only if the Polygon has been drawn before,
-
-	 * and if the MapView positioning has not changed. 
-	 * @param event
-	 * @return true if the Polygon contains the event position. 
-	 */
-	public boolean contains(MotionEvent event){
-		if (mPath.isEmpty())
-			return false;
-		RectF bounds = new RectF(); //bounds of the Path
-		mPath.computeBounds(bounds, true);
-		Region region = new Region();
-		//Path has been computed in #draw (we assume that if it can be clicked, it has been drawn before). 
-		region.setPath(mPath, new Region((int)bounds.left, (int)bounds.top, 
-				(int) (bounds.right), (int) (bounds.bottom)));
-		return region.contains((int)event.getX(), (int)event.getY());
-	}
-
-	/**
-	 * Default listener for a single tap event on a Polygon:
-	 * set the infowindow at the tapped position, and open the infowindow (if any).
-	 * @param event
-	 * @param mapView
-	 * @return true if tapped
-	 */
-	@Override public boolean onSingleTapConfirmed(final MotionEvent event, final MapView mapView){
-		Projection pj = mapView.getProjection();
-		GeoPoint eventPos = (GeoPoint)pj.fromPixels((int)event.getX(), (int)event.getY());
-		boolean tapped = contains(event);
-		if (tapped) {
-			if (mOnClickListener == null) {
-				return onClickDefault(this, mapView, eventPos);
-			} else {
-				return mOnClickListener.onClick(this, mapView, eventPos);
-			}
-		} else
-			return tapped;
-	}
 
 	@Override public void onDetach(MapView mapView) {
 		super.onDetach(mapView);
@@ -263,5 +218,17 @@ public class Polygon extends PolyOverlayWithIW {
 	 */
 	public void setOnClickListener(OnClickListener listener) {
 		mOnClickListener = listener;
+	}
+
+	/**
+	 * @since 6.2.0
+	 */
+	@Override
+	protected boolean click(final MapView pMapView, final GeoPoint pEventPos) {
+		if (mOnClickListener == null) {
+			return onClickDefault(this, pMapView, pEventPos);
+		} else {
+			return mOnClickListener.onClick(this, pMapView, pEventPos);
+		}
 	}
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polyline.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/Polyline.java
@@ -2,11 +2,9 @@ package org.osmdroid.views.overlay;
 
 import android.graphics.Color;
 import android.graphics.Paint;
-import android.view.MotionEvent;
 
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.MapView;
-import org.osmdroid.views.Projection;
 
 import java.util.ArrayList;
 
@@ -24,12 +22,6 @@ import java.util.ArrayList;
 public class Polyline extends PolyOverlayWithIW {
 
     protected OnClickListener mOnClickListener;
-
-    private float mDensity = 1.0f;
-
-
-    private float mDensityMultiplier = 1.0f;
-
 
     /**
      * If MapView is not provided, infowindow popup will not function unless you set it yourself.
@@ -121,49 +113,6 @@ public class Polyline extends PolyOverlayWithIW {
         mOnClickListener = listener;
     }
 
-    public void setDensityMultiplier(float multiplier) {
-        mDensityMultiplier = multiplier;
-    }
-
-    /**
-     * Detection is done is screen coordinates.
-     *
-     * @param point
-     * @param tolerance in pixels
-     * @return true if the Polyline is close enough to the point.
-     */
-    public boolean isCloseTo(GeoPoint point, double tolerance, MapView mapView) {
-        return getCloseTo(point, tolerance, mapView) != null;
-    }
-
-    /**
-     * @since 6.0.3
-     * Detection is done is screen coordinates.
-     *
-     * @param point
-     * @param tolerance in pixels
-     * @return the first GeoPoint of the Polyline close enough to the point
-     */
-    public GeoPoint getCloseTo(GeoPoint point, double tolerance, MapView mapView) {
-        return mOutline.getCloseTo(point, tolerance, mapView.getProjection(), false);
-    }
-
-    @Override
-    public boolean onSingleTapConfirmed(final MotionEvent event, final MapView mapView) {
-        final Projection pj = mapView.getProjection();
-        GeoPoint eventPos = (GeoPoint) pj.fromPixels((int) event.getX(), (int) event.getY());
-        double tolerance = mOutlinePaint.getStrokeWidth() * mDensity * mDensityMultiplier;
-        final GeoPoint closest = getCloseTo(eventPos, tolerance, mapView);
-        if (closest != null) {
-            if (mOnClickListener == null) {
-                return onClickDefault(this, mapView, closest);
-            } else {
-                return mOnClickListener.onClick(this, mapView, closest);
-            }
-        } else
-            return false;
-    }
-
     /** Internal method used to ensure that the infowindow will have a default position in all cases,
      * so that the user can call showInfoWindow even if no tap occured before.
      * Currently, set the position on the "middle" point of the polyline.
@@ -193,5 +142,16 @@ public class Polyline extends PolyOverlayWithIW {
      */
     public double getDistance() {
         return mOutline.getDistance();
+    }
+
+    /**
+     * @since 6.2.0
+     */
+    @Override
+    protected boolean click(final MapView pMapView, final GeoPoint pEventPos) {
+        if (mOnClickListener == null) {
+            return onClickDefault(this, pMapView, pEventPos);
+        }
+        return mOnClickListener.onClick(this, pMapView, pEventPos);
     }
 }


### PR DESCRIPTION
Impacted classes:
* `CustomPaintingSurface`: now using the new `PolyOverlayWithIW.usePath(boolean)` method for the "Polyline as Path" demo
* `Polygon`: moved methods `contains` and `onSingleTapConfirmed` to `PolyOverlayWithIW`; implements new method `PolyOverlayWithIW.click(MapView,GeoPoint)`
* `Polyline`: removed erroneous member `mDensity`; moved member `mDensityMultiplier` (with setter) and methods `isCloseTo`, `getCloseTo` and `onSingleTapConfirmed` to `PolyOverlayWithIW`; implements new method `PolyOverlayWithIW.click(MapView,GeoPoint)`
* `PolyOverlayWithIW`: new abstract method `PolyOverlayWithIW.click(MapView,GeoPoint)`; created method `usePath(boolean)` in order to set the path mode even after the addition of GeoPoints; moved methods from `Polygon` and `Polyline`