### PR TITLE
Only zoom in/out on ACTION_UP event

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/views/CustomZoomButtonsDisplay.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/CustomZoomButtonsDisplay.java
@@ -228,8 +228,7 @@ public class CustomZoomButtonsDisplay {
      * @since 6.1.3
      */
     public boolean isTouched(final MotionEvent pMotionEvent, final boolean pInOrOut) {
-        int action = pMotionEvent.getAction();
-        if (action == MotionEvent.ACTION_DOWN || action == MotionEvent.ACTION_UP) {
+        if (pMotionEvent.getAction() == MotionEvent.ACTION_UP) {
             return isTouched((int) pMotionEvent.getX(), (int) pMotionEvent.getY(), pInOrOut);
         } else {
             return false;


### PR DESCRIPTION
This fixes issue #1733. I tested this by building the osmdroid-android project and manually loading the resulting library into my app. The unwanted behavior described in #1733 is gone: Only one zoom takes place when I tap long on the zoom in or out button.