### PR TITLE
Android11 MBTiles fix

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/GEMFFileArchive.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/GEMFFileArchive.java
@@ -1,5 +1,7 @@
 package org.osmdroid.tileprovider.modules;
 
+import android.content.Context;
+import android.net.Uri;
 import android.util.Log;
 
 import org.osmdroid.api.IMapView;
@@ -31,6 +33,11 @@ public class GEMFFileArchive implements IArchiveFile {
     @Override
     public void init(File pFile) throws Exception {
         mFile = new GEMFFile(pFile);
+    }
+
+    @Override
+    public void init(Uri pFile, Context context) throws Exception {
+        throw new Exception("URI files not available for GEM Files");
     }
 
     @Override

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/IArchiveFile.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/IArchiveFile.java
@@ -1,5 +1,8 @@
 package org.osmdroid.tileprovider.modules;
 
+import android.content.Context;
+import android.net.Uri;
+
 import org.osmdroid.tileprovider.tilesource.ITileSource;
 
 import java.io.File;
@@ -24,6 +27,8 @@ public interface IArchiveFile {
      * @throws Exception
      */
     void init(File pFile) throws Exception;
+
+    void init(Uri pFile, Context context) throws Exception;
 
     /**
      * Get the input stream for the requested tile and tile source.

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/ZipFileArchive.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/ZipFileArchive.java
@@ -1,10 +1,14 @@
 package org.osmdroid.tileprovider.modules;
 
+import android.content.Context;
+import android.net.Uri;
+import android.provider.DocumentsContract;
 import android.util.Log;
 
 import org.osmdroid.api.IMapView;
 import org.osmdroid.tileprovider.tilesource.ITileSource;
 import org.osmdroid.util.MapTileIndex;
+import org.osmdroid.util.OsmUriHelper;
 
 import java.io.File;
 import java.io.IOException;
@@ -43,6 +47,15 @@ public class ZipFileArchive implements IArchiveFile {
     @Override
     public void init(File pFile) throws Exception {
         mZipFile = new ZipFile(pFile);
+    }
+
+    @Override
+    public void init(Uri pFile, Context context) throws Exception {
+        Uri docUri = DocumentsContract.buildDocumentUriUsingTree(pFile,
+                DocumentsContract.getTreeDocumentId(pFile));
+        String path = OsmUriHelper.getPath(context, docUri);
+        path += File.separator + ArchiveFileFactory.getFileName(pFile, context);
+        mZipFile = new ZipFile(path);
     }
 
     @Override

--- a/osmdroid-android/src/main/java/org/osmdroid/util/OsmUriHelper.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/util/OsmUriHelper.java
@@ -1,0 +1,137 @@
+package org.osmdroid.util;
+
+import android.annotation.TargetApi;
+import android.content.ContentUris;
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Environment;
+import android.provider.DocumentsContract;
+import android.provider.MediaStore;
+
+public class OsmUriHelper {
+    @TargetApi(Build.VERSION_CODES.KITKAT)
+    public static String getPath(final Context context, final Uri uri) {
+
+        final boolean isKitKat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
+
+        // DocumentProvider
+        if (isKitKat && DocumentsContract.isDocumentUri(context, uri)) {
+            // ExternalStorageProvider
+            if (isExternalStorageDocument(uri)) {
+                final String docId = DocumentsContract.getDocumentId(uri);
+                final String[] split = docId.split(":");
+                final String type = split[0];
+
+                if ("primary".equalsIgnoreCase(type)) {
+                    return Environment.getExternalStorageDirectory() + "/" + split[1];
+                }
+
+                // TODO handle non-primary volumes
+            }
+            // DownloadsProvider
+            else if (isDownloadsDocument(uri)) {
+
+                final String id = DocumentsContract.getDocumentId(uri);
+                final Uri contentUri = ContentUris.withAppendedId(
+                        Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
+
+                return getDataColumn(context, contentUri, null, null);
+            }
+            // MediaProvider
+            else if (isMediaDocument(uri)) {
+                final String docId = DocumentsContract.getDocumentId(uri);
+                final String[] split = docId.split(":");
+                final String type = split[0];
+
+                Uri contentUri = null;
+                if ("image".equals(type)) {
+                    contentUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
+                } else if ("video".equals(type)) {
+                    contentUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
+                } else if ("audio".equals(type)) {
+                    contentUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;
+                }
+
+                final String selection = "_id=?";
+                final String[] selectionArgs = new String[] {
+                        split[1]
+                };
+
+                return getDataColumn(context, contentUri, selection, selectionArgs);
+            }
+        }
+        // MediaStore (and general)
+        else if ("content".equalsIgnoreCase(uri.getScheme())) {
+
+            // Return the remote address
+            if (isGooglePhotosUri(uri))
+                return uri.getLastPathSegment();
+
+            return getDataColumn(context, uri, null, null);
+        }
+        // File
+        else if ("file".equalsIgnoreCase(uri.getScheme())) {
+            return uri.getPath();
+        }
+
+        return null;
+    }
+
+    public static String getDataColumn(Context context, Uri uri, String selection,
+                                       String[] selectionArgs) {
+
+        Cursor cursor = null;
+        final String column = "_data";
+        final String[] projection = {
+                column
+        };
+
+        try {
+            cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs,
+                    null);
+            if (cursor != null && cursor.moveToFirst()) {
+                final int index = cursor.getColumnIndexOrThrow(column);
+                return cursor.getString(index);
+            }
+        } finally {
+            if (cursor != null)
+                cursor.close();
+        }
+        return null;
+    }
+
+
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is ExternalStorageProvider.
+     */
+    public static boolean isExternalStorageDocument(Uri uri) {
+        return "com.android.externalstorage.documents".equals(uri.getAuthority());
+    }
+
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is DownloadsProvider.
+     */
+    public static boolean isDownloadsDocument(Uri uri) {
+        return "com.android.providers.downloads.documents".equals(uri.getAuthority());
+    }
+
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is MediaProvider.
+     */
+    public static boolean isMediaDocument(Uri uri) {
+        return "com.android.providers.media.documents".equals(uri.getAuthority());
+    }
+
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is Google Photos.
+     */
+    public static boolean isGooglePhotosUri(Uri uri) {
+        return "com.google.android.apps.photos.content".equals(uri.getAuthority());
+    }
+}


### PR DESCRIPTION
Allows user to pass URI of file if using android 11 or higher. This will read the file and copy it into a temporary location so we can work with the MBTiles file. Hopefully the user does this from a thread because this can take a while depending on the size of the MBTiles file.