### PR TITLE
Fixed bouncing fling in bug/#1612.

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
@@ -1525,6 +1525,7 @@ public class MapView extends ViewGroup implements IMapView,
 				return false;
 			}
 
+
 			if (MapView.this.getOverlayManager()
 					.onFling(e1, e2, velocityX, velocityY, MapView.this)) {
 				return true;
@@ -1534,15 +1535,10 @@ public class MapView extends ViewGroup implements IMapView,
 				mImpossibleFlinging = false;
 				return false;
 			}
+      
 			mIsFlinging = true;
 			if (mScroller!=null) {  //fix for edit mode in the IDE
-        Point v;
-        if (Build.VERSION.SDK_INT >= 28) {
-          v = getProjection().unrotateAndScalePoint((int)velocityX, (int)velocityY, null);
-        } else {
-          v = new Point((int)velocityX, (int)velocityY);
-        }
-				mScroller.fling((int) getMapScrollX(), (int) getMapScrollY(), -v.x, - v.y,
+        mScroller.fling((int) getMapScrollX(), (int) getMapScrollY(), -(int)velocityX, -(int)velocityY,
             Integer.MIN_VALUE, Integer.MAX_VALUE, Integer.MIN_VALUE, Integer.MAX_VALUE);
 			}
 			return true;


### PR DESCRIPTION
Fixes #1612 for all tested devices < Android 9 or > Android 9 and for **some** tested Android 9 devices.
I claim, that the Android 9 devices which now "bounce" are a minority, I have no idea how to figure what is the difference.