### PR TITLE
Support custom TileWriter implementation in MapTileProviderBasic

### DIFF
--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/tilesources/SampleLieFi.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/tilesources/SampleLieFi.java
@@ -11,7 +11,6 @@ import org.osmdroid.samplefragments.BaseSampleFragment;
 import org.osmdroid.tileprovider.IMapTileProviderCallback;
 import org.osmdroid.tileprovider.IRegisterReceiver;
 import org.osmdroid.tileprovider.MapTileProviderArray;
-import org.osmdroid.tileprovider.MapTileProviderBasic;
 import org.osmdroid.tileprovider.modules.CantContinueException;
 import org.osmdroid.tileprovider.modules.IFilesystemCache;
 import org.osmdroid.tileprovider.modules.INetworkAvailablityCheck;
@@ -20,8 +19,11 @@ import org.osmdroid.tileprovider.modules.MapTileAssetsProvider;
 import org.osmdroid.tileprovider.modules.MapTileDownloader;
 import org.osmdroid.tileprovider.modules.MapTileFileArchiveProvider;
 import org.osmdroid.tileprovider.modules.MapTileFileStorageProviderBase;
+import org.osmdroid.tileprovider.modules.MapTileFilesystemProvider;
+import org.osmdroid.tileprovider.modules.MapTileSqlCacheProvider;
 import org.osmdroid.tileprovider.modules.NetworkAvailabliltyCheck;
 import org.osmdroid.tileprovider.modules.SqlTileWriter;
+import org.osmdroid.tileprovider.modules.TileWriter;
 import org.osmdroid.tileprovider.tilesource.ITileSource;
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
 import org.osmdroid.tileprovider.util.SimpleRegisterReceiver;
@@ -90,8 +92,12 @@ public class SampleLieFi extends BaseSampleFragment {
                     pRegisterReceiver, pContext.getAssets(), pTileSource);
             mTileProviderList.add(assetsProvider);
 
-            final MapTileFileStorageProviderBase cacheProvider =
-                    MapTileProviderBasic.getMapTileFileStorageProviderBase(pRegisterReceiver, pTileSource, tileWriter);
+            MapTileFileStorageProviderBase cacheProvider;
+            if (tileWriter instanceof TileWriter) {
+                cacheProvider = new MapTileFilesystemProvider(pRegisterReceiver, pTileSource);
+            } else {
+                cacheProvider = new MapTileSqlCacheProvider(pRegisterReceiver, pTileSource);
+            }
             mTileProviderList.add(cacheProvider);
 
             final MapTileFileArchiveProvider archiveProvider = new MapTileFileArchiveProvider(

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderBasic.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/MapTileProviderBasic.java
@@ -203,15 +203,18 @@ public class MapTileProviderBasic extends MapTileProviderArray implements IMapTi
 	 * @since 6.0.3
 	 * cf. https://github.com/osmdroid/osmdroid/issues/1172
 	 */
-	public static MapTileFileStorageProviderBase getMapTileFileStorageProviderBase(
+	protected MapTileFileStorageProviderBase getMapTileFileStorageProviderBase(
 			final IRegisterReceiver pRegisterReceiver,
 			final ITileSource pTileSource,
 			final IFilesystemCache pTileWriter
 	) {
 		if (pTileWriter instanceof TileWriter) {
-			return new MapTileFilesystemProvider(pRegisterReceiver, pTileSource);
+			return new MapTileFilesystemProvider(pRegisterReceiver, pTileSource, (TileWriter) pTileWriter);
+		} else if (pTileWriter instanceof SqlTileWriter) {
+			return new MapTileSqlCacheProvider(pRegisterReceiver, pTileSource, (SqlTileWriter) pTileWriter);
+		} else {
+			return new MapTileSqlCacheProvider(pRegisterReceiver, pTileSource);
 		}
-		return new MapTileSqlCacheProvider(pRegisterReceiver, pTileSource);
 	}
 
 	/**

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileFilesystemProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileFilesystemProvider.java
@@ -32,7 +32,7 @@ public class MapTileFilesystemProvider extends MapTileFileStorageProviderBase {
     // Fields
     // ===========================================================
 
-    private final TileWriter mWriter = new TileWriter();
+    private TileWriter mWriter = new TileWriter();
     private final AtomicReference<ITileSource> mTileSource = new AtomicReference<ITileSource>();
 
     // ===========================================================
@@ -68,6 +68,19 @@ public class MapTileFilesystemProvider extends MapTileFileStorageProviderBase {
         setTileSource(pTileSource);
 
         mWriter.setMaximumCachedFileAge(pMaximumCachedFileAge);
+    }
+
+    /**
+     * Constructor that supports injecting custom {@link TileWriter} implementation.
+     *
+     * @since 6.1.15
+     */
+    public MapTileFilesystemProvider(final IRegisterReceiver pRegisterReceiver,
+                                     final ITileSource aTileSource,
+                                     final TileWriter tileWriter) {
+        this(pRegisterReceiver, aTileSource);
+
+        this.mWriter = tileWriter;
     }
     // ===========================================================
     // Getter & Setter

--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileSqlCacheProvider.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/modules/MapTileSqlCacheProvider.java
@@ -33,7 +33,7 @@ public class MapTileSqlCacheProvider extends MapTileFileStorageProviderBase {
     // ===========================================================
 
     private final AtomicReference<ITileSource> mTileSource = new AtomicReference<ITileSource>();
-    private SqlTileWriter mWriter;
+    private SqlTileWriter mWriter = new SqlTileWriter();
     private static final String[] columns = {DatabaseFileArchive.COLUMN_TILE, SqlTileWriter.COLUMN_EXPIRES};
 
     // ===========================================================
@@ -57,7 +57,19 @@ public class MapTileSqlCacheProvider extends MapTileFileStorageProviderBase {
                 Configuration.getInstance().getTileFileSystemMaxQueueSize());
 
         setTileSource(pTileSource);
-        mWriter = new SqlTileWriter();
+    }
+
+    /**
+     * Constructor that supports injecting custom {@link SqlTileWriter} implementation.
+     *
+     * @since 6.1.15
+     */
+    public MapTileSqlCacheProvider(final IRegisterReceiver pRegisterReceiver,
+                                   final ITileSource pTileSource,
+                                   final SqlTileWriter pTileWriter) {
+        this(pRegisterReceiver, pTileSource);
+
+        mWriter = pTileWriter;
     }
 
     // ===========================================================
@@ -110,7 +122,6 @@ public class MapTileSqlCacheProvider extends MapTileFileStorageProviderBase {
     protected void onMediaUnmounted() {
         if (mWriter != null)
             mWriter.onDetach();
-        mWriter = new SqlTileWriter();
     }
 
     @Override

--- a/osmdroid-geopackage/src/main/java/org/osmdroid/gpkg/tiles/raster/GeoPackageProvider.java
+++ b/osmdroid-geopackage/src/main/java/org/osmdroid/gpkg/tiles/raster/GeoPackageProvider.java
@@ -11,6 +11,9 @@ import org.osmdroid.tileprovider.MapTileProviderArray;
 import org.osmdroid.tileprovider.MapTileProviderBasic;
 import org.osmdroid.tileprovider.modules.IFilesystemCache;
 import org.osmdroid.tileprovider.modules.INetworkAvailablityCheck;
+import org.osmdroid.tileprovider.modules.MapTileFileStorageProviderBase;
+import org.osmdroid.tileprovider.modules.MapTileFilesystemProvider;
+import org.osmdroid.tileprovider.modules.MapTileSqlCacheProvider;
 import org.osmdroid.tileprovider.modules.NetworkAvailabliltyCheck;
 import org.osmdroid.tileprovider.modules.SqlTileWriter;
 import org.osmdroid.tileprovider.modules.TileWriter;
@@ -62,7 +65,14 @@ public class GeoPackageProvider extends MapTileProviderArray implements IMapTile
             }
         }
 
-        mTileProviderList.add(MapTileProviderBasic.getMapTileFileStorageProviderBase(pRegisterReceiver, pTileSource, tileWriter));
+        MapTileFileStorageProviderBase cacheProvider;
+        if (tileWriter instanceof TileWriter) {
+            cacheProvider = new MapTileFilesystemProvider(pRegisterReceiver, pTileSource);
+        } else {
+            cacheProvider = new MapTileSqlCacheProvider(pRegisterReceiver, pTileSource);
+        }
+        mTileProviderList.add(cacheProvider);
+
         geopackage = new GeoPackageMapTileModuleProvider(databases, pContext, tileWriter);
         mTileProviderList.add(geopackage);
 


### PR DESCRIPTION
https://github.com/osmdroid/osmdroid/issues/1839

### Problem

1. Even though it has a method to customize `MapTileFileStorageProviderBase`, it's static so it can't be overwritten
2. The passed `IFilesystemCache` parameter doesn't get injected into the corresponding `CacheProvider`

That means you have to hard copy at least 4 classes to make this work.

### Solution

1. Make `MapTileProviderBasic.getMapTileFileStorageProviderBase(...)` protected instead of static.
4. Enable `MapTileFilesystemProvider` and `MapTileSqlCacheProvider` to inject custom `TileWriter` implementation
