### PR TITLE
Bug/#1512 - Storage location on API29 and above

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/PreferenceActivity.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/PreferenceActivity.java
@@ -368,48 +368,11 @@ public class PreferenceActivity extends AppCompatActivity implements View.OnClic
         AlertDialog.Builder builder = new AlertDialog.Builder(this);
         builder.setTitle(R.string.enterCacheLocation);
 
-
-        final List<StorageUtils.StorageInfo> storageList = StorageUtils.getStorageList();
-
+        final List<StorageUtils.StorageInfo> storageList = StorageUtils.getStorageList(this);
         List<StorageUtils.StorageInfo> storageListFiltered = new ArrayList<>();
-        for (int i = 0; i < storageList.size(); i++) {
-            if (!storageList.get(i).readonly) {
-                storageListFiltered.add(storageList.get(i));
-            }
-        }
-        try {
-            File f = new File("/data/data/" + getPackageName() + "/osmdroid/");
-            f.mkdirs();
-            StorageUtils.StorageInfo privateStorage=new StorageUtils.StorageInfo(f.getAbsolutePath(), true, false, 0);
-            privateStorage.setDisplayName("Application Private Storage");
-            storageListFiltered.add(privateStorage);
-        } catch (Exception ex) {
-        }
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT) {
-            File[] externalFilesDirs = getExternalFilesDirs(null);
-            if (externalFilesDirs != null) {
-                //i hate android!
-                for (int i = 0; i < externalFilesDirs.length; i++) {
-                    File mount = externalFilesDirs[i];
-                    if (mount != null && mount.exists() && mount.isDirectory()) {
-                        boolean writable = StorageUtils.isWritable(mount);
-                        if (writable) {
-                            boolean alreadyAdded = false;
-                            for (int k = 0; k < storageList.size(); k++) {
-                                StorageUtils.StorageInfo storageInfo = storageList.get(k);
-                                if (storageInfo.path.equals(mount.getAbsolutePath())) {
-                                    alreadyAdded = true;
-                                    break;
-                                }
-                            }
-                            if (!alreadyAdded) {
-                                StorageUtils.StorageInfo x = new StorageUtils.StorageInfo(mount.getAbsolutePath(), false, false, 0);
-                                x.freeSpace = mount.getFreeSpace();
-                                storageListFiltered.add(x);
-                            }
-                        }
-                    }
-                }
+        for (StorageUtils.StorageInfo storageInfo : storageList) {
+            if (!storageInfo.readonly) {
+                storageListFiltered.add(storageInfo);
             }
         }
 

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/diag/DiagnosticsActivity.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/diag/DiagnosticsActivity.java
@@ -110,9 +110,9 @@ public class DiagnosticsActivity extends AppCompatActivity
 
     private void probeStorage() {
         StringBuilder sb = new StringBuilder();
-        Iterator<File> iterator = StorageUtils.getAllStorageLocations().values().iterator();
-        while (iterator.hasNext()) {
-            sb.append(iterator.next()).append("\n");
+        List<StorageUtils.StorageInfo> storageInfos = StorageUtils.getStorageList();
+        for (StorageUtils.StorageInfo storageInfo : storageInfos) {
+            sb.append(storageInfo.path).append("\n");
         }
         output.setText(sb.toString());
     }

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/diag/DiagnosticsActivity.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/diag/DiagnosticsActivity.java
@@ -110,7 +110,7 @@ public class DiagnosticsActivity extends AppCompatActivity
 
     private void probeStorage() {
         StringBuilder sb = new StringBuilder();
-        List<StorageUtils.StorageInfo> storageInfos = StorageUtils.getStorageList();
+        List<StorageUtils.StorageInfo> storageInfos = StorageUtils.getStorageList(this);
         for (StorageUtils.StorageInfo storageInfo : storageInfos) {
             sb.append(storageInfo.path).append("\n");
         }

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/intro/StoragePreferenceFragment.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/intro/StoragePreferenceFragment.java
@@ -110,52 +110,14 @@ public class StoragePreferenceFragment extends Fragment implements View.OnClickL
     }
 
     private void showPickCacheFromList() {
-
         AlertDialog.Builder builder = new AlertDialog.Builder(this.getContext());
         builder.setTitle(R.string.enterCacheLocation);
 
-
-        final List<StorageUtils.StorageInfo> storageList = StorageUtils.getStorageList();
-
+        final List<StorageUtils.StorageInfo> storageList = StorageUtils.getStorageList(getActivity());
         List<StorageUtils.StorageInfo> storageListFiltered = new ArrayList<>();
-        for (int i = 0; i < storageList.size(); i++) {
-            if (!storageList.get(i).readonly) {
-                storageListFiltered.add(storageList.get(i));
-            }
-        }
-        try {
-            File f = new File("/data/data/" + getActivity().getPackageName() + "/osmdroid/");
-            f.mkdirs();
-            StorageUtils.StorageInfo privateStorage = new StorageUtils.StorageInfo(f.getAbsolutePath(), true, false, 0);
-            privateStorage.setDisplayName("Application Private Storage");
-            storageListFiltered.add(privateStorage);
-        } catch (Exception ex) {
-        }
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT) {
-            File[] externalFilesDirs = getContext().getExternalFilesDirs(null);
-            if (externalFilesDirs != null) {
-                //i hate android!
-                for (int i = 0; i < externalFilesDirs.length; i++) {
-                    File mount = externalFilesDirs[i];
-                    if (mount != null && mount.exists() && mount.isDirectory()) {
-                        boolean writable = StorageUtils.isWritable(mount);
-                        if (writable) {
-                            boolean alreadyAdded = false;
-                            for (int k = 0; k < storageList.size(); k++) {
-                                StorageUtils.StorageInfo storageInfo = storageList.get(k);
-                                if (storageInfo.path.equals(mount.getAbsolutePath())) {
-                                    alreadyAdded = true;
-                                    break;
-                                }
-                            }
-                            if (!alreadyAdded) {
-                                StorageUtils.StorageInfo x = new StorageUtils.StorageInfo(mount.getAbsolutePath(), false, false, 0);
-                                x.freeSpace = mount.getFreeSpace();
-                                storageListFiltered.add(x);
-                            }
-                        }
-                    }
-                }
+        for (StorageUtils.StorageInfo storageInfo : storageList) {
+            if (!storageInfo.readonly) {
+                storageListFiltered.add(storageInfo);
             }
         }
 
@@ -263,6 +225,5 @@ public class StoragePreferenceFragment extends Fragment implements View.OnClickL
         });
 
         builder.show();
-
     }
 }

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/intro/StoragePreferenceFragment.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/intro/StoragePreferenceFragment.java
@@ -51,15 +51,11 @@ public class StoragePreferenceFragment extends Fragment implements View.OnClickL
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View v = inflater.inflate(R.layout.intro_storage, container, false);
 
-        Configuration.getInstance().load(getContext(), PreferenceManager.getDefaultSharedPreferences(getContext()));
         textViewCacheDirectory = v.findViewById(R.id.textViewCacheDirectory);
-        textViewCacheDirectory.setText(Configuration.getInstance().getOsmdroidTileCache().toString());
-
         buttonSetCache = v.findViewById(R.id.buttonSetCache);
         buttonManualCacheEntry = v.findViewById(R.id.buttonManualCacheEntry);
         buttonSetCache.setOnClickListener(this);
         buttonManualCacheEntry.setOnClickListener(this);
-        textViewCacheDirectory.setText(Configuration.getInstance().getOsmdroidTileCache().toString());
         textViewCacheMaxSize = v.findViewById(R.id.textViewCacheMaxSize);
         textViewCacheFreeSpace = v.findViewById(R.id.textViewCacheFreeSpace);
         textViewCacheCurrentSize = v.findViewById(R.id.textViewCacheCurrentSize);
@@ -71,12 +67,12 @@ public class StoragePreferenceFragment extends Fragment implements View.OnClickL
     public void onResume() {
         super.onResume();
         updateStorage(getContext());
-        textViewCacheDirectory.setText(Configuration.getInstance().getOsmdroidTileCache().toString());
 
+        textViewCacheDirectory.setText(Configuration.getInstance().getOsmdroidTileCache().toString());
         textViewCacheMaxSize.setText(readableFileSize(Configuration.getInstance().getTileFileSystemCacheMaxBytes()));
         textViewCacheTrimSize.setText(readableFileSize(Configuration.getInstance().getTileFileSystemCacheTrimBytes()));
-
         textViewCacheFreeSpace.setText(readableFileSize(Configuration.getInstance().getOsmdroidTileCache().getFreeSpace()));
+
         File dbFile = new File(Configuration.getInstance().getOsmdroidTileCache().getAbsolutePath() + File.separator + SqlTileWriter.DATABASE_FILENAME);
         if (dbFile.exists()) {
             textViewCacheCurrentSize.setText(readableFileSize(dbFile.length()));
@@ -87,25 +83,18 @@ public class StoragePreferenceFragment extends Fragment implements View.OnClickL
 
     public void updateStorage(Context ctx) {
         //only needed for api23+ since we "should" have had permissions granted by now
-        //PreferenceActivity.resetSettings(ctx);
         Configuration.getInstance().load(ctx, PreferenceManager.getDefaultSharedPreferences(ctx));
-
     }
 
-    // END PERMISSION CHECK
     @Override
     public void onClick(View v) {
-
         switch (v.getId()) {
-            case R.id.buttonManualCacheEntry: {
+            case R.id.buttonManualCacheEntry:
                 showManualEntry();
-            }
-            break;
-            case R.id.buttonSetCache: {
+                break;
+            case R.id.buttonSetCache:
                 showPickCacheFromList();
-            }
-            break;
-
+                break;
         }
     }
 

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/cache/SampleAlternateCacheDir.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/cache/SampleAlternateCacheDir.java
@@ -35,7 +35,7 @@ public class SampleAlternateCacheDir extends BaseSampleFragment {
         // an inflater call.
 
         //get the list of all mount points
-        List<StorageUtils.StorageInfo> storageList = StorageUtils.getStorageList();
+        List<StorageUtils.StorageInfo> storageList = StorageUtils.getStorageList(getActivity());
         //loop over them to find a writable location
         //or do whatever you need to do to select a new tile cache path.
 

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/geopackage/GeopackageFeatureTiles.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/geopackage/GeopackageFeatureTiles.java
@@ -245,9 +245,9 @@ public class GeopackageFeatureTiles extends BaseSampleFragment {
      *
      * @return
      */
-    protected static Set<File> findMapFiles() {
+    protected Set<File> findMapFiles() {
         Set<File> maps = new HashSet<>();
-        List<StorageUtils.StorageInfo> storageList = StorageUtils.getStorageList();
+        List<StorageUtils.StorageInfo> storageList = StorageUtils.getStorageList(getActivity());
         for (int i = 0; i < storageList.size(); i++) {
             File f = new File(storageList.get(i).path + File.separator + "osmdroid" + File.separator);
             if (f.exists()) {
@@ -257,14 +257,12 @@ public class GeopackageFeatureTiles extends BaseSampleFragment {
         return maps;
     }
 
-    static private Collection<? extends File> scan(File f) {
+    private Collection<? extends File> scan(File f) {
         List<File> ret = new ArrayList<>();
         File[] files = f.listFiles(new FileFilter() {
             @Override
             public boolean accept(File pathname) {
-                if (pathname.getName().toLowerCase().endsWith(".gpkg"))
-                    return true;
-                return false;
+                return pathname.getName().toLowerCase().endsWith(".gpkg");
             }
         });
         if (files != null) {

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/geopackage/GeopackageFeatures.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/geopackage/GeopackageFeatures.java
@@ -333,9 +333,9 @@ public class GeopackageFeatures extends BaseSampleFragment {
      *
      * @return
      */
-    protected static Set<File> findMapFiles() {
+    protected Set<File> findMapFiles() {
         Set<File> maps = new HashSet<>();
-        List<StorageUtils.StorageInfo> storageList = StorageUtils.getStorageList();
+        List<StorageUtils.StorageInfo> storageList = StorageUtils.getStorageList(getActivity());
         for (int i = 0; i < storageList.size(); i++) {
             File f = new File(storageList.get(i).path + File.separator + "osmdroid" + File.separator);
             if (f.exists()) {
@@ -345,14 +345,12 @@ public class GeopackageFeatures extends BaseSampleFragment {
         return maps;
     }
 
-    static private Collection<? extends File> scan(File f) {
+    private Collection<? extends File> scan(File f) {
         List<File> ret = new ArrayList<>();
         File[] files = f.listFiles(new FileFilter() {
             @Override
             public boolean accept(File pathname) {
-                if (pathname.getName().toLowerCase().endsWith(".gpkg"))
-                    return true;
-                return false;
+                return pathname.getName().toLowerCase().endsWith(".gpkg");
             }
         });
         if (files != null) {

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/geopackage/GeopackageSample.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/geopackage/GeopackageSample.java
@@ -226,9 +226,9 @@ public class GeopackageSample extends BaseSampleFragment {
      *
      * @return
      */
-    protected static Set<File> findMapFiles() {
+    protected Set<File> findMapFiles() {
         Set<File> maps = new HashSet<>();
-        List<StorageUtils.StorageInfo> storageList = StorageUtils.getStorageList();
+        List<StorageUtils.StorageInfo> storageList = StorageUtils.getStorageList(getActivity());
         for (int i = 0; i < storageList.size(); i++) {
             File f = new File(storageList.get(i).path + File.separator + "osmdroid" + File.separator);
             if (f.exists()) {
@@ -238,14 +238,12 @@ public class GeopackageSample extends BaseSampleFragment {
         return maps;
     }
 
-    static private Collection<? extends File> scan(File f) {
+    private Collection<? extends File> scan(File f) {
         List<File> ret = new ArrayList<>();
         File[] files = f.listFiles(new FileFilter() {
             @Override
             public boolean accept(File pathname) {
-                if (pathname.getName().toLowerCase().endsWith(".gpkg"))
-                    return true;
-                return false;
+                return pathname.getName().toLowerCase().endsWith(".gpkg");
             }
         });
         if (files != null) {

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/tileproviders/MapsforgeTileProviderSample.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/tileproviders/MapsforgeTileProviderSample.java
@@ -158,9 +158,9 @@ public class MapsforgeTileProviderSample extends BaseSampleFragment {
      *
      * @return
      */
-    protected static Set<File> findMapFiles() {
+    protected Set<File> findMapFiles() {
         Set<File> maps = new HashSet<>();
-        List<StorageUtils.StorageInfo> storageList = StorageUtils.getStorageList();
+        List<StorageUtils.StorageInfo> storageList = StorageUtils.getStorageList(getActivity());
         for (int i = 0; i < storageList.size(); i++) {
             File f = new File(storageList.get(i).path + File.separator + "osmdroid" + File.separator);
             if (f.exists()) {
@@ -170,14 +170,12 @@ public class MapsforgeTileProviderSample extends BaseSampleFragment {
         return maps;
     }
 
-    static private Collection<? extends File> scan(File f) {
+    private Collection<? extends File> scan(File f) {
         List<File> ret = new ArrayList<>();
         File[] files = f.listFiles(new FileFilter() {
             @Override
             public boolean accept(File pathname) {
-                if (pathname.getName().toLowerCase().endsWith(".map"))
-                    return true;
-                return false;
+                return pathname.getName().toLowerCase().endsWith(".map");
             }
         });
         if (files != null) {

--- a/osmdroid-android/src/main/java/org/osmdroid/config/DefaultConfigurationProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/config/DefaultConfigurationProvider.java
@@ -245,7 +245,7 @@ public class DefaultConfigurationProvider implements IConfigurationProvider {
     @Override
     public File getOsmdroidBasePath() {
         if (osmdroidBasePath==null)
-            osmdroidBasePath = new File(StorageUtils.getBestStorage().path, "osmdroid");
+            osmdroidBasePath = new File(StorageUtils.getBestWritableStorage().path, "osmdroid");
         try {
             osmdroidBasePath.mkdirs();
         }catch (Exception ex){

--- a/osmdroid-android/src/main/java/org/osmdroid/config/DefaultConfigurationProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/config/DefaultConfigurationProvider.java
@@ -244,12 +244,17 @@ public class DefaultConfigurationProvider implements IConfigurationProvider {
 
     @Override
     public File getOsmdroidBasePath() {
+        return getOsmdroidBasePath(null);
+    }
+
+    @Override
+    public File getOsmdroidBasePath(Context context) {
         if (osmdroidBasePath==null)
-            osmdroidBasePath = new File(StorageUtils.getBestWritableStorage().path, "osmdroid");
+            osmdroidBasePath = new File(StorageUtils.getBestWritableStorage(context).path, "osmdroid");
         try {
             osmdroidBasePath.mkdirs();
         }catch (Exception ex){
-            Log.d(IMapView.LOGTAG, "Unable to create base path at " + osmdroidBasePath.getAbsolutePath(), ex);
+            Log.d(IMapView.LOGTAG, "Unable to create base path at " + osmdroidBasePath, ex);
             //IO/permissions issue
             //trap for android studio layout editor and some for certain devices
             //see https://github.com/osmdroid/osmdroid/issues/508
@@ -264,12 +269,17 @@ public class DefaultConfigurationProvider implements IConfigurationProvider {
 
     @Override
     public File getOsmdroidTileCache() {
+        return getOsmdroidTileCache(null);
+    }
+
+    @Override
+    public File getOsmdroidTileCache(Context context) {
         if (osmdroidTileCache==null)
-            osmdroidTileCache =  new File(getOsmdroidBasePath(), "tiles");
+            osmdroidTileCache =  new File(getOsmdroidBasePath(context), "tiles");
         try {
             osmdroidTileCache.mkdirs();
         }catch (Exception ex){
-            Log.d(IMapView.LOGTAG, "Unable to create tile cache path at " + osmdroidTileCache.getAbsolutePath(), ex);
+            Log.d(IMapView.LOGTAG, "Unable to create tile cache path at " + osmdroidTileCache, ex);
             //IO/permissions issue
             //trap for android studio layout editor and some for certain devices
             //see https://github.com/osmdroid/osmdroid/issues/508
@@ -302,8 +312,8 @@ public class DefaultConfigurationProvider implements IConfigurationProvider {
         //check to see if the shared preferences is set for the tile cache
         if (!prefs.contains("osmdroid.basePath")) {
             //this is the first time startup. run the discovery bit
-            File discoveredBasePath = getOsmdroidBasePath();
-            File discoveredCachePath = getOsmdroidTileCache();
+            File discoveredBasePath = getOsmdroidBasePath(ctx);
+            File discoveredCachePath = getOsmdroidTileCache(ctx);
             if (!discoveredBasePath.exists() || !StorageUtils.isWritable(discoveredBasePath)) {
                 //this should always be writable...
                 discoveredBasePath = new File(ctx.getFilesDir(), "osmdroid");

--- a/osmdroid-android/src/main/java/org/osmdroid/config/DefaultConfigurationProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/config/DefaultConfigurationProvider.java
@@ -245,7 +245,7 @@ public class DefaultConfigurationProvider implements IConfigurationProvider {
     @Override
     public File getOsmdroidBasePath() {
         if (osmdroidBasePath==null)
-            osmdroidBasePath = new File(StorageUtils.getStorage().getAbsolutePath(), "osmdroid");
+            osmdroidBasePath = new File(StorageUtils.getBestStorage().path, "osmdroid");
         try {
             osmdroidBasePath.mkdirs();
         }catch (Exception ex){

--- a/osmdroid-android/src/main/java/org/osmdroid/config/IConfigurationProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/config/IConfigurationProvider.java
@@ -200,9 +200,25 @@ public interface IConfigurationProvider {
      * Base path for osmdroid files. Zip/sqlite/mbtiles/etc files are in this folder.
      * Note: also used for offline tile sources
      *
+     * If no directory has been set before with {@link #setOsmdroidBasePath(File)} it tries
+     * to automatically detect one. On API>29 and for better results use
+     * {@link #getOsmdroidBasePath(Context)}
+     *
      * @return
      */
     File getOsmdroidBasePath();
+
+    /**
+     * Base path for osmdroid files. Zip/sqlite/mbtiles/etc files are in this folder.
+     * Note: also used for offline tile sources
+     *
+     * If no directory has been set before with {@link #setOsmdroidBasePath(File)} it tries
+     * to automatically detect one. Passing a context gives better results than
+     * {@link #getOsmdroidBasePath()} and is required to find any location on API29.
+     *
+     * @return
+     */
+    File getOsmdroidBasePath(Context context);
 
     /**
      * Base path for osmdroid files. Zip/sqlite/mbtiles/etc files are in this folder.
@@ -226,9 +242,32 @@ public interface IConfigurationProvider {
      * Note: basePath and tileCache directories can be changed independently
      * This has no effect on offline archives and can be changed independently
      *
+     * If no directory has been set before with {@link #setOsmdroidTileCache(File)} it tries
+     * to automatically detect one. On API>29 and for better results use
+     * {@link #getOsmdroidTileCache(Context)}
+     *
      * @return
      */
     File getOsmdroidTileCache();
+
+    /**
+     * by default, maps to getOsmdroidBasePath() + "/tiles"
+     * By default, it is defined in SD card, osmdroid directory.
+     * Sets the location where the tile cache is stored. Changes are only in effect when the @{link {@link org.osmdroid.views.MapView}}
+     * is created. Changes made after it's creation (either pogrammatic or via layout inflator) have
+     * no effect until the map is restarted or the {@link org.osmdroid.views.MapView#setTileProvider(MapTileProviderBase)}
+     * is changed or recreated.
+     * <p>
+     * Note: basePath and tileCache directories can be changed independently
+     * This has no effect on offline archives and can be changed independently
+     *
+     * If no directory has been set before with {@link #setOsmdroidTileCache(File)} it tries
+     * to automatically detect one. Passing a context gives better results than
+     * {@link #getOsmdroidTileCache()} and is required to find any location on API29.
+     *
+     * @return
+     */
+    File getOsmdroidTileCache(Context context);
 
     /**
      * by default, maps to getOsmdroidBasePath() + "/tiles"

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/StorageUtils.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/StorageUtils.java
@@ -197,7 +197,7 @@ public class StorageUtils {
 
     /**
      * @deprecated As of 6.1.7, will be removed in the future.
-     * @return True if the external storage is available. False otherwise.
+     * @return True if the primary shared storage is available. False otherwise.
      */
     @Deprecated
     public static boolean isAvailable() {
@@ -214,6 +214,7 @@ public class StorageUtils {
 
     /**
      * @deprecated As of 6.1.7, will be removed in the future.
+     * @return The path of the primary shared storage.
      */
     @Deprecated
     public static String getSdCardPath() {
@@ -251,7 +252,7 @@ public class StorageUtils {
 
     /**
      * @return A {@link Map} of all storage locations available
-     * @deprecated As of 6.1.7, will be removed in the future.
+     * @deprecated As of 6.1.7, use {@link #getStorageList()} instead.
      */
     public static Map<String, File> getAllStorageLocations() {
         Map<String, File> map = new HashMap<>(10);

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/StorageUtils.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/StorageUtils.java
@@ -38,13 +38,12 @@ public class StorageUtils {
     private static final String TAG = "StorageUtils";
 
     public static class StorageInfo {
-
         public final String path;
         public final boolean internal;
         public boolean readonly;
         public final int display_number;
         public long freeSpace = 0;
-        String displayName = "";
+        String displayName;
 
         public StorageInfo(String path, boolean internal, boolean readonly, int display_number) {
             this.path = path;
@@ -54,6 +53,7 @@ public class StorageUtils {
             if (Build.VERSION.SDK_INT >= 9) {
                 this.freeSpace = new File(path).getFreeSpace();
             }
+
             if (!readonly) {
                 //confirm it's writable
                 File f = new File(path + File.separator + UUID.randomUUID().toString());
@@ -67,8 +67,9 @@ public class StorageUtils {
                     this.readonly = true;
                 }
             } else {
-                this.readonly = readonly;
+                this.readonly = true;
             }
+
             StringBuilder res = new StringBuilder();
             if (internal) {
                 res.append("Internal SD card");
@@ -136,7 +137,6 @@ public class StorageUtils {
             //see https://github.com/osmdroid/osmdroid/issues/508
             ex.printStackTrace();
         }
-
         try {
             def_path_readonly = Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED_READ_ONLY);
         } catch (Throwable ex) {
@@ -144,9 +144,10 @@ public class StorageUtils {
             //see https://github.com/osmdroid/osmdroid/issues/508
             ex.printStackTrace();
         }
+
         BufferedReader buf_reader = null;
         try {
-            HashSet<String> paths = new HashSet<String>();
+            HashSet<String> paths = new HashSet<>();
             buf_reader = new BufferedReader(new FileReader("/proc/mounts"));
             String line;
             int cur_display_number = 1;
@@ -408,12 +409,6 @@ public class StorageUtils {
                 }
                 hash.append("]");
                 if (!mountHash.contains(hash.toString())) {
-                    String key = SD_CARD + "_" + map.size();
-                    if (map.size() == 0) {
-                        key = SD_CARD;
-                    } else if (map.size() == 1) {
-                        key = EXTERNAL_SD_CARD;
-                    }
                     mountHash.add(hash.toString());
                     if (isWritable(root)) {
                         map.add(root);
@@ -487,7 +482,6 @@ public class StorageUtils {
                     scanner.close();
                 } catch (Exception ignored) {
                 }
-            scanner = null;
         }
 
         for (int i = 0; i < mMounts.size(); i++) {

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/StorageUtils.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/StorageUtils.java
@@ -23,15 +23,6 @@ import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.UUID;
 
-/**
- * Based on some of the responses from this question
- * http://stackoverflow.com/questions/5694933/find-an-external-sd-card-location/15612964#15612964
- * Returns the first storage mount point with the most space that is writable for use as the default
- * location for the osmdroid cache. If an external mount point is not available, application private
- * storage will be used
- * Created by alex on 10/19/16.
- */
-
 public class StorageUtils {
     public static final String SD_CARD = "sdCard";
     public static final String EXTERNAL_SD_CARD = "externalSdCard";
@@ -88,9 +79,13 @@ public class StorageUtils {
     }
 
     /**
-     * Returns a {@link List} of {@link StorageInfo} of all storage paths, writable or not.
+     * Attention! This method only gets storage locations that are context independent. Especially
+     * it does not return application specific paths like getFilesDir() or getCacheDir(), which
+     * might lead to problems especially on API29 and up due to scoped storage restrictions.
+     * For now it is advised to manually determine a proper cache location and set it via
+     * {@link org.osmdroid.config.IConfigurationProvider#setOsmdroidTileCache(File)}.
      *
-     * @return
+     * @return A {@link List} of {@link StorageInfo} of all storage paths, writable or not.
      */
     public static List<StorageInfo> getStorageList() {
         List<StorageInfo> storageInfos = new ArrayList<>();
@@ -103,7 +98,7 @@ public class StorageUtils {
         storageInfos.addAll(tryToFindOtherVoIdManagedStorages(
                 primarySharedStorageInfo != null ? primarySharedStorageInfo.path : ""));
 
-        Set<File> allStorageLocationsRevised = getAllStorageLocationsRevised();
+        Set<File> allStorageLocationsRevised = getAllWritableStorageLocations();
         for (File storageLocation : allStorageLocationsRevised) {
             boolean found = false;
             for (StorageInfo storageInfo : storageInfos) {
@@ -121,7 +116,13 @@ public class StorageUtils {
     }
 
     /**
-     * gets the best possible storage location by freespace
+     * Gets the best possible storage location by free space
+     *
+     * Attention! This method only gets storage locations that are context independent. Especially
+     * it does not return application specific paths like getFilesDir() or getCacheDir(), which
+     * might lead to problems especially on API29 and up due to scoped storage restrictions.
+     * For now it is advised to manually determine a proper cache location and set it via
+     * {@link org.osmdroid.config.IConfigurationProvider#setOsmdroidTileCache(File)}.
      *
      * @deprecated As of 6.1.7, use {@link #getBestStorage()} instead.
      */
@@ -132,16 +133,22 @@ public class StorageUtils {
     }
 
     /**
-     * gets the best possible storage location by freespace
+     * Gets the best possible storage location by free space
      *
-     * @return
+     * Attention! This method only gets storage locations that are context independent. Especially
+     * it does not return application specific paths like getFilesDir() or getCacheDir(), which
+     * might lead to problems especially on API29 and up due to scoped storage restrictions.
+     * For now it is advised to manually determine a proper cache location and set it via
+     * {@link org.osmdroid.config.IConfigurationProvider#setOsmdroidTileCache(File)}.
+     *
+     * @return A {@link StorageInfo} object.
      */
     public static StorageInfo getBestStorage() {
        return getBestStorage(null);
     }
 
     /**
-     * gets the best possible storage location by freespace
+     * Gets the best possible storage location by free space
      *
      * @deprecated As of 6.1.7, use {@link #getBestStorage(Context)} instead.
      */
@@ -156,9 +163,9 @@ public class StorageUtils {
     }
 
     /**
-     * gets the best possible storage location by freespace
+     * Gets the best possible storage location by free space
      *
-     * @return
+     * @return A {@link StorageInfo} object.
      */
     public static StorageInfo getBestStorage(final Context context) {
         StorageInfo bestStorage = null;
@@ -274,7 +281,7 @@ public class StorageUtils {
     /**
      * @return A {@link Set} of all writable storage locations available
      */
-    private static Set<File> getAllStorageLocationsRevised() {
+    private static Set<File> getAllWritableStorageLocations() {
         Set<File> map = new HashSet<>();
 
         Set<File> fromSystemEnv = tryToGetStorageFromSystemEnv();

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/StorageUtils.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/StorageUtils.java
@@ -96,24 +96,24 @@ public class StorageUtils {
         List<StorageInfo> storageInfos = new ArrayList<>();
 
         StorageInfo primarySharedStorageInfo = getPrimarySharedStorage();
-
         if (primarySharedStorageInfo != null) {
             storageInfos.add(primarySharedStorageInfo);
         }
 
-        storageInfos.addAll(tryToFindOtherVoIdManagedStorages(primarySharedStorageInfo != null ? primarySharedStorageInfo.path : ""));
+        storageInfos.addAll(tryToFindOtherVoIdManagedStorages(
+                primarySharedStorageInfo != null ? primarySharedStorageInfo.path : ""));
 
         Set<File> allStorageLocationsRevised = getAllStorageLocationsRevised();
-        for (File next : allStorageLocationsRevised) {
+        for (File storageLocation : allStorageLocationsRevised) {
             boolean found = false;
-            for (int i = 0; i < storageInfos.size(); i++) {
-                if (storageInfos.get(i).path.equals(next.getAbsolutePath())) {
+            for (StorageInfo storageInfo : storageInfos) {
+                if (storageInfo.path.equals(storageLocation.getAbsolutePath())) {
                     found = true;
                     break;
                 }
             }
             if (!found) {
-                storageInfos.add(new StorageInfo(next.getAbsolutePath(), false, false, -1));
+                storageInfos.add(new StorageInfo(storageLocation.getAbsolutePath(), false, false, -1));
             }
         }
 

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/StorageUtils.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/StorageUtils.java
@@ -3,6 +3,7 @@ package org.osmdroid.tileprovider.util;
 import android.content.Context;
 import android.os.Build;
 import android.os.Environment;
+import android.os.StatFs;
 import android.util.Log;
 
 import java.io.BufferedReader;
@@ -50,7 +51,11 @@ public class StorageUtils {
             this.internal = internal;
 
             this.display_number = display_number;
-            if (Build.VERSION.SDK_INT >= 9) {
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+                // gives more accurate information
+                this.freeSpace = new StatFs(path).getAvailableBytes();
+            } else if (Build.VERSION.SDK_INT >=  Build.VERSION_CODES.GINGERBREAD) {
                 this.freeSpace = new File(path).getFreeSpace();
             }
 

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/StorageUtils.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/StorageUtils.java
@@ -190,15 +190,9 @@ public class StorageUtils {
         if (context != null) {
             String dbPath = context.getDatabasePath("temp.sqlite").getAbsolutePath().replace("temp.sqlite", "");
             return new StorageInfo(dbPath, true, false, -1);
-        } else {
-            try {
-                return getPrimarySharedStorage();
-            } catch (Exception ex) {
-                //trap for android studio layout editor and some for certain devices
-                //see https://github.com/osmdroid/osmdroid/issues/508
-                return null;
-            }
         }
+
+        return null;
     }
 
     /**

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/StorageUtils.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/StorageUtils.java
@@ -194,7 +194,7 @@ public class StorageUtils {
     }
 
     /**
-     * @deprecated As of 6.1.7, use {@link #isPrimarySharedStorageAvailable()} instead.
+     * @deprecated As of 6.1.7, will be removed in the future.
      * @return True if the external storage is available. False otherwise.
      */
     @Deprecated
@@ -205,18 +205,24 @@ public class StorageUtils {
     /**
      * @return True if the primary shared storage is available. False otherwise.
      */
-    public static boolean isPrimarySharedStorageAvailable() {
+    private static boolean isPrimarySharedStorageAvailable() {
         String state = Environment.getExternalStorageState();
         return Environment.MEDIA_MOUNTED.equals(state) || Environment.MEDIA_MOUNTED_READ_ONLY.equals(state);
     }
 
+    /**
+     * @deprecated As of 6.1.7, will be removed in the future.
+     */
+    @Deprecated
     public static String getSdCardPath() {
         return Environment.getExternalStorageDirectory().getPath() + "/";
     }
 
     /**
      * @return True if the primary shared storage is writable. False otherwise.
+     * @deprecated As of 6.1.7, will be removed in the future.
      */
+    @Deprecated
     public static boolean isWritable() {
         String state = Environment.getExternalStorageState();
         return Environment.MEDIA_MOUNTED.equals(state);
@@ -243,6 +249,7 @@ public class StorageUtils {
 
     /**
      * @return A {@link Map} of all storage locations available
+     * @deprecated As of 6.1.7, will be removed in the future.
      */
     public static Map<String, File> getAllStorageLocations() {
         Map<String, File> map = new HashMap<>(10);
@@ -264,7 +271,7 @@ public class StorageUtils {
     }
 
     /**
-     * @return A {@link Set} of all storage locations available
+     * @return A {@link Set} of all writable storage locations available
      */
     private static Set<File> getAllStorageLocationsRevised() {
         Set<File> map = new HashSet<>();

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/StorageUtils.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/StorageUtils.java
@@ -83,7 +83,7 @@ public class StorageUtils {
     }
 
     /**
-     * returns all storage paths, writable or not
+     * Returns a {@link List} of {@link StorageInfo} all storage paths, writable or not.
      *
      * @return
      */
@@ -216,10 +216,11 @@ public class StorageUtils {
     /**
      * gets the best possible storage location by freespace
      *
-     * @return
+     * @deprecated As of 6.1.7, use {@link #getBestStorage()} instead.
      */
+    @Deprecated
     public static File getStorage() {
-        return getStorage(null);
+        return getBestStorage();
     }
 
     /**
@@ -227,7 +228,26 @@ public class StorageUtils {
      *
      * @return
      */
+    public static File getBestStorage() {
+       return getBestStorage(null);
+    }
+
+    /**
+     * gets the best possible storage location by freespace
+     *
+     * @deprecated As of 6.1.7, use {@link #getBestStorage(Context)} instead.
+     */
+    @Deprecated
     public static File getStorage(final Context context) {
+        return getBestStorage(context);
+    }
+
+    /**
+     * gets the best possible storage location by freespace
+     *
+     * @return
+     */
+    public static File getBestStorage(final Context context) {
         StorageInfo bestStorage = null;
         List<StorageInfo> storageList = getStorageList();
         for (int i = 0; i < storageList.size(); i++) {
@@ -261,9 +281,18 @@ public class StorageUtils {
     }
 
     /**
+     * @deprecated As of 6.1.7, use {@link #isPrimarySharedStorageAvailable()} instead.
      * @return True if the external storage is available. False otherwise.
      */
+    @Deprecated
     public static boolean isAvailable() {
+        return isPrimarySharedStorageAvailable();
+    }
+
+    /**
+     * @return True if the primary shared storage is available. False otherwise.
+     */
+    public static boolean isPrimarySharedStorageAvailable() {
         String state = Environment.getExternalStorageState();
         return Environment.MEDIA_MOUNTED.equals(state) || Environment.MEDIA_MOUNTED_READ_ONLY.equals(state);
     }
@@ -273,13 +302,16 @@ public class StorageUtils {
     }
 
     /**
-     * @return True if the external storage is writable. False otherwise.
+     * @return True if the primary shared storage is writable. False otherwise.
      */
     public static boolean isWritable() {
         String state = Environment.getExternalStorageState();
         return Environment.MEDIA_MOUNTED.equals(state);
     }
 
+    /**
+     * @return True if the path is writable. False otherwise.
+     */
     public static boolean isWritable(File path) {
         try {
             File tmp = new File(path.getAbsolutePath() + File.separator + UUID.randomUUID().toString());
@@ -297,7 +329,7 @@ public class StorageUtils {
     }
 
     /**
-     * @return A map of all storage locations available
+     * @return A {@link Map} of all storage locations available
      */
     public static Map<String, File> getAllStorageLocations() {
         Map<String, File> map = new HashMap<>(10);
@@ -347,7 +379,7 @@ public class StorageUtils {
     }
 
     /**
-     * @return A map of all storage locations available
+     * @return A {@link Set} of all storage locations available
      */
     private static Set<File> getAllStorageLocationsRevised() {
         Set<File> map = new HashSet<>();

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/StorageUtils.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/StorageUtils.java
@@ -127,7 +127,7 @@ public class StorageUtils {
      */
     @Deprecated
     public static File getStorage() {
-        return getBestStorage();
+        return getStorage(null);
     }
 
     /**
@@ -135,7 +135,7 @@ public class StorageUtils {
      *
      * @return
      */
-    public static File getBestStorage() {
+    public static StorageInfo getBestStorage() {
        return getBestStorage(null);
     }
 
@@ -146,7 +146,12 @@ public class StorageUtils {
      */
     @Deprecated
     public static File getStorage(final Context context) {
-        return getBestStorage(context);
+        StorageInfo bestStorage = getBestStorage(context);
+        if (bestStorage != null) {
+            return new File(bestStorage.path);
+        }
+
+        return null;
     }
 
     /**
@@ -154,7 +159,7 @@ public class StorageUtils {
      *
      * @return
      */
-    public static File getBestStorage(final Context context) {
+    public static StorageInfo getBestStorage(final Context context) {
         StorageInfo bestStorage = null;
         List<StorageInfo> storageList = getStorageList();
         for (int i = 0; i < storageList.size(); i++) {
@@ -171,14 +176,15 @@ public class StorageUtils {
             }
         }
         if (bestStorage != null) {
-            return new File(bestStorage.path);
+            return bestStorage;
         }
         //http://stackoverflow.com/questions/21230629/getfilesdir-vs-environment-getdatadirectory
         if (context != null) {
-            return new File(context.getDatabasePath("temp.sqlite").getAbsolutePath().replace("temp.sqlite", ""));
+            String dbPath = context.getDatabasePath("temp.sqlite").getAbsolutePath().replace("temp.sqlite", "");
+            return new StorageInfo(dbPath, true, false, -1);
         } else {
             try {
-                return Environment.getExternalStorageDirectory();
+                return getPrimarySharedStorage();
             } catch (Exception ex) {
                 //trap for android studio layout editor and some for certain devices
                 //see https://github.com/osmdroid/osmdroid/issues/508

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/StorageUtils.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/StorageUtils.java
@@ -44,7 +44,7 @@ public class StorageUtils {
         public boolean readonly;
         public final int display_number;
         public long freeSpace = 0;
-        String displayName;
+        public String displayName;
 
         public StorageInfo(String path, boolean internal, boolean readonly, int display_number) {
             this.path = path;
@@ -127,6 +127,7 @@ public class StorageUtils {
      */
     @Deprecated
     public static File getStorage() {
+        //noinspection deprecation
         return getStorage(null);
     }
 

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/StorageUtils.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/StorageUtils.java
@@ -115,115 +115,6 @@ public class StorageUtils {
         return storageInfos;
     }
 
-    private static StorageInfo getPrimarySharedStorage() {
-        String primarySharedStoragePath = "";
-        boolean isPrimarySharedStorageNotRemovable = false;
-        String primarySharedStorageState = "";
-        boolean isPrimarySharedStorageReadonly = true;
-        boolean isPrimarySharedStorageAvailable = false;
-
-        try {
-            if (Environment.getExternalStorageDirectory() != null) {
-                primarySharedStoragePath = Environment.getExternalStorageDirectory().getPath();
-            }
-        } catch (Throwable ex) {
-            //trap for android studio layout editor and some for certain devices
-            //see https://github.com/osmdroid/osmdroid/issues/508
-            ex.printStackTrace();
-        }
-        try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD) {
-                isPrimarySharedStorageNotRemovable = !Environment.isExternalStorageRemovable();
-            }
-        } catch (Throwable ex) {
-            //trap for android studio layout editor and some for certain devices
-            //see https://github.com/osmdroid/osmdroid/issues/508
-            ex.printStackTrace();
-        }
-        try {
-            primarySharedStorageState = Environment.getExternalStorageState();
-        } catch (Throwable ex) {
-            //trap for android studio layout editor and some for certain devices
-            //see https://github.com/osmdroid/osmdroid/issues/508
-            ex.printStackTrace();
-        }
-        try {
-            isPrimarySharedStorageAvailable = primarySharedStorageState.equals(Environment.MEDIA_MOUNTED) || primarySharedStorageState.equals(Environment.MEDIA_MOUNTED_READ_ONLY);
-        } catch (Throwable ex) {
-            //trap for android studio layout editor and some for certain devices
-            //see https://github.com/osmdroid/osmdroid/issues/508
-            ex.printStackTrace();
-        }
-        try {
-            isPrimarySharedStorageReadonly = Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED_READ_ONLY);
-        } catch (Throwable ex) {
-            //trap for android studio layout editor and some for certain devices
-            //see https://github.com/osmdroid/osmdroid/issues/508
-            ex.printStackTrace();
-        }
-
-        StorageInfo primarySharedStorageInfo = null;
-        if (isPrimarySharedStorageAvailable) {
-            primarySharedStorageInfo = new StorageInfo(primarySharedStoragePath, isPrimarySharedStorageNotRemovable, isPrimarySharedStorageReadonly, -1);
-        }
-        return primarySharedStorageInfo;
-    }
-
-    private static List<StorageInfo> tryToFindOtherVoIdManagedStorages(String storagePathToIgnore) {
-        List<StorageInfo> storageInfos = new ArrayList<>();
-        BufferedReader bufferedReader = null;
-
-        try {
-            HashSet<String> paths = new HashSet<>();
-            bufferedReader = new BufferedReader(new FileReader("/proc/mounts"));
-            String line;
-            int currentDisplayNumber = 1;
-            Log.d(TAG, "/proc/mounts");
-            while ((line = bufferedReader.readLine()) != null) {
-                Log.d(TAG, line);
-                if (line.contains("vfat") || line.contains("/mnt")) {
-                    StringTokenizer tokens = new StringTokenizer(line, " ");
-                    String unused = tokens.nextToken(); //device
-                    String mountPoint = tokens.nextToken(); //mount point
-                    if (paths.contains(mountPoint)) {
-                        continue;
-                    }
-                    unused = tokens.nextToken(); //file system
-                    List<String> flags = Arrays.asList(tokens.nextToken().split(",")); //flags
-                    boolean readonly = flags.contains("ro");
-
-                    // if mountPoint is the primary shared storage, skip it
-                    if (mountPoint.equals(storagePathToIgnore)) {
-                        paths.add(storagePathToIgnore);
-                    } else if (line.contains("/dev/block/vold")) {
-                        if (!line.contains("/mnt/secure")
-                                && !line.contains("/mnt/asec")
-                                && !line.contains("/mnt/obb")
-                                && !line.contains("/dev/mapper")
-                                && !line.contains("tmpfs")) {
-                            paths.add(mountPoint);
-                            if (new File(mountPoint + File.separator).exists()) {
-                                storageInfos.add(new StorageInfo(mountPoint, false, readonly, currentDisplayNumber++));
-                            }
-                        }
-                    }
-                }
-            }
-        } catch (FileNotFoundException ex) {
-            ex.printStackTrace();
-        } catch (IOException ex) {
-            ex.printStackTrace();
-        } finally {
-            if (bufferedReader != null) {
-                try {
-                    bufferedReader.close();
-                } catch (IOException ignored) {
-                }
-            }
-        }
-        return storageInfos;
-    }
-
     /**
      * gets the best possible storage location by freespace
      *
@@ -389,6 +280,115 @@ public class StorageUtils {
         }
 
         return map;
+    }
+
+    private static StorageInfo getPrimarySharedStorage() {
+        String primarySharedStoragePath = "";
+        boolean isPrimarySharedStorageNotRemovable = false;
+        String primarySharedStorageState = "";
+        boolean isPrimarySharedStorageReadonly = true;
+        boolean isPrimarySharedStorageAvailable = false;
+
+        try {
+            if (Environment.getExternalStorageDirectory() != null) {
+                primarySharedStoragePath = Environment.getExternalStorageDirectory().getPath();
+            }
+        } catch (Throwable ex) {
+            //trap for android studio layout editor and some for certain devices
+            //see https://github.com/osmdroid/osmdroid/issues/508
+            ex.printStackTrace();
+        }
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD) {
+                isPrimarySharedStorageNotRemovable = !Environment.isExternalStorageRemovable();
+            }
+        } catch (Throwable ex) {
+            //trap for android studio layout editor and some for certain devices
+            //see https://github.com/osmdroid/osmdroid/issues/508
+            ex.printStackTrace();
+        }
+        try {
+            primarySharedStorageState = Environment.getExternalStorageState();
+        } catch (Throwable ex) {
+            //trap for android studio layout editor and some for certain devices
+            //see https://github.com/osmdroid/osmdroid/issues/508
+            ex.printStackTrace();
+        }
+        try {
+            isPrimarySharedStorageAvailable = primarySharedStorageState.equals(Environment.MEDIA_MOUNTED) || primarySharedStorageState.equals(Environment.MEDIA_MOUNTED_READ_ONLY);
+        } catch (Throwable ex) {
+            //trap for android studio layout editor and some for certain devices
+            //see https://github.com/osmdroid/osmdroid/issues/508
+            ex.printStackTrace();
+        }
+        try {
+            isPrimarySharedStorageReadonly = Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED_READ_ONLY);
+        } catch (Throwable ex) {
+            //trap for android studio layout editor and some for certain devices
+            //see https://github.com/osmdroid/osmdroid/issues/508
+            ex.printStackTrace();
+        }
+
+        StorageInfo primarySharedStorageInfo = null;
+        if (isPrimarySharedStorageAvailable) {
+            primarySharedStorageInfo = new StorageInfo(primarySharedStoragePath, isPrimarySharedStorageNotRemovable, isPrimarySharedStorageReadonly, -1);
+        }
+        return primarySharedStorageInfo;
+    }
+
+    private static List<StorageInfo> tryToFindOtherVoIdManagedStorages(String storagePathToIgnore) {
+        List<StorageInfo> storageInfos = new ArrayList<>();
+        BufferedReader bufferedReader = null;
+
+        try {
+            HashSet<String> paths = new HashSet<>();
+            bufferedReader = new BufferedReader(new FileReader("/proc/mounts"));
+            String line;
+            int currentDisplayNumber = 1;
+            Log.d(TAG, "/proc/mounts");
+            while ((line = bufferedReader.readLine()) != null) {
+                Log.d(TAG, line);
+                if (line.contains("vfat") || line.contains("/mnt")) {
+                    StringTokenizer tokens = new StringTokenizer(line, " ");
+                    String unused = tokens.nextToken(); //device
+                    String mountPoint = tokens.nextToken(); //mount point
+                    if (paths.contains(mountPoint)) {
+                        continue;
+                    }
+                    unused = tokens.nextToken(); //file system
+                    List<String> flags = Arrays.asList(tokens.nextToken().split(",")); //flags
+                    boolean readonly = flags.contains("ro");
+
+                    // if mountPoint is the primary shared storage, skip it
+                    if (mountPoint.equals(storagePathToIgnore)) {
+                        paths.add(storagePathToIgnore);
+                    } else if (line.contains("/dev/block/vold")) {
+                        if (!line.contains("/mnt/secure")
+                                && !line.contains("/mnt/asec")
+                                && !line.contains("/mnt/obb")
+                                && !line.contains("/dev/mapper")
+                                && !line.contains("tmpfs")) {
+                            paths.add(mountPoint);
+                            if (new File(mountPoint + File.separator).exists()) {
+                                storageInfos.add(new StorageInfo(mountPoint, false, readonly, currentDisplayNumber++));
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (FileNotFoundException ex) {
+            ex.printStackTrace();
+        } catch (IOException ex) {
+            ex.printStackTrace();
+        } finally {
+            if (bufferedReader != null) {
+                try {
+                    bufferedReader.close();
+                } catch (IOException ignored) {
+                }
+            }
+        }
+        return storageInfos;
     }
 
     private static Map<String, File> tryToGetMountedStoragesFromFilesystem() {

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/StorageUtils.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/StorageUtils.java
@@ -285,7 +285,6 @@ public class StorageUtils {
     private static StorageInfo getPrimarySharedStorage() {
         String primarySharedStoragePath = "";
         boolean isPrimarySharedStorageNotRemovable = false;
-        String primarySharedStorageState = "";
         boolean isPrimarySharedStorageReadonly = true;
         boolean isPrimarySharedStorageAvailable = false;
 
@@ -308,14 +307,7 @@ public class StorageUtils {
             ex.printStackTrace();
         }
         try {
-            primarySharedStorageState = Environment.getExternalStorageState();
-        } catch (Throwable ex) {
-            //trap for android studio layout editor and some for certain devices
-            //see https://github.com/osmdroid/osmdroid/issues/508
-            ex.printStackTrace();
-        }
-        try {
-            isPrimarySharedStorageAvailable = primarySharedStorageState.equals(Environment.MEDIA_MOUNTED) || primarySharedStorageState.equals(Environment.MEDIA_MOUNTED_READ_ONLY);
+            isPrimarySharedStorageAvailable = isPrimarySharedStorageAvailable();
         } catch (Throwable ex) {
             //trap for android studio layout editor and some for certain devices
             //see https://github.com/osmdroid/osmdroid/issues/508

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/StorageUtils.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/StorageUtils.java
@@ -56,18 +56,7 @@ public class StorageUtils {
 
             if (!readonly) {
                 //confirm it's writable
-                File f = new File(path + File.separator + UUID.randomUUID().toString());
-                try {
-                    //noinspection ResultOfMethodCallIgnored
-                    f.createNewFile();
-                    //noinspection ResultOfMethodCallIgnored
-                    f.delete();
-                    this.readonly = false;
-                } catch (Throwable e) {
-                    this.readonly = true;
-                }
-            } else {
-                this.readonly = true;
+                this.readonly = !isWritable(new File(path));
             }
 
             StringBuilder res = new StringBuilder();
@@ -284,13 +273,13 @@ public class StorageUtils {
 
     public static boolean isWritable(File path) {
         try {
-            File tmp = new File(path.getAbsolutePath() + File.separator + "osm.tmp");
+            File tmp = new File(path.getAbsolutePath() + File.separator + UUID.randomUUID().toString());
             FileOutputStream fos = new FileOutputStream(tmp);
             fos.write("hi".getBytes());
             fos.close();
-            Log.i(TAG, path.getAbsolutePath() + " is writable");
             //noinspection ResultOfMethodCallIgnored
             tmp.delete();
+            Log.i(TAG, path.getAbsolutePath() + " is writable");
             return true;
         } catch (Throwable ex) {
             Log.i(TAG, path.getAbsolutePath() + " is NOT writable");

--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
@@ -205,6 +205,12 @@ public class MapView extends ViewGroup implements IMapView,
 					  MapTileProviderBase tileProvider,
 					  final Handler tileRequestCompleteHandler, final AttributeSet attrs, boolean hardwareAccelerated) {
 		super(context, attrs);
+
+		// Hacky workaround: If no storage location was set manually, we need to try to be
+		// the first to give DefaultConfigurationProvider a chance to detect the best storage
+		// location WITH a context. Otherwise there will be no valid cache directory on >API29!
+		Configuration.getInstance().getOsmdroidTileCache(context);
+
 		if(isInEditMode()){ 	//fix for edit mode in the IDE
 			mTileRequestCompleteHandler=null;
 			mController=null;


### PR DESCRIPTION
#1512 
Basically a complete overhaul of StorageUtils:

- lot's of refactoring
- < API19: Behaviour is untouched except fixing a minor bug, that lead to non-writable locations returned as writable
- 19 <= API < 29: legacy behaviour + additional storage locations when a context is provided
- \>API29: Only new behviour with fallback for targetSdk < API29 apps on >API29 devices.
- replacing references to now deprecated methods to the new alternatives.

On API29 and above a valid storage location can only be retrieved when a context is available. Therefore a hacky workaround has been implemented in MapView. This should cover most naive usages of the library.
In more advanced cases (e.g. own `MapTileModuleProviderBase` implementations) this can still lead to problems if the storage detection via `getOsmdroidBasePath(Context)` / `getOsmdroidTileCache(Context)` was not triggered before with a context or a valid directory was set via `setOsmdroidBasePath()` / `setOsmdroidTileCache()`.
This is not easily fixed due to the Configuration being a static singleton. This should probably be changed in a future release since it also causes lots of other issues (testing, hard to reason about code), but will mean a breaking change.