### PR TITLE
Android-Support to AndroidX Upgrade

### DIFF
--- a/OpenStreetMapViewer/build.gradle
+++ b/OpenStreetMapViewer/build.gradle
@@ -98,8 +98,8 @@ dependencies {
     implementation 'com.squareup.leakcanary:leakcanary-android:2.2'
 
     //on device testing
-    androidTestImplementation 'androidx.multidex:multidex:2.0.1'
-    androidTestImplementation "androidx.annotation:annotation:1.5.0"
+    androidTestImplementation 'androidx.multidex:multidex:2.0.0'
+    androidTestImplementation "androidx.annotation:annotation:1.3.0"
 
 
     androidTestImplementation "androidx.test:runner:1.4.0"

--- a/OpenStreetMapViewer/build.gradle
+++ b/OpenStreetMapViewer/build.gradle
@@ -88,7 +88,7 @@ dependencies {
     implementation "com.google.android.material:material:1.6.1" //needed for UI menuing
     implementation "androidx.cardview:cardview:1.0.0"
     implementation "androidx.recyclerview:recyclerview:1.2.1"
-    implementation 'com.android.support:multidex:1.0.3'
+    implementation 'androidx.multidex:multidex:2.0.1'
 
     implementation "androidx.appcompat:appcompat:1.4.2"
     //crash logging

--- a/OpenStreetMapViewer/build.gradle
+++ b/OpenStreetMapViewer/build.gradle
@@ -109,7 +109,7 @@ dependencies {
     // Optional -- UI testing with UI Automator
     androidTestImplementation "androidx.test.uiautomator:uiautomator:2.2.0"
     // Optional -- UI testing with Compose
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4:1.2.1"
+    androidTestImplementation "androidx.compose.ui:ui-test-junit4:1.1.0"
 }
 
 

--- a/OpenStreetMapViewer/build.gradle
+++ b/OpenStreetMapViewer/build.gradle
@@ -1,4 +1,3 @@
-
 description = 'OpenMap in the Play Store, the example app for using osmdroid'
 
 apply plugin: 'com.android.application'
@@ -6,7 +5,7 @@ apply from: "$rootDir/gradle/android-signing.gradle"
 
 
 group = project.property("pom.groupId")
-version =  project.property("pom.version")
+version = project.property("pom.version")
 
 android {
     compileSdkVersion findProperty('android.compileSdkVersion').toInteger()
@@ -14,7 +13,6 @@ android {
 
     defaultConfig {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-
 
 
         applicationId "org.osmdroid"
@@ -44,18 +42,17 @@ android {
             // All the usual Gradle options.
             testLogging {
                 events "passed", "skipped", "failed", "standardOut", "standardError"
-                outputs.upToDateWhen {false}
+                outputs.upToDateWhen { false }
                 showStandardStreams = true
             }
         }
     }
-    
-    packagingOptions{
+
+    packagingOptions {
         pickFirst "androidsupportmultidexversion.txt"
         pickFirst "META-INF/AL2.0"
         pickFirst "META-INF/LGPL2.1"
     }
-
 
 
 }
@@ -67,12 +64,12 @@ dependencies {
     //are not longer resolved...
 
     //osmdroid-mapsforge
-    implementation 'org.mapsforge:mapsforge-map-android:0.11.0'
-    implementation 'org.mapsforge:mapsforge-map:0.11.0'
+    implementation 'org.mapsforge:mapsforge-map-android:0.18.0'
+    implementation 'org.mapsforge:mapsforge-map:0.18.0'
     implementation 'org.mapsforge:mapsforge-themes:0.11.0'
 
 
-    implementation "com.android.support:support-v4:${project.property('android-support.version')}"
+    implementation "androidx.legacy:legacy-support-v4:1.0.0"
     implementation project(':osmdroid-android')
     implementation project(':osmdroid-geopackage')
     implementation project(':osmdroid-mapsforge')
@@ -88,12 +85,12 @@ dependencies {
     implementation group: 'com.opencsv', name: 'opencsv', version: '4.4'
 
     //usual android stuff
-    implementation "com.android.support:design:${project.property('android-support.version')}" //needed for UI menuing
-    implementation "com.android.support:cardview-v7:${project.property('android-support.version')}"  //needed for samples only
-    implementation "com.android.support:recyclerview-v7:${project.property('android-support.version')}" //needed for samples only
+    implementation "com.google.android.material:material:1.6.1" //needed for UI menuing
+    implementation "androidx.cardview:cardview:1.0.0"
+    implementation "androidx.recyclerview:recyclerview:1.2.1"
     implementation 'com.android.support:multidex:1.0.3'
 
-    implementation "com.android.support:appcompat-v7:${project.property('android-support.version')}" //needed for UI menuing
+    implementation "androidx.appcompat:appcompat:1.4.2"
     //crash logging
     implementation 'ch.acra:acra:4.7.0'
 
@@ -101,8 +98,8 @@ dependencies {
     implementation 'com.squareup.leakcanary:leakcanary-android:2.2'
 
     //on device testing
-    androidTestImplementation  'com.android.support:multidex:1.0.3'
-    androidTestImplementation  "com.android.support:support-annotations:${project.property('android-support.version')}"
+    androidTestImplementation 'androidx.multidex:multidex:2.0.1'
+    androidTestImplementation "androidx.annotation:annotation:1.5.0"
 
 
     androidTestImplementation "androidx.test:runner:1.4.0"
@@ -112,7 +109,7 @@ dependencies {
     // Optional -- UI testing with UI Automator
     androidTestImplementation "androidx.test.uiautomator:uiautomator:2.2.0"
     // Optional -- UI testing with Compose
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4:1.1.1"
+    androidTestImplementation "androidx.compose.ui:ui-test-junit4:1.2.1"
 }
 
 
@@ -120,7 +117,7 @@ dependencies {
 
 android.applicationVariants.all { variant ->
     if (variant.getBuildType().name == "debug") {
-        task "configDevice${variant.name.capitalize()}" (type: Exec){
+        task "configDevice${variant.name.capitalize()}"(type: Exec) {
             dependsOn variant.install
 
             group = 'nameofyourtaskgroup'
@@ -137,7 +134,7 @@ android.applicationVariants.all { variant ->
 
 android.applicationVariants.all { variant ->
     if (variant.getBuildType().name == "debug") {
-        task "configDevice2${variant.name.capitalize()}" (type: Exec){
+        task "configDevice2${variant.name.capitalize()}"(type: Exec) {
             dependsOn variant.install
 
             group = 'nameofyourtaskgroup'

--- a/OpenStreetMapViewer/src/androidTest/java/org/osmdroid/test/ExtraSamplesTest.java
+++ b/OpenStreetMapViewer/src/androidTest/java/org/osmdroid/test/ExtraSamplesTest.java
@@ -9,8 +9,6 @@
 
 package org.osmdroid.test;
 
-import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentManager;
 import android.util.Log;
 
 import junit.framework.Assert;
@@ -29,6 +27,8 @@ import org.osmdroid.tileprovider.util.Counters;
 
 import java.util.Random;
 
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
 import androidx.test.rule.ActivityTestRule;
 
 import static org.junit.Assert.assertNotNull;

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/Bug1783Activity.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/Bug1783Activity.java
@@ -1,13 +1,14 @@
 package org.osmdroid;
 
 import android.os.Bundle;
-import android.support.v4.app.DialogFragment;
-import android.support.v4.app.FragmentActivity;
 import android.view.View;
 import android.widget.Button;
 
 import org.osmdroid.bugtestfragments.Bug1783MyLocationOverlayNPE;
 import org.osmdroid.model.IBaseActivity;
+
+import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.FragmentActivity;
 
 public class Bug1783Activity extends FragmentActivity implements IBaseActivity {
 

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/BugsTestingActivity.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/BugsTestingActivity.java
@@ -1,10 +1,6 @@
 package org.osmdroid;
 
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentManager;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
 import android.view.KeyEvent;
 
 import org.osmdroid.bugtestfragments.BugFactory;
@@ -16,6 +12,11 @@ import org.osmdroid.views.MapView;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
 
 /**
  * Created by alex on 6/29/16.

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/ExtraSamplesActivity.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/ExtraSamplesActivity.java
@@ -1,10 +1,6 @@
 package org.osmdroid;
 
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentManager;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
 import android.view.KeyEvent;
 
 import org.osmdroid.samplefragments.BaseSampleFragment;
@@ -13,6 +9,11 @@ import org.osmdroid.samplefragments.ui.SamplesMenuFragment;
 import org.osmdroid.views.MapView;
 
 import java.util.Collections;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
 
 public class ExtraSamplesActivity extends AppCompatActivity {
     public static final String SAMPLES_FRAGMENT_TAG = "org.osmdroid.SAMPLES_FRAGMENT_TAG";

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/LicenseActivity.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/LicenseActivity.java
@@ -1,13 +1,14 @@
 package org.osmdroid;
 
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Spinner;
 import android.widget.TextView;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
 
 /**
  * created on 1/14/2017.

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/MainActivity.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/MainActivity.java
@@ -11,9 +11,6 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Environment;
 import android.preference.PreferenceManager;
-import android.support.v7.app.AlertDialog;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
 import android.text.format.Formatter;
 import android.view.View;
 import android.widget.AdapterView;
@@ -32,6 +29,10 @@ import org.osmdroid.tileprovider.modules.SqlTileWriter;
 
 import java.io.File;
 import java.util.ArrayList;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
 
 public class MainActivity extends AppCompatActivity implements AdapterView.OnItemClickListener {
 

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/OsmApplication.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/OsmApplication.java
@@ -3,8 +3,6 @@ package org.osmdroid;
 import android.content.Context;
 import android.os.Environment;
 import android.os.StrictMode;
-import android.support.multidex.MultiDex;
-import android.support.multidex.MultiDexApplication;
 import android.util.Log;
 
 import org.acra.ACRA;
@@ -18,6 +16,9 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
+
+import androidx.multidex.MultiDex;
+import androidx.multidex.MultiDexApplication;
 
 /**
  * This is the base application for the sample app. We only use to catch errors during development cycles

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/PreferenceActivity.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/PreferenceActivity.java
@@ -6,8 +6,6 @@ import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
 import android.text.Editable;
 import android.text.InputType;
 import android.text.TextWatcher;
@@ -29,6 +27,9 @@ import org.osmdroid.tileprovider.util.StorageUtils;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
 
 /**
  * OK so why is here?

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/StarterMapActivity.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/StarterMapActivity.java
@@ -7,10 +7,11 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.net.ConnectivityManager;
 import android.os.Bundle;
-import android.support.v4.app.FragmentManager;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
 import android.view.KeyEvent;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.fragment.app.FragmentManager;
 
 /**
  * Default map view activity.

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/StarterMapFragment.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/StarterMapFragment.java
@@ -6,7 +6,6 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
 import android.util.DisplayMetrics;
 import android.view.InputDevice;
 import android.view.LayoutInflater;
@@ -30,6 +29,8 @@ import org.osmdroid.views.overlay.compass.InternalCompassOrientationProvider;
 import org.osmdroid.views.overlay.gestures.RotationGestureOverlay;
 import org.osmdroid.views.overlay.mylocation.GpsMyLocationProvider;
 import org.osmdroid.views.overlay.mylocation.MyLocationNewOverlay;
+
+import androidx.fragment.app.Fragment;
 
 /**
  * Default map view activity.

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/bugtestfragments/Bug1783MyLocationOverlayNPE.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/bugtestfragments/Bug1783MyLocationOverlayNPE.java
@@ -1,13 +1,13 @@
 package org.osmdroid.bugtestfragments;
 
 import android.os.Bundle;
-import android.support.v4.app.DialogFragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.overlay.mylocation.MyLocationNewOverlay;
+import androidx.fragment.app.DialogFragment;
 
 
 /**

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/bugtestfragments/SampleBug57.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/bugtestfragments/SampleBug57.java
@@ -1,7 +1,6 @@
 package org.osmdroid.bugtestfragments;
 
 import android.os.Bundle;
-import android.support.v4.app.FragmentManager;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -12,6 +11,8 @@ import org.osmdroid.ExtraSamplesActivity;
 import org.osmdroid.R;
 import org.osmdroid.samplefragments.BaseSampleFragment;
 import org.osmdroid.views.MapView;
+
+import androidx.fragment.app.FragmentManager;
 
 
 /**

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/bugtestfragments/SampleBug57Step2.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/bugtestfragments/SampleBug57Step2.java
@@ -2,12 +2,13 @@ package org.osmdroid.bugtestfragments;
 
 
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
 import org.osmdroid.R;
+
+import androidx.fragment.app.Fragment;
 
 /**
  * A simple {@link Fragment} subclass.

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/bugtestfragments/WeathForceActivity.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/bugtestfragments/WeathForceActivity.java
@@ -10,7 +10,6 @@ import android.location.Location;
 import android.location.LocationListener;
 import android.location.LocationManager;
 import android.os.Bundle;
-import android.support.v4.app.ActivityCompat;
 import android.util.Log;
 import android.view.Surface;
 import android.view.WindowManager;
@@ -29,6 +28,8 @@ import org.osmdroid.views.overlay.compass.IOrientationConsumer;
 import org.osmdroid.views.overlay.compass.IOrientationProvider;
 import org.osmdroid.views.overlay.compass.InternalCompassOrientationProvider;
 import org.osmdroid.views.overlay.mylocation.MyLocationNewOverlay;
+
+import androidx.core.app.ActivityCompat;
 
 /**
  * http://stackoverflow.com/q/40112165/1203182

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/data/DataCountryLoader.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/data/DataCountryLoader.java
@@ -1,10 +1,11 @@
 package org.osmdroid.data;
 
 import android.content.Context;
-import android.support.annotation.RawRes;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+
+import androidx.annotation.RawRes;
 
 /**
  * {@link DataCountry} json loader

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/data/DataLoader.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/data/DataLoader.java
@@ -1,7 +1,6 @@
 package org.osmdroid.data;
 
 import android.content.Context;
-import android.support.annotation.RawRes;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -12,6 +11,8 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+
+import androidx.annotation.RawRes;
 
 /**
  * {@link DataRegion} json loader

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/data/DataRegionLoader.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/data/DataRegionLoader.java
@@ -1,11 +1,12 @@
 package org.osmdroid.data;
 
 import android.content.Context;
-import android.support.annotation.RawRes;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.osmdroid.util.BoundingBox;
+
+import androidx.annotation.RawRes;
 
 /**
  * {@link DataRegion} json loader

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/debug/CacheAnalyzerActivity.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/debug/CacheAnalyzerActivity.java
@@ -4,8 +4,6 @@ import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
@@ -21,6 +19,9 @@ import org.osmdroid.tileprovider.util.Counters;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
 
 /**
  * A debug utility to show various cache metrics and management

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/debug/browser/CacheBrowserActivity.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/debug/browser/CacheBrowserActivity.java
@@ -1,8 +1,6 @@
 package org.osmdroid.debug.browser;
 
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
 import android.widget.ListView;
 import android.widget.TextView;
 
@@ -11,6 +9,9 @@ import org.osmdroid.R;
 import org.osmdroid.debug.model.SqlTileWriterExt;
 import org.osmdroid.debug.util.FileDateUtil;
 import org.osmdroid.intro.StorageAdapter;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
 
 /**
  * A simple view for browsing the osmdroid tile cache database

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/diag/DiagnosticsActivity.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/diag/DiagnosticsActivity.java
@@ -12,9 +12,6 @@ import android.location.LocationListener;
 import android.location.LocationManager;
 import android.location.LocationProvider;
 import android.os.Bundle;
-import android.support.v4.content.ContextCompat;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
 import android.view.View;
 import android.widget.TextView;
 
@@ -23,6 +20,10 @@ import org.osmdroid.tileprovider.util.StorageUtils;
 
 import java.util.Iterator;
 import java.util.List;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.core.content.ContextCompat;
 
 /**
  * created on 2/6/2018.

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/intro/AboutFragment.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/intro/AboutFragment.java
@@ -3,12 +3,13 @@ package org.osmdroid.intro;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
 import org.osmdroid.R;
+
+import androidx.fragment.app.Fragment;
 
 /**
  * created on 1/5/2017.

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/intro/DataUseWarning.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/intro/DataUseWarning.java
@@ -1,12 +1,13 @@
 package org.osmdroid.intro;
 
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
 import org.osmdroid.R;
+
+import androidx.fragment.app.Fragment;
 
 /**
  * created on 1/12/2017.

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/intro/IntroActivity.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/intro/IntroActivity.java
@@ -4,14 +4,15 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
-import android.support.v4.app.FragmentActivity;
-import android.support.v4.view.ViewPager;
 import android.view.View;
 import android.widget.Button;
 import android.widget.ProgressBar;
 
 import org.osmdroid.MainActivity;
 import org.osmdroid.R;
+
+import androidx.fragment.app.FragmentActivity;
+import androidx.viewpager.widget.ViewPager;
 
 
 /**

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/intro/IntroSliderAdapter.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/intro/IntroSliderAdapter.java
@@ -1,9 +1,10 @@
 package org.osmdroid.intro;
 
-import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentManager;
-import android.support.v4.app.FragmentStatePagerAdapter;
 import android.view.ViewGroup;
+
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
+import androidx.fragment.app.FragmentStatePagerAdapter;
 
 /**
  * Created by alex on 10/22/16.

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/intro/LogoFragment.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/intro/LogoFragment.java
@@ -1,12 +1,13 @@
 package org.osmdroid.intro;
 
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
 import org.osmdroid.R;
+
+import androidx.fragment.app.Fragment;
 
 /**
  * created on 1/5/2017.

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/intro/PermissionsFragment.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/intro/PermissionsFragment.java
@@ -5,13 +5,12 @@ import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
-import android.support.design.widget.Snackbar;
-import android.support.v4.app.Fragment;
-import android.support.v4.content.ContextCompat;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Toast;
+
+import com.google.android.material.snackbar.Snackbar;
 
 import org.osmdroid.R;
 import org.osmdroid.config.Configuration;
@@ -20,6 +19,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import androidx.core.content.ContextCompat;
+import androidx.fragment.app.Fragment;
 
 /**
  * created on 1/5/2017.

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/intro/StoragePreferenceFragment.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/intro/StoragePreferenceFragment.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
-import android.support.v4.app.Fragment;
 import android.text.Editable;
 import android.text.InputType;
 import android.text.TextWatcher;
@@ -24,6 +23,8 @@ import org.osmdroid.tileprovider.util.StorageUtils;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+
+import androidx.fragment.app.Fragment;
 
 import static org.osmdroid.intro.StorageAdapter.readableFileSize;
 

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/intro/TileSourceWarnings.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/intro/TileSourceWarnings.java
@@ -1,12 +1,13 @@
 package org.osmdroid.intro;
 
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
 import org.osmdroid.R;
+
+import androidx.fragment.app.Fragment;
 
 /**
  * created on 1/12/2017.

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/BaseSampleFragment.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/BaseSampleFragment.java
@@ -4,7 +4,6 @@ import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.InputDevice;
@@ -24,6 +23,8 @@ import org.osmdroid.util.GeoPoint;
 import org.osmdroid.util.TileSystem;
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.overlay.CopyrightOverlay;
+
+import androidx.fragment.app.Fragment;
 
 public abstract class BaseSampleFragment extends Fragment {
     private static int MENU_LAST_ID = Menu.FIRST; // Always set to last unused id

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleItemizedOverlayMultiClick.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleItemizedOverlayMultiClick.java
@@ -3,7 +3,6 @@ package org.osmdroid.samplefragments.data;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.graphics.Color;
-import android.support.v7.app.AlertDialog;
 import android.widget.Toast;
 
 import org.osmdroid.api.IGeoPoint;
@@ -18,6 +17,8 @@ import org.osmdroid.views.overlay.OverlayItem;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import androidx.appcompat.app.AlertDialog;
 
 /**
  * @author Fabrice Fontaine

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleMapSnapshot.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleMapSnapshot.java
@@ -2,8 +2,6 @@ package org.osmdroid.samplefragments.data;
 
 import android.graphics.Bitmap;
 import android.os.Bundle;
-import android.support.v7.widget.LinearLayoutManager;
-import android.support.v7.widget.RecyclerView;
 import android.util.DisplayMetrics;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -31,6 +29,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 
 /**
  * Demo with the new "MapSnapshot" feature - a RecyclerView with bitmap maps of all USA states

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleMarkerMultiClick.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleMarkerMultiClick.java
@@ -2,7 +2,6 @@ package org.osmdroid.samplefragments.data;
 
 import android.content.DialogInterface;
 import android.graphics.drawable.Drawable;
-import android.support.v7.app.AlertDialog;
 
 import org.osmdroid.R;
 import org.osmdroid.api.IGeoPoint;
@@ -16,6 +15,8 @@ import org.osmdroid.views.overlay.Marker;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import androidx.appcompat.app.AlertDialog;
 
 /**
  * @author Fabrice Fontaine

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/drawing/ShowAdvancedPolylineStylesInvalidation.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/drawing/ShowAdvancedPolylineStylesInvalidation.java
@@ -3,7 +3,6 @@ package org.osmdroid.samplefragments.drawing;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.os.Bundle;
-import android.support.annotation.Nullable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -20,6 +19,8 @@ import org.osmdroid.views.overlay.advancedpolyline.MonochromaticPaintList;
 import org.osmdroid.views.overlay.advancedpolyline.PolychromaticPaintList;
 
 import java.util.ArrayList;
+
+import androidx.annotation.Nullable;
 
 
 /**

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/layers/LayerManager.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/layers/LayerManager.java
@@ -1,7 +1,6 @@
 package org.osmdroid.samplefragments.layers;
 
 import android.os.Bundle;
-import android.support.v4.widget.DrawerLayout;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -29,6 +28,8 @@ import org.osmdroid.views.overlay.Polyline;
 
 import java.text.DecimalFormat;
 import java.util.ArrayList;
+
+import androidx.drawerlayout.widget.DrawerLayout;
 
 /**
  * Views the current layers in a navigation drawer layout

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/layers/OverlayAdapter.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/layers/OverlayAdapter.java
@@ -1,7 +1,6 @@
 package org.osmdroid.samplefragments.layers;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -12,6 +11,8 @@ import org.osmdroid.R;
 import org.osmdroid.views.overlay.Overlay;
 import org.osmdroid.views.overlay.OverlayManager;
 import org.osmdroid.views.overlay.OverlayWithIW;
+
+import androidx.annotation.NonNull;
 
 /**
  * created on 2/18/2018.

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/layouts/MapInAViewPagerFragment.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/layouts/MapInAViewPagerFragment.java
@@ -2,8 +2,6 @@ package org.osmdroid.samplefragments.layouts;
 
 import android.app.Activity;
 import android.os.Bundle;
-import android.support.v4.view.PagerAdapter;
-import android.support.v4.view.ViewPager;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -12,6 +10,9 @@ import android.view.ViewGroup;
 import org.osmdroid.R;
 import org.osmdroid.samplefragments.BaseSampleFragment;
 import org.osmdroid.samplefragments.layouts.pager.MapSliderAdapter;
+
+import androidx.viewpager.widget.PagerAdapter;
+import androidx.viewpager.widget.ViewPager;
 
 /**
  * Created by alex on 10/22/16.

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/layouts/RecyclerCardView.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/layouts/RecyclerCardView.java
@@ -1,8 +1,6 @@
 package org.osmdroid.samplefragments.layouts;
 
 import android.os.Bundle;
-import android.support.v7.widget.LinearLayoutManager;
-import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -14,6 +12,9 @@ import org.osmdroid.samplefragments.layouts.rec.CustomRecycler;
 import org.osmdroid.samplefragments.layouts.rec.Info;
 
 import java.util.ArrayList;
+
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 
 /**
  * created on 1/13/2017.

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/layouts/StreetAddressFragment.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/layouts/StreetAddressFragment.java
@@ -2,9 +2,6 @@ package org.osmdroid.samplefragments.layouts;
 
 import android.content.Context;
 import android.os.Bundle;
-import android.support.v7.widget.GridLayoutManager;
-import android.support.v7.widget.LinearLayoutManager;
-import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -13,6 +10,10 @@ import org.osmdroid.R;
 import org.osmdroid.samplefragments.BaseSampleFragment;
 import org.osmdroid.samplefragments.layouts.list.MyStreetAddressRecyclerViewAdapter;
 import org.osmdroid.samplefragments.layouts.list.dummy.DummyContent;
+
+import androidx.recyclerview.widget.GridLayoutManager;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 
 /**
  * A fragment representing a list of Items.

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/layouts/list/MyStreetAddressRecyclerViewAdapter.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/layouts/list/MyStreetAddressRecyclerViewAdapter.java
@@ -1,6 +1,5 @@
 package org.osmdroid.samplefragments.layouts.list;
 
-import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -10,6 +9,8 @@ import org.osmdroid.R;
 import org.osmdroid.samplefragments.layouts.list.dummy.DummyContent.DummyItem;
 
 import java.util.List;
+
+import androidx.recyclerview.widget.RecyclerView;
 
 /**
  * {@link RecyclerView.Adapter} that can display a {@link DummyItem} and makes a call to the

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/layouts/pager/MapSliderAdapter.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/layouts/pager/MapSliderAdapter.java
@@ -1,8 +1,8 @@
 package org.osmdroid.samplefragments.layouts.pager;
 
-import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentManager;
-import android.support.v4.app.FragmentStatePagerAdapter;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
+import androidx.fragment.app.FragmentStatePagerAdapter;
 
 /**
  * Created by alex on 10/22/16.

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/layouts/pager/SimpleTextFragment.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/layouts/pager/SimpleTextFragment.java
@@ -1,12 +1,13 @@
 package org.osmdroid.samplefragments.layouts.pager;
 
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
 import org.osmdroid.R;
+
+import androidx.fragment.app.Fragment;
 
 /**
  * Created by alex on 10/22/16.

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/layouts/pager/WebviewFragment.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/layouts/pager/WebviewFragment.java
@@ -1,13 +1,14 @@
 package org.osmdroid.samplefragments.layouts.pager;
 
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.webkit.WebView;
 
 import org.osmdroid.R;
+
+import androidx.fragment.app.Fragment;
 
 /**
  * Created by alex on 10/22/16.

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/layouts/rec/CustomRecycler.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/layouts/rec/CustomRecycler.java
@@ -8,7 +8,6 @@ package org.osmdroid.samplefragments.layouts.rec;
  */
 
 import android.content.Context;
-import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -19,6 +18,8 @@ import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.MapView;
 
 import java.util.ArrayList;
+
+import androidx.recyclerview.widget.RecyclerView;
 
 /**
  * Custom Adapter for Recycler data

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/location/SampleCustomMyLocation.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/location/SampleCustomMyLocation.java
@@ -7,12 +7,13 @@ import android.location.Location;
 import android.location.LocationListener;
 import android.location.LocationManager;
 import android.os.Bundle;
-import android.support.v4.app.ActivityCompat;
 import android.util.Log;
 
 import org.osmdroid.samplefragments.BaseSampleFragment;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.overlay.Marker;
+
+import androidx.core.app.ActivityCompat;
 
 /**
  * See https://github.com/osmdroid/osmdroid/issues/815

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/location/SampleMyLocationWithClick.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/location/SampleMyLocationWithClick.java
@@ -1,6 +1,5 @@
 package org.osmdroid.samplefragments.location;
 
-import android.support.v4.app.FragmentActivity;
 import android.util.Log;
 import android.view.MotionEvent;
 import android.widget.Toast;
@@ -9,6 +8,8 @@ import org.osmdroid.samplefragments.BaseSampleFragment;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.overlay.mylocation.MyLocationNewOverlay;
+
+import androidx.fragment.app.FragmentActivity;
 
 /**
  * created on 1/13/2017.

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/tileproviders/MapsforgeTileProviderSample.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/tileproviders/MapsforgeTileProviderSample.java
@@ -108,7 +108,7 @@ public class MapsforgeTileProviderSample extends BaseSampleFragment {
             //null is ok here, uses the default rendering theme if it's not set
             XmlRenderTheme theme = null;
             try {
-                theme = new AssetsRenderTheme(getContext().getApplicationContext(), "renderthemes/", "rendertheme-v4.xml");
+                theme = new AssetsRenderTheme(getContext().getApplicationContext().getAssets(), "renderthemes/", "rendertheme-v4.xml");
             } catch (Exception ex) {
                 ex.printStackTrace();
             }

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/tileproviders/OfflinePickerSample.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/tileproviders/OfflinePickerSample.java
@@ -213,7 +213,7 @@ public class OfflinePickerSample extends BaseSampleFragment implements View.OnCl
             //fire up the forge maps...
             XmlRenderTheme theme = null;
             try {
-                theme = new AssetsRenderTheme(getContext().getApplicationContext(), "renderthemes/", "rendertheme-v4.xml");
+                theme = new AssetsRenderTheme(getContext().getApplicationContext().getAssets(), "renderthemes/", "rendertheme-v4.xml");
             } catch (Exception ex) {
                 ex.printStackTrace();
             }

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/tileproviders/SampleOfflineGemfOnly.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/tileproviders/SampleOfflineGemfOnly.java
@@ -1,8 +1,9 @@
 package org.osmdroid.samplefragments.tileproviders;
 
 import android.os.Environment;
-import android.support.design.widget.Snackbar;
 import android.widget.Toast;
+
+import com.google.android.material.snackbar.Snackbar;
 
 import org.osmdroid.samplefragments.BaseSampleFragment;
 import org.osmdroid.tileprovider.modules.IArchiveFile;

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/tileproviders/SampleOfflineOnly.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/tileproviders/SampleOfflineOnly.java
@@ -1,8 +1,9 @@
 package org.osmdroid.samplefragments.tileproviders;
 
 import android.os.Environment;
-import android.support.design.widget.Snackbar;
 import android.widget.Toast;
+
+import com.google.android.material.snackbar.Snackbar;
 
 import org.osmdroid.R;
 import org.osmdroid.samplefragments.BaseSampleFragment;

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/ui/SamplesMenuFragment.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/ui/SamplesMenuFragment.java
@@ -3,8 +3,6 @@ package org.osmdroid.samplefragments.ui;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentManager;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -26,6 +24,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
 
 /**
  * http://www.androidhive.info/2013/07/android-expandable-list-view-tutorial/

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samples/SampleWithMinimapItemizedoverlay.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samples/SampleWithMinimapItemizedoverlay.java
@@ -2,8 +2,6 @@
 package org.osmdroid.samples;
 
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout.LayoutParams;
 import android.widget.Toast;
@@ -23,6 +21,9 @@ import org.osmdroid.views.overlay.gestures.RotationGestureOverlay;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
 
 /**
  * @author Nicolas Gramlich

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samples/SampleWithTilesOverlay.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samples/SampleWithTilesOverlay.java
@@ -2,8 +2,6 @@ package org.osmdroid.samples;
 
 import android.graphics.Color;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.RelativeLayout.LayoutParams;
@@ -16,6 +14,9 @@ import org.osmdroid.views.CustomZoomButtonsController;
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.overlay.CopyrightOverlay;
 import org.osmdroid.views.overlay.TilesOverlay;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
 
 /**
  * @author Alex van der Linden

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samples/SampleWithTilesOverlayAndCustomTileSource.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samples/SampleWithTilesOverlayAndCustomTileSource.java
@@ -2,8 +2,6 @@ package org.osmdroid.samples;
 
 import android.graphics.Color;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.RelativeLayout.LayoutParams;
@@ -17,6 +15,9 @@ import org.osmdroid.views.CustomZoomButtonsController;
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.overlay.CopyrightOverlay;
 import org.osmdroid.views.overlay.TilesOverlay;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
 
 /**
  * @author Alex van der Linden

--- a/OpenStreetMapViewer/src/main/res/layout/activity_cache_analyzer.xml
+++ b/OpenStreetMapViewer/src/main/res/layout/activity_cache_analyzer.xml
@@ -3,7 +3,7 @@
     android:orientation="vertical" android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/my_toolbar"
         style="@style/ToolbarStyle"/>
 

--- a/OpenStreetMapViewer/src/main/res/layout/activity_cache_browser.xml
+++ b/OpenStreetMapViewer/src/main/res/layout/activity_cache_browser.xml
@@ -5,7 +5,7 @@
     android:layout_height="match_parent">
     <!-- header bar with some stats -->
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/my_toolbar"
         style="@style/ToolbarStyle"/>
 

--- a/OpenStreetMapViewer/src/main/res/layout/activity_diag.xml
+++ b/OpenStreetMapViewer/src/main/res/layout/activity_diag.xml
@@ -4,7 +4,7 @@
               android:layout_height="match_parent"
               android:orientation="vertical">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/my_toolbar"
         style="@style/ToolbarStyle"/>
 

--- a/OpenStreetMapViewer/src/main/res/layout/activity_extra_samples.xml
+++ b/OpenStreetMapViewer/src/main/res/layout/activity_extra_samples.xml
@@ -6,7 +6,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 tools:context="org.osmdroid.ExtraSamplesActivity">
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/my_toolbar"
         app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
         style="@style/ToolbarStyle"/>

--- a/OpenStreetMapViewer/src/main/res/layout/activity_license.xml
+++ b/OpenStreetMapViewer/src/main/res/layout/activity_license.xml
@@ -3,7 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/my_toolbar"
         style="@style/ToolbarStyle"
         />

--- a/OpenStreetMapViewer/src/main/res/layout/activity_main.xml
+++ b/OpenStreetMapViewer/src/main/res/layout/activity_main.xml
@@ -4,7 +4,7 @@
               android:layout_height="match_parent"
               xmlns:app="http://schemas.android.com/apk/res-auto"
               android:orientation="vertical" >
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/my_toolbar"
         app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
         style="@style/ToolbarStyle"/>

--- a/OpenStreetMapViewer/src/main/res/layout/activity_prefs.xml
+++ b/OpenStreetMapViewer/src/main/res/layout/activity_prefs.xml
@@ -5,7 +5,7 @@
               android:layout_height="match_parent"
               android:orientation="vertical">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/my_toolbar"
         app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
         style="@style/ToolbarStyle"/>

--- a/OpenStreetMapViewer/src/main/res/layout/activity_samplewithminimapitemizedoverlay.xml
+++ b/OpenStreetMapViewer/src/main/res/layout/activity_samplewithminimapitemizedoverlay.xml
@@ -4,7 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/my_toolbar"
         style="@style/ToolbarStyle"/>
 

--- a/OpenStreetMapViewer/src/main/res/layout/activity_samplewithtilesoverlay.xml
+++ b/OpenStreetMapViewer/src/main/res/layout/activity_samplewithtilesoverlay.xml
@@ -4,7 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/my_toolbar"
         style="@style/ToolbarStyle"/>
 

--- a/OpenStreetMapViewer/src/main/res/layout/activity_samplewithtilesoverlayandcustomtilesource.xml
+++ b/OpenStreetMapViewer/src/main/res/layout/activity_samplewithtilesoverlayandcustomtilesource.xml
@@ -4,7 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/my_toolbar"
         style="@style/ToolbarStyle"/>
 

--- a/OpenStreetMapViewer/src/main/res/layout/activity_starter_main.xml
+++ b/OpenStreetMapViewer/src/main/res/layout/activity_starter_main.xml
@@ -4,7 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/my_toolbar"
         style="@style/ToolbarStyle"/>
 

--- a/OpenStreetMapViewer/src/main/res/layout/fragment_streetaddress_list.xml
+++ b/OpenStreetMapViewer/src/main/res/layout/fragment_streetaddress_list.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.RecyclerView
+<androidx.recyclerview.widget.RecyclerView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"

--- a/OpenStreetMapViewer/src/main/res/layout/intro_frame.xml
+++ b/OpenStreetMapViewer/src/main/res/layout/intro_frame.xml
@@ -4,7 +4,7 @@
               android:layout_width="match_parent"
               android:layout_height="match_parent">
 
-    <android.support.v4.view.ViewPager
+    <androidx.viewpager.widget.ViewPager
         android:id="@+id/introviewpager"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/OpenStreetMapViewer/src/main/res/layout/layermanage_drawer.xml
+++ b/OpenStreetMapViewer/src/main/res/layout/layermanage_drawer.xml
@@ -1,4 +1,4 @@
-<android.support.v4.widget.DrawerLayout
+<androidx.drawerlayout.widget.DrawerLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
@@ -35,4 +35,4 @@
         android:divider="@android:color/transparent"
         android:dividerHeight="0dp"
         android:background="#111"/>
-</android.support.v4.widget.DrawerLayout>
+</androidx.drawerlayout.widget.DrawerLayout>

--- a/OpenStreetMapViewer/src/main/res/layout/map_viewpager.xml
+++ b/OpenStreetMapViewer/src/main/res/layout/map_viewpager.xml
@@ -2,7 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical" android:layout_width="match_parent"
     android:layout_height="match_parent">
- <android.support.v4.view.ViewPager
+ <androidx.viewpager.widget.ViewPager
      android:id="@+id/pager"
      android:layout_width="match_parent"
      android:layout_height="match_parent"/>

--- a/OpenStreetMapViewer/src/main/res/layout/recyclercard2.xml
+++ b/OpenStreetMapViewer/src/main/res/layout/recyclercard2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
                                     xmlns:card_view="http://schemas.android.com/apk/res-auto"
                                     android:id="@+id/cardview"
                                     android:layout_width="match_parent"
@@ -57,4 +57,4 @@
 
     </LinearLayout>
 
-</android.support.v7.widget.CardView>
+</androidx.cardview.widget.CardView>

--- a/OpenStreetMapViewer/src/main/res/layout/recyclerview.xml
+++ b/OpenStreetMapViewer/src/main/res/layout/recyclerview.xml
@@ -6,7 +6,7 @@
                 android:layout_height="match_parent">
 
 
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/OpenStreetMapViewer/src/main/res/layout/recyclerviewcard.xml
+++ b/OpenStreetMapViewer/src/main/res/layout/recyclerviewcard.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
                                     xmlns:card_view="http://schemas.android.com/apk/res-auto"
                                     android:id="@+id/cardview"
                                     android:layout_width="fill_parent"
@@ -14,4 +14,4 @@
         android:layout_height="250dp"
         tilesource="Mapnik" />
 
-</android.support.v7.widget.CardView>
+</androidx.cardview.widget.CardView>

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ org.gradle.configureondemand true
 # "Specifies the jvmargs used for the daemon process.  The setting is particularly useful for
 #  tweaking memory settings.  At the moment, the default settings are pretty generous with regards
 #  to memory."
-#org.gradle.jvmargs=-Xms256m -Xmx2048m -XX:MaxPermSize=256m
+org.gradle.jvmargs=-Xms256m -Xmx2048m -XX:MaxPermSize=256m
 
 
 # Dependency version configurations ----------------------------------------------------------------

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,12 +41,12 @@ gradleFury.version=1.0.14
 
 
 android-plugin.version=7.1.3
-android-support.version=28.0.0
 # To be used for packages that depend on support lib (minSDK = 14 since 26.0.0)
 android-minSdkForSupportLib.version=14
 junit.version=4.13.2
 robolectric.version=4.7.3
 android.useAndroidX=true
+android.enableJetifier=true
 
 # Maven Repository (i.e. Sonatype Nexus Repository Manager) Configuration --------------------------
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ org.gradle.configureondemand true
 # "Specifies the jvmargs used for the daemon process.  The setting is particularly useful for
 #  tweaking memory settings.  At the moment, the default settings are pretty generous with regards
 #  to memory."
-org.gradle.jvmargs=-Xms256m -Xmx2048m -XX:MaxPermSize=256m
+#org.gradle.jvmargs=-Xms256m -Xmx2048m -XX:MaxPermSize=256m
 
 
 # Dependency version configurations ----------------------------------------------------------------
@@ -47,7 +47,6 @@ junit.version=4.13.2
 robolectric.version=4.7.3
 android.useAndroidX=true
 android.enableJetifier=true
-
 # Maven Repository (i.e. Sonatype Nexus Repository Manager) Configuration --------------------------
 
 # username and pass can be stored local.properties with encryption

--- a/osmdroid-geopackage/build.gradle
+++ b/osmdroid-geopackage/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
 
 group = project.property("pom.groupId")
-version =  project.property("pom.version")
+version = project.property("pom.version")
 
 android {
     compileSdkVersion findProperty('android.compileSdkVersion').toInteger()
@@ -70,16 +70,16 @@ afterEvaluate {
                 artifactId project.name
                 version = project.property("pom.version")
                 pom {
-                    description =  project.description
+                    description = project.description
                     url = project.property("pom.url")
 
                     //scm, organization and developers are injected via other mechanisms
 
                     licenses {
                         license {
-                            name=project.property("pom.licenses.license.0.name");
-                            url=project.property("pom.licenses.license.0.url");
-                            distribution==project.property("pom.licenses.license.0.distribution");
+                            name = project.property("pom.licenses.license.0.name");
+                            url = project.property("pom.licenses.license.0.url");
+                            distribution == project.property("pom.licenses.license.0.distribution");
                         }
 
                     }


### PR DESCRIPTION
After looking into upgrading NGA-Geopackage, it seems that there are too many clashing dependencies from android.support and androidx. I saw there was a feature request to update the older libraries to the newer libraries. 

PR: #1853 - should be done after this to resolve the duplicate file issues

Issue: #1453 


I followed this guide: https://developer.android.com/jetpack/androidx/migrate/artifact-mappings to update all legacy mappings to the equivalent AndroidX
