### PR TITLE
change compile to implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-    compile 'org.osmdroid:osmdroid-android:<VERSION>'
+    implementation 'org.osmdroid:osmdroid-android:<VERSION>'
 }
 ```
 
@@ -64,7 +64,7 @@ repositories {
     }
 }
 dependencies {
-    compile 'org.osmdroid:osmdroid-android:<VERSION>-SNAPSHOT:debug@aar'
+    implementation 'org.osmdroid:osmdroid-android:<VERSION>-SNAPSHOT:debug@aar'
 }
 ```
 
@@ -176,7 +176,7 @@ allprojects {
 Then in your APK or AAR project that needs osmdroid.
 
 ```
-    compile 'org.osmdroid:osmdroid-android:<VERSION>-SNAPSHOT:debug@aar'
+    implementation 'org.osmdroid:osmdroid-android:<VERSION>-SNAPSHOT:debug@aar'
 ```
 Where VERSION is the version listed as the value for `pom.version` in osmdroid's `gradle.properties`. Note that when using the release versions from Maven Central, drop the `:debug@aar` part. When using a "release" version that you build locally with gradle, you'll need `:debug@aar` instead.
 


### PR DESCRIPTION
compile is deprecated from new version of graddle