### PR TITLE
Use context for discovering cache dir also when prefs already exist

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/config/DefaultConfigurationProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/config/DefaultConfigurationProvider.java
@@ -334,8 +334,8 @@ public class DefaultConfigurationProvider implements IConfigurationProvider {
             save(ctx,prefs);
         } else {
             //normal startup, load user preferences and populate the config object
-            setOsmdroidBasePath(new File(prefs.getString("osmdroid.basePath", getOsmdroidBasePath().getAbsolutePath())));
-            setOsmdroidTileCache(new File(prefs.getString("osmdroid.cachePath", getOsmdroidTileCache().getAbsolutePath())));
+            setOsmdroidBasePath(new File(prefs.getString("osmdroid.basePath", getOsmdroidBasePath(ctx).getAbsolutePath())));
+            setOsmdroidTileCache(new File(prefs.getString("osmdroid.cachePath", getOsmdroidTileCache(ctx).getAbsolutePath())));
             setDebugMode(prefs.getBoolean("osmdroid.DebugMode", debugMode));
             setDebugMapTileDownloader(prefs.getBoolean("osmdroid.DebugDownloading", debugMapTileDownloader));
             setDebugMapView(prefs.getBoolean("osmdroid.DebugMapView", debugMapView));


### PR DESCRIPTION
Should fix #1621 as it covers cornercases where prefs exist, but there is no saved directory.