### PR TITLE
feature/ enable editing UserScaleFactor for generating MapsForge tiles

### DIFF
--- a/OpenStreetMapViewer/build.gradle
+++ b/OpenStreetMapViewer/build.gradle
@@ -64,9 +64,9 @@ dependencies {
     //are not longer resolved...
 
     //osmdroid-mapsforge
-    implementation 'org.mapsforge:mapsforge-map-android:0.18.0'
-    implementation 'org.mapsforge:mapsforge-map:0.18.0'
-    implementation 'org.mapsforge:mapsforge-themes:0.11.0'
+    implementation 'org.mapsforge:mapsforge-map-android:0.20.0'
+    implementation 'org.mapsforge:mapsforge-map:0.20.0'
+    implementation 'org.mapsforge:mapsforge-themes:0.20.0'
 
 
     implementation "androidx.legacy:legacy-support-v4:1.0.0"

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/tileproviders/MapsforgeTileProviderSample.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/tileproviders/MapsforgeTileProviderSample.java
@@ -118,6 +118,8 @@ public class MapsforgeTileProviderSample extends BaseSampleFragment {
                     new SimpleRegisterReceiver(getContext()),
                     fromFiles, null);
 
+            // with value of .5F the map tiles more closely resemble that of native MapsForge basic map
+            // fromFiles.setUserScaleFactor(.5F);
 
             mMapView.setTileProvider(forge);
 

--- a/osmdroid-mapsforge/build.gradle
+++ b/osmdroid-mapsforge/build.gradle
@@ -30,9 +30,9 @@ dependencies {
     testImplementation "junit:junit:${project.property('junit.version')}"
 
     //Mapsforge rendering and database support, which is LGPL
-    api 'org.mapsforge:mapsforge-map-android:0.11.0'
-    api 'org.mapsforge:mapsforge-map:0.11.0'
-    api 'org.mapsforge:mapsforge-themes:0.11.0'
+    api 'org.mapsforge:mapsforge-map-android:0.20.0'
+    api 'org.mapsforge:mapsforge-map:0.20.0'
+    api 'org.mapsforge:mapsforge-themes:0.20.0'
 
     //osmdroid which is ASF licensed
     api  project(':osmdroid-android' )

--- a/osmdroid-mapsforge/src/main/java/org/osmdroid/mapsforge/MapsForgeTileSource.java
+++ b/osmdroid-mapsforge/src/main/java/org/osmdroid/mapsforge/MapsForgeTileSource.java
@@ -291,4 +291,9 @@ public class MapsForgeTileSource extends BitmapTileSourceBase {
             renderer.addTileRefresher(pDirectTileRefresher);
         }
     }
+
+    // for example a scaleFactor of .6F
+    public void setUserScaleFactor(float scaleFactor){
+        model.setUserScaleFactor(scaleFactor);
+    }
 }


### PR DESCRIPTION
Issue: MapsForge roads are too thick.

Setting UserScaleFactor for MapsForge with a value of .5F generates map tiles that more closely resemble that of a native MapsForge basic map with the same theme and .map. Roads are not too thick.