### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-    compile 'org.osmdroid:osmdroid-android:<VERSION>'
+    implementation 'org.osmdroid:osmdroid-android:<VERSION>'
 }
 ```
 
@@ -64,7 +64,7 @@ repositories {
     }
 }
 dependencies {
-    compile 'org.osmdroid:osmdroid-android:<VERSION>-SNAPSHOT:debug@aar'
+    implementation 'org.osmdroid:osmdroid-android:<VERSION>-SNAPSHOT:debug@aar'
 }
 ```
 


### PR DESCRIPTION
"compile" tag changed to "implementation".
compile is deprecated; replace with implementation