### PR TITLE
Update HEREWeGoTileSource.java

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/HEREWeGoTileSource.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/HEREWeGoTileSource.java
@@ -31,10 +31,10 @@ public class HEREWeGoTileSource extends OnlineTileSourceBase {
 
     private static final String COPYRIGHT = "© 1987 - 2019 HERE. All rights reserved.";
     private static final String[] mapBoxBaseUrl = new String[]{
-            "http://1.{domain}/maptile/2.1/maptile/newest/",
-            "http://2.{domain}/maptile/2.1/maptile/newest/",
-            "http://3.{domain}/maptile/2.1/maptile/newest/",
-            "http://4.{domain}/maptile/2.1/maptile/newest/"};
+            "https://1.{domain}/maptile/2.1/maptile/newest/",
+            "https://2.{domain}/maptile/2.1/maptile/newest/",
+            "https://3.{domain}/maptile/2.1/maptile/newest/",
+            "https://4.{domain}/maptile/2.1/maptile/newest/"};
 
     private String herewegoMapId = "hybrid.day";
     private String appId = "";


### PR DESCRIPTION
Here maps API now require use of HTTPS and not HTTP so mapBoxBaseUrl initialisations have been updated to HTTPS from HTTP