### PR TITLE
Fixes drawing accuracy circle

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/views/overlay/mylocation/DirectedLocationOverlay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/overlay/mylocation/DirectedLocationOverlay.java
@@ -122,7 +122,7 @@ public class DirectedLocationOverlay extends Overlay {
 			pj.toPixels(this.mLocation, screenCoords);
 
 			if (this.mShowAccuracy && this.mAccuracy > 10) {
-				final float accuracyRadius = pj.metersToEquatorPixels(this.mAccuracy);
+				final float accuracyRadius = pj.metersToPixels(this.mAccuracy, mLocation.getLatitude(), pj.getZoomLevel());
 				/* Only draw if the DirectionArrow doesn't cover it. */
 				if (accuracyRadius > 8) {
 					/* Draw the inner shadow. */


### PR DESCRIPTION
Fixes drawing accuracy circle in dependent of point's lattitude

By default accuracy circle is drawing with reference to equator. If your geo point is above or below equator, accuracy circle drawing incorrect. Changes of this commit allow to draw correct circle with radius binded to point lattitude.