### PR TITLE
Should call mapTileRequestCompleted instead

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileModuleProviderBase.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileModuleProviderBase.java
@@ -296,7 +296,7 @@ public abstract class MapTileModuleProviderBase {
 			}
 			removeTileFromQueues(pState.getMapTile());
 			ExpirableBitmapDrawable.setState(pDrawable, ExpirableBitmapDrawable.SCALED);
-			pState.getCallback().mapTileRequestExpiredTile(pState, pDrawable);
+			pState.getCallback().mapTileRequestCompleted(pState, pDrawable);
 		}
 
 


### PR DESCRIPTION
Should call mapTileRequestCompleted otherwise it will just keep expiring and requesting tiles.