### PR TITLE
feature/#1378_3 - comparison for ColorMappingRanges can be strict or not

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/drawing/ShowAdvancedPolylineStyles.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/drawing/ShowAdvancedPolylineStyles.java
@@ -229,7 +229,7 @@ public class ShowAdvancedPolylineStyles extends BaseSampleFragment implements Vi
         mColorRanges.put(7.5f, Color.YELLOW);
         mColorRanges.put(10.0f, Color.GREEN);
         mListExamples.add(new AdvancedPolylineExample("Tram", "Ranges polyline with border showing a tram ride between airport and main train station.\n\nBorders: 5 m/s RED, 7.5 m/s YELLOW, 10.0 m/s GREEN.",
-                new ColorMappingRanges(mColorRanges),
+                new ColorMappingRanges(mColorRanges, true),
                 false, Color.BLACK, false,
                 getPoints("tram"), getScalars("tram")));
 

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/advancedpolyline/ColorMappingRanges.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/advancedpolyline/ColorMappingRanges.java
@@ -13,10 +13,12 @@ public class ColorMappingRanges extends ColorMappingForScalar {
      * Using a sorted map to define borders of ranges.
      * Borders are sorted from low to high.
      */
-    private SortedMap<Float, Integer> mColorRanges;
+    private final SortedMap<Float, Integer> mColorRanges;
+    private final boolean mStrictComparison;
 
-    public ColorMappingRanges(final SortedMap<Float, Integer> colorArray) {
-        mColorRanges = colorArray;
+    public ColorMappingRanges(final SortedMap<Float, Integer> pColorArray, final boolean pStrictComparison) {
+        mColorRanges = pColorArray;
+        mStrictComparison = pStrictComparison;
     }
 
     @Override
@@ -25,8 +27,14 @@ public class ColorMappingRanges extends ColorMappingForScalar {
         // iterate over array and sort point in
         for (Map.Entry<Float, Integer> entry : mColorRanges.entrySet()) {
 
-            if(pScalar < entry.getKey()) {
-                return entry.getValue();
+            if (mStrictComparison) {
+                if (pScalar < entry.getKey()) {
+                    return entry.getValue();
+                }
+            } else {
+                if (pScalar <= entry.getKey()) {
+                    return entry.getValue();
+                }
             }
             lastArrayIndexFromLoop++;
 


### PR DESCRIPTION
Impacted classes:
* `ColorMappingRanges`: added a strict comparison boolean parameter to the constructor
* `ShowAdvancedPolylineStyles`: impacted the call to `ColorMappingRanges` constructor