### PR TITLE
bug/#1509 - Android bug fixes for MapTileApproximater and transparent images

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samples/SampleWithTilesOverlay.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samples/SampleWithTilesOverlay.java
@@ -9,6 +9,7 @@ import org.osmdroid.views.MapView;
 import org.osmdroid.views.overlay.CopyrightOverlay;
 import org.osmdroid.views.overlay.TilesOverlay;
 
+import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
@@ -56,13 +57,14 @@ public class SampleWithTilesOverlay extends AppCompatActivity {
 		mMapView.getOverlays().add(copyrightOverlay);
 
 		// zoom to the netherlands
-		mMapView.getController().setZoom(7D);
-		mMapView.getController().setCenter(new GeoPoint(51.5, 5.4));
+		mMapView.getController().setZoom(8.);
+		mMapView.getController().setCenter(new GeoPoint(53.6, 5.3));
 
 		// Add tiles layer
 		MapTileProviderBasic provider = new MapTileProviderBasic(getApplicationContext());
-		provider.setTileSource(TileSourceFactory.FIETS_OVERLAY_NL);
+		provider.setTileSource(TileSourceFactory.PUBLIC_TRANSPORT);
 		TilesOverlay tilesOverlay = new TilesOverlay(provider, this.getBaseContext());
+		tilesOverlay.setLoadingBackgroundColor(Color.TRANSPARENT);
 		mMapView.getOverlays().add(tilesOverlay);
 	}
 

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/IMapTileProviderCallback.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/IMapTileProviderCallback.java
@@ -43,5 +43,5 @@ public interface IMapTileProviderCallback {
 	 *
 	 * @return true if data connection should be used, false otherwise
 	 */
-	public boolean useDataConnection();
+	boolean useDataConnection();
 }

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileApproximater.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileApproximater.java
@@ -2,9 +2,11 @@ package org.osmdroid.tileprovider.modules;
 
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
+import android.graphics.Color;
 import android.graphics.Rect;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 
 import org.osmdroid.config.Configuration;
 import org.osmdroid.tileprovider.BitmapPool;
@@ -241,13 +243,16 @@ public class MapTileApproximater extends MapTileModuleProviderBase {
 
     /**
      * Try to get a tile bitmap from the pool, otherwise allocate a new one
-     *
-     * @param pTileSizePx
-     * @return
      */
     public static Bitmap getTileBitmap(final int pTileSizePx) {
         final Bitmap bitmap = BitmapPool.getInstance().obtainSizedBitmapFromPool(pTileSizePx, pTileSizePx);
         if (bitmap != null) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB_MR1) {
+                // without that, the retrieved bitmap forgets it allowed transparency
+                bitmap.setHasAlpha(true);
+            }
+            // without that, the bitmap keeps its previous contents when transparent content is copied on it
+            bitmap.eraseColor(Color.TRANSPARENT);
             return bitmap;
         }
         return Bitmap.createBitmap(pTileSizePx, pTileSizePx, Bitmap.Config.ARGB_8888);

--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/DefaultOverlayManager.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/DefaultOverlayManager.java
@@ -178,8 +178,7 @@ public class DefaultOverlayManager extends AbstractList<Overlay> implements Over
                 if (pMapView != null) {
                     overlay.draw(c, pMapView, false);
                 } else {
-                    if (pProjection.getBoundingBox().overlaps(overlay.getBounds(), pProjection.getZoomLevel()))
-                        overlay.draw(c, pProjection);
+                    overlay.draw(c, pProjection);
                 }
             }
         }


### PR DESCRIPTION
Impacted classes:
* `DefaultOverlayManager`: unrelated minor fix
* `IMapTileProviderCallback`: unrelated minor refactoring
* `MapTileApproximater`: Android bug fixes for method `getTileBitmap` - when we get a bitmap from the pool, now we explicitly make it totally transparent
* `SampleWithTilesOverlay`: minor changes - `TileSourceFactory.PUBLIC_TRANSPORT`, `setLoadingBackgroundColor(Color.TRANSPARENT)` - in order to be able to reproduce the bug more easily if needed