### PR TITLE
 bug/#1471 - zoom buttons should zoom only when touched 

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/views/CustomZoomButtonsDisplay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/CustomZoomButtonsDisplay.java
@@ -226,7 +226,12 @@ public class CustomZoomButtonsDisplay {
 	 * @since 6.1.3
 	 */
 	public boolean isTouched(final MotionEvent pMotionEvent, final boolean pInOrOut) {
-		return isTouched((int) pMotionEvent.getX(), (int) pMotionEvent.getY(), pInOrOut);
+		int action = pMotionEvent.getAction();
+		if (action == MotionEvent.ACTION_DOWN || action == MotionEvent.ACTION_UP) {
+			return isTouched((int) pMotionEvent.getX(), (int) pMotionEvent.getY(), pInOrOut);
+		} else {
+			return false;
+		}
 	}
 
 	private boolean isTouched(final int pEventX, final int pEventY, final boolean pInOrOut) {


### PR DESCRIPTION
Custom map zoom buttons should zoom only when touched but not when finger slides across them.