### PR TITLE
Changed osmdroid-mapsforge MAX ZOOM value to 29

### DIFF
--- a/osmdroid-mapsforge/src/main/java/org/osmdroid/mapsforge/MapsForgeTileSource.java
+++ b/osmdroid-mapsforge/src/main/java/org/osmdroid/mapsforge/MapsForgeTileSource.java
@@ -36,7 +36,7 @@ public class MapsForgeTileSource extends BitmapTileSourceBase {
 
     // Reasonable defaults ..
     public static int MIN_ZOOM = 3;
-    public static int MAX_ZOOM = 20;
+    public static int MAX_ZOOM = 29;
     public static final int TILE_SIZE_PIXELS = 256;
     private final DisplayModel model = new DisplayModel();
     private final float scale = DisplayModel.getDefaultUserScaleFactor();


### PR DESCRIPTION
As discussed in this #1764 issue, osmdroid-mapsforge plugin could provide max zoom as it is provided by osmdroid plugin. 

Currently, when using osmdroid with mapsforge we are limited to use max zoom as 20 because of this [lower constant value](https://github.com/osmdroid/osmdroid/blob/master/osmdroid-mapsforge/src/main/java/org/osmdroid/mapsforge/MapsForgeTileSource.java#L39) and not able to use max zoom as 29 which is provided from osmdroid. 

As discussed in the issue, I tested if the osmdroid-mapsforge plugin can work with max zoom = 29 and it works perfectly.