### PR TITLE
fix crash if no storage permission

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/config/DefaultConfigurationProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/config/DefaultConfigurationProvider.java
@@ -249,11 +249,14 @@ public class DefaultConfigurationProvider implements IConfigurationProvider {
 
     @Override
     public File getOsmdroidBasePath(Context context) {
-        if (osmdroidBasePath==null)
-            osmdroidBasePath = new File(StorageUtils.getBestWritableStorage(context).path, "osmdroid");
         try {
-            osmdroidBasePath.mkdirs();
-        }catch (Exception ex){
+            if (osmdroidBasePath==null) {
+                StorageUtils.StorageInfo storageInfo = StorageUtils.getBestWritableStorage(context);
+                String pathToStorage = storageInfo.path;
+                osmdroidBasePath = new File(pathToStorage, "osmdroid");
+                osmdroidBasePath.mkdirs();
+            }
+        } catch (Exception ex){
             Log.d(IMapView.LOGTAG, "Unable to create base path at " + osmdroidBasePath, ex);
             //IO/permissions issue
             //trap for android studio layout editor and some for certain devices

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileFileArchiveProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileFileArchiveProvider.java
@@ -176,16 +176,18 @@ public class MapTileFileArchiveProvider extends MapTileFileStorageProviderBase {
 
           // path should be optionally configurable
           File cachePaths = Configuration.getInstance().getOsmdroidBasePath();
-          final File[] files = cachePaths.listFiles();
-          if (files != null) {
-               for (final File file : files) {
-                    final IArchiveFile archiveFile = ArchiveFileFactory.getArchiveFile(file);
-                    if (archiveFile != null) {
-                   		 archiveFile.setIgnoreTileSource(ignoreTileSource);
-                         mArchiveFiles.add(archiveFile);
-                    }
-               }
-          }
+          if (cachePaths != null) {
+			  final File[] files = cachePaths.listFiles();
+			  if (files != null) {
+				  for (final File file : files) {
+					  final IArchiveFile archiveFile = ArchiveFileFactory.getArchiveFile(file);
+					  if (archiveFile != null) {
+						  archiveFile.setIgnoreTileSource(ignoreTileSource);
+						  mArchiveFiles.add(archiveFile);
+					  }
+				  }
+			  }
+		  }
 	}
 
 	private synchronized InputStream getInputStream(final long pMapTileIndex,


### PR DESCRIPTION
When I disable Storage (and before asking for permissions in the same Activity) I would be getting
```
java.lang.NullPointerException: Attempt to read from field 'java.lang.String org.osmdroid.tileprovider.util.StorageUtils$StorageInfo.path' on a null object reference
```