### PR TITLE
DelayTest.check: skip the test if a sleep call exceeds the expected wait time

### DIFF
--- a/osmdroid-android/src/test/java/org/osmdroid/util/DelayTest.java
+++ b/osmdroid-android/src/test/java/org/osmdroid/util/DelayTest.java
@@ -1,6 +1,7 @@
 package org.osmdroid.util;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 /**
@@ -39,7 +40,7 @@ public class DelayTest {
 
     private void check(final Delay pDelay, final long pMillis) {
         sleep((pMillis * 3) / 4);
-        Assert.assertTrue(pDelay.shouldWait());
+        Assume.assumeTrue(pDelay.shouldWait());
         sleep(pMillis / 2);
         Assert.assertFalse(pDelay.shouldWait());
     }


### PR DESCRIPTION
The [DelayTest 'check' function's first call to Thread.sleep](https://github.com/osmdroid/osmdroid/blob/713f680f8e7c56418331415f7dd8adb9b6f43375/osmdroid-android/src/test/java/org/osmdroid/util/DelayTest.java#L41) is intended to wait for _some_ but _not all_ of the current delay (backoff) duration.

In practice this seems to be causing some [flaky unit test](https://github.com/osmdroid/osmdroid/actions/runs/3548810663/jobs/5960434258#step:5:1354) failures: my theory is that this occurs when the test thread is interrupted during the sleep, resulting in the [DelayTest.sleep](https://github.com/osmdroid/osmdroid/blob/713f680f8e7c56418331415f7dd8adb9b6f43375/osmdroid-android/src/test/java/org/osmdroid/util/DelayTest.java#L47-L53) call sometimes _exceeding_ the delay duration.

To accommodate that possibility, we can use [JUnit4's Assume class](https://junit.org/junit4/javadoc/4.12/org/junit/Assume.html) to test whether the condition that Delay.shouldWait is true.

If the condition does _not_ hold -- that is, the DelayTest.sleep exceeded the expected delay duration -- then ~~JUnit~~ the default JUnit test runner will skip the test (the condition for testing didn't hold, so we can't rely on the results).

Please note: untested locally; this is a theory, so far.

cc @monsieurtanuki 