### PR TITLE
Wrong options object in Polyline conversion

### DIFF
--- a/osmdroid-geopackage/src/main/java/org/osmdroid/gpkg/overlay/OsmMapShapeConverter.java
+++ b/osmdroid-geopackage/src/main/java/org/osmdroid/gpkg/overlay/OsmMapShapeConverter.java
@@ -212,7 +212,7 @@ public class OsmMapShapeConverter {
             line.getOutlinePaint().setColor(polylineOptions.getColor());
             line.setGeodesic(polylineOptions.isGeodesic());
             line.getOutlinePaint().setStrokeWidth(polylineOptions.getWidth());
-            line.setSubDescription(polygonOptions.getSubtitle());
+            line.setSubDescription(polylineOptions.getSubtitle());
         }
 
         List<GeoPoint> pts = new ArrayList<>();


### PR DESCRIPTION
Use of polygonOptions's subtitle instead of polylineOptions's subtitle in toPolyline method of OsmMapShapeConverter