### PR TITLE
Update sdk 34, built with gradle 8.7 in terminal

### DIFF
--- a/OSMMapTilePackager/build.gradle
+++ b/OSMMapTilePackager/build.gradle
@@ -36,7 +36,8 @@ dependencies {
 }
 
 //copy the instrumentation tests from the maven osmdroid-android-it src folder
-task preBuildTask1(type: Copy) {
+tasks.register('preBuildTask1', Copy) {
+    dependsOn ':osmdroid-android:copyFiles'
     println("copying StreamUtils sources")
     description 'copy java classes from osmdroid-android.'
     from("${rootDir}/osmdroid-android/src/main/java/org/osmdroid/tileprovider/util/StreamUtils.java")
@@ -44,7 +45,8 @@ task preBuildTask1(type: Copy) {
 
 }
 
-task preBuildTask2(type: Copy) {
+tasks.register('preBuildTask2', Copy) {
+    dependsOn ':osmdroid-android:copyFiles'
     println("copying GEMF sources")
     description 'copy java classes from osmdroid-android.'
     from("${rootDir}/osmdroid-android/src/main/java/org/osmdroid/util/GEMFFile.java")
@@ -53,7 +55,8 @@ task preBuildTask2(type: Copy) {
 }
 
 
-task preBuildTask3(type: Copy) {
+tasks.register('preBuildTask3', Copy) {
+    dependsOn ':osmdroid-android:copyFiles'
     println("copying api sources")
     description 'copy java classes from osmdroid-android.'
     from("${rootDir}/osmdroid-android/src/main/java/org/osmdroid/api/") {
@@ -67,7 +70,7 @@ task preBuildTask3(type: Copy) {
 }
 
 
-task preBuildTask4(type: Delete) {
+tasks.register('preBuildTask4', Delete) {
     println("removing android specific api sources")
     delete "${projectDir}/src/main/java/org/osmdroid/api/"
     delete "${projectDir}/src/main/java/org/osmdroid/api/IMyLocationOverlay.java"
@@ -76,6 +79,9 @@ task preBuildTask4(type: Delete) {
     delete "${projectDir}/src/main/java/org/osmdroid/api/IProjection.java"
 }
 
+sourcesJar.dependsOn(preBuildTask1)
+sourcesJar.dependsOn(preBuildTask2)
+sourcesJar.dependsOn(preBuildTask3)
 compileJava.dependsOn preBuildTask1
 compileJava.dependsOn preBuildTask2
 compileJava.dependsOn preBuildTask3
@@ -113,6 +119,6 @@ afterEvaluate {
             }
         }
     }
-
+    publishPdZipPublicationPublicationToMavenLocal.dependsOn(distZip)
 
 }

--- a/OpenStreetMapViewer/build.gradle
+++ b/OpenStreetMapViewer/build.gradle
@@ -97,7 +97,7 @@ dependencies {
 
 
     //on device testing
-    androidTestImplementation 'androidx.multidex:multidex:2.0.1'
+//    androidTestImplementation 'androidx.multidex:multidex:2.0.1'
     androidTestImplementation "androidx.annotation:annotation:1.3.0"
 
 

--- a/OpenStreetMapViewer/build.gradle
+++ b/OpenStreetMapViewer/build.gradle
@@ -19,7 +19,7 @@ android {
         applicationId "org.osmdroid"
 
         minSdkVersion 21
-        multiDexEnabled = true
+//        multiDexEnabled = true
 
         compileSdk(project.hasProperty('android.compileSdkVersion')
                 ? Integer.parseInt(project.property('android.compileSdkVersion')) : 34)
@@ -95,14 +95,14 @@ dependencies {
     implementation "androidx.recyclerview:recyclerview:1.3.2"
     implementation 'androidx.multidex:multidex:2.0.1'
 
-    implementation "androidx.appcompat:appcompat:1.6.1"
+    implementation "androidx.appcompat:appcompat:1.7.0"
     //crash logging
     implementation 'ch.acra:acra:4.7.0'
 
 
     //on device testing
 //    androidTestImplementation 'androidx.multidex:multidex:2.0.1'
-    androidTestImplementation "androidx.annotation:annotation:1.6.0"
+//    androidTestImplementation "androidx.annotation:annotation:1.8.2"
 
 
     androidTestImplementation "androidx.test:runner:1.6.2"

--- a/OpenStreetMapViewer/build.gradle
+++ b/OpenStreetMapViewer/build.gradle
@@ -8,7 +8,8 @@ group = project.property("pom.groupId")
 version = project.property("pom.version")
 
 android {
-    compileSdkVersion findProperty('android.compileSdkVersion').toInteger()
+    namespace "org.osmdroid"
+    compileSdk findProperty('android.compileSdkVersion').toInteger()
 
 
     defaultConfig {
@@ -20,7 +21,7 @@ android {
         minSdkVersion 21
         multiDexEnabled = true
 
-        compileSdkVersion(project.hasProperty('android.compileSdkVersion')
+        compileSdk(project.hasProperty('android.compileSdkVersion')
                 ? Integer.parseInt(project.property('android.compileSdkVersion')) : 34)
 
         // default targetSdkVersion to API 23, if not provided

--- a/OpenStreetMapViewer/build.gradle
+++ b/OpenStreetMapViewer/build.gradle
@@ -49,6 +49,10 @@ android {
         }
     }
 
+    buildFeatures {
+        buildConfig = true
+    }
+
     packagingOptions {
         pickFirst "androidsupportmultidexversion.txt"
         pickFirst "META-INF/AL2.0"
@@ -86,7 +90,7 @@ dependencies {
     implementation group: 'com.opencsv', name: 'opencsv', version: '5.8'
 
     //usual android stuff
-    implementation "com.google.android.material:material:1.11.0" //needed for UI menuing
+    implementation "com.google.android.material:material:1.12.0" //needed for UI menuing
     implementation "androidx.cardview:cardview:1.0.0"
     implementation "androidx.recyclerview:recyclerview:1.3.2"
     implementation 'androidx.multidex:multidex:2.0.1'
@@ -98,17 +102,17 @@ dependencies {
 
     //on device testing
 //    androidTestImplementation 'androidx.multidex:multidex:2.0.1'
-    androidTestImplementation "androidx.annotation:annotation:1.3.0"
+    androidTestImplementation "androidx.annotation:annotation:1.6.0"
 
 
-    androidTestImplementation "androidx.test:runner:1.5.2"
-    androidTestImplementation "androidx.test:rules:1.5.0"
+    androidTestImplementation "androidx.test:runner:1.6.2"
+    androidTestImplementation "androidx.test:rules:1.6.1"
     // Optional -- UI testing with Espresso
-    androidTestImplementation "androidx.test.espresso:espresso-core:3.5.1"
+    androidTestImplementation "androidx.test.espresso:espresso-core:3.6.1"
     // Optional -- UI testing with UI Automator
     androidTestImplementation "androidx.test.uiautomator:uiautomator:2.3.0"
     // Optional -- UI testing with Compose
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4:1.6.5"
+    androidTestImplementation "androidx.compose.ui:ui-test-junit4:1.6.8"
 }
 
 

--- a/OpenStreetMapViewer/src/main/AndroidManifest.xml
+++ b/OpenStreetMapViewer/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.osmdroid"
+<manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
@@ -260,5 +260,5 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <uses-sdk tools:overrideLibrary="mil.army.missioncommand,armyc2.c2sd.singlepointrenderer,org.osmdroid.gpkg,mil.nga.geopackage,org.osmdroid.mapsforge,android.support.v13,com.github.angads25.filepicker,android.support.v7.gridlayout" />
->
+
 </manifest>

--- a/OpenStreetMapViewer/src/main/AndroidManifest.xml
+++ b/OpenStreetMapViewer/src/main/AndroidManifest.xml
@@ -257,7 +257,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
 
     <uses-sdk tools:overrideLibrary="mil.army.missioncommand,armyc2.c2sd.singlepointrenderer,org.osmdroid.gpkg,mil.nga.geopackage,org.osmdroid.mapsforge,android.support.v13,com.github.angads25.filepicker,android.support.v7.gridlayout" />
 

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/OsmApplication.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/OsmApplication.java
@@ -1,5 +1,6 @@
 package org.osmdroid;
 
+import android.app.Application;
 import android.content.Context;
 import android.os.Environment;
 import android.os.StrictMode;
@@ -17,8 +18,8 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import androidx.multidex.MultiDex;
-import androidx.multidex.MultiDexApplication;
+//import androidx.multidex.MultiDex;
+//import androidx.multidex.MultiDexApplication;
 
 /**
  * This is the base application for the sample app. We only use to catch errors during development cycles
@@ -28,7 +29,7 @@ import androidx.multidex.MultiDexApplication;
  */
 
 @ReportsCrashes(formUri = "")
-public class OsmApplication extends MultiDexApplication {
+public class OsmApplication extends Application {
 
     @Override
     public void onCreate() {
@@ -98,7 +99,7 @@ public class OsmApplication extends MultiDexApplication {
     @Override
     protected void attachBaseContext(Context base) {
         super.attachBaseContext(base);
-        MultiDex.install(this);
+//        MultiDex.install(this);
 
         try {
             // Initialise ACRA

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/bugtestfragments/Bug382Crash.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/bugtestfragments/Bug382Crash.java
@@ -42,7 +42,7 @@ public class Bug382Crash extends BaseSampleFragment {
         polygon.getFillPaint().setColor(0x96FF8200);
         polygon.getOutlinePaint().setColor(Color.RED);
         polygon.getOutlinePaint().setStrokeWidth(4);
-        polygon.setInfoWindow(new BasicInfoWindow(R.layout.bonuspack_bubble, mMapView));
+        polygon.setInfoWindow(new BasicInfoWindow(org.osmdroid.library.R.layout.bonuspack_bubble, mMapView));
         polygon.setTitle("Polygon tapped!");
         mMapView.getOverlays().add(polygon);
         mMapView.invalidate();
@@ -51,7 +51,7 @@ public class Bug382Crash extends BaseSampleFragment {
         polyline.setPoints(geoPoints.subList(3, 6));
         polyline.getOutlinePaint().setColor(Color.YELLOW);
         polyline.getOutlinePaint().setStrokeWidth(8);
-        polyline.setInfoWindow(new BasicInfoWindow(R.layout.bonuspack_bubble, mMapView));
+        polyline.setInfoWindow(new BasicInfoWindow(org.osmdroid.library.R.layout.bonuspack_bubble, mMapView));
         polyline.setTitle("Polyline tapped!");
         mMapView.getOverlays().add(polyline);
         mMapView.invalidate();

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleOsmPath.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/data/SampleOsmPath.java
@@ -81,7 +81,7 @@ public class SampleOsmPath extends BaseSampleFragment implements MapListener {
         pts.add(new GeoPoint(40.796788, -73.949232));
         line.setPoints(pts);
         line.setGeodesic(true);
-        line.setInfoWindow(new BasicInfoWindow(R.layout.bonuspack_bubble, mMapView));
+        line.setInfoWindow(new BasicInfoWindow(org.osmdroid.library.R.layout.bonuspack_bubble, mMapView));
         //Note, the info window will not show if you set the onclick listener
         //line can also attach click listeners to the line
 		/*
@@ -115,7 +115,7 @@ public class SampleOsmPath extends BaseSampleFragment implements MapListener {
         polygon.getFillPaint().setColor(Color.RED);
         polygon.setVisible(true);
         polygon.getOutlinePaint().setColor(Color.BLACK);
-        polygon.setInfoWindow(new BasicInfoWindow(R.layout.bonuspack_bubble, mMapView));
+        polygon.setInfoWindow(new BasicInfoWindow(org.osmdroid.library.R.layout.bonuspack_bubble, mMapView));
 
 
         pts = new ArrayList<>();
@@ -144,7 +144,7 @@ public class SampleOsmPath extends BaseSampleFragment implements MapListener {
         pts.add(new GeoPoint(51.7875, 6.135278));
         line.setPoints(pts);
         line.setGeodesic(true);
-        line.setInfoWindow(new BasicInfoWindow(R.layout.bonuspack_bubble, mMapView));
+        line.setInfoWindow(new BasicInfoWindow(org.osmdroid.library.R.layout.bonuspack_bubble, mMapView));
 
         mMapView.getOverlayManager().add(m);
         mMapView.getOverlayManager().add(line);

--- a/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/drawing/ShowAdvancedPolylineStyles.java
+++ b/OpenStreetMapViewer/src/main/java/org/osmdroid/samplefragments/drawing/ShowAdvancedPolylineStyles.java
@@ -169,7 +169,7 @@ public class ShowAdvancedPolylineStyles extends BaseSampleFragment implements Vi
 
             // add infowindow
             final InfoWindowExample infoWindow;
-            infoWindow = new InfoWindowExample(R.layout.bonuspack_bubble, mMapView);
+            infoWindow = new InfoWindowExample(org.osmdroid.library.R.layout.bonuspack_bubble, mMapView);
             infoWindow.setText(title, description);
             mPolyline.setInfoWindow(infoWindow);
         }
@@ -196,8 +196,8 @@ public class ShowAdvancedPolylineStyles extends BaseSampleFragment implements Vi
         }
 
         public void setText(String title, String description) {
-            ((TextView) getView().findViewById(R.id.bubble_title)).setText(title);
-            ((TextView) getView().findViewById(R.id.bubble_description)).setText(description);
+            ((TextView) getView().findViewById(org.osmdroid.library.R.id.bubble_title)).setText(title);
+            ((TextView) getView().findViewById(org.osmdroid.library.R.id.bubble_description)).setText(description);
         }
 
         @Override

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ allprojects {
     }
 
     repositories {
+        google()
         mavenCentral()
         mavenLocal()
         maven {

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ org.gradle.jvmargs=-Xms8G -Xmx8G
 gradleFury.version=1.1.3
 
 
-android-plugin.version=7.2.2
+android-plugin.version=7.4.2
 # To be used for packages that depend on support lib (minSDK = 14 since 26.0.0)
 android-minSdkForSupportLib.version=14
 junit.version=5.10.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,8 +39,11 @@ org.gradle.jvmargs=-Xms8G -Xmx8G
 
 gradleFury.version=1.1.3
 
+# see https://stackoverflow.com/a/77003602 for "constant expression required" error for res IDs beginning in gradle 8
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false
 
-android-plugin.version=7.4.2
+android-plugin.version=8.5.2
 # To be used for packages that depend on support lib (minSDK = 14 since 26.0.0)
 android-minSdkForSupportLib.version=14
 junit.version=5.10.2
@@ -65,10 +68,10 @@ compileJava.targetCompatibility=17
 
 # Android Configuration (used by gradle/android-support.gradle) ------------------------------------
 
-android.buildToolsVersion=34.0.0
+android.buildToolsVersion=34.0.3
 android.compileSdkVersion=34
 android.minSdkVersion=8
-android.targetSdkVersion=33
+android.targetSdkVersion=34
 
 android.versionCode=57
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip

--- a/osmdroid-android/build.gradle
+++ b/osmdroid-android/build.gradle
@@ -42,18 +42,18 @@ dependencies {
     testImplementation "org.robolectric:robolectric:${project.property('robolectric.version')}"
 }
 
-task cleanCustomFiles(type: Delete) {
+tasks.register('cleanCustomFiles', Delete) {
     delete file('src/main/java/org/osmdroid/OsmdroidBuildInfo.java')
 }
 
 
 import org.apache.tools.ant.filters.*
-task copyFiles(type: Copy) {
+tasks.register('copyFiles', Copy) {
     from 'src/main/filtered/org/osmdroid'
     into 'src/main/java/org/osmdroid'
     filter(ReplaceTokens, tokens: [
             "pom.version": project.property("pom.version"),
-            "date": new Date().toString()
+            "date"       : new Date().toString()
     ])
 }
 
@@ -90,7 +90,9 @@ afterEvaluate {
 }
 
 
-task androidSourcesJar(type: Jar) {
+tasks.register('androidSourcesJar', Jar) {
+    dependsOn tasks.copyFiles
+    mustRunAfter tasks.copyFiles
     from android.sourceSets.main.java.srcDirs
 }
 
@@ -100,5 +102,7 @@ artifacts {
 
 }
 clean.dependsOn(copyFiles)
+// preBuild task is listed just after androidSourcesJar task in big list of builtin tasks
+preBuild.dependsOn(copyFiles)
 build.dependsOn(copyFiles)
 copyFiles.dependsOn(cleanCustomFiles)

--- a/osmdroid-android/build.gradle
+++ b/osmdroid-android/build.gradle
@@ -8,7 +8,8 @@ version =  project.property("pom.version")
 
 
 android {
-    compileSdkVersion findProperty('android.compileSdkVersion').toInteger()
+    namespace "org.osmdroid.library"
+    compileSdk findProperty('android.compileSdkVersion').toInteger()
 
     defaultConfig{
         targetSdkVersion  findProperty('android.targetSdkVersion').toInteger()

--- a/osmdroid-android/src/main/AndroidManifest.xml
+++ b/osmdroid-android/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-		package="org.osmdroid.library">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" >
 	<supports-screens android:largeScreens="true" android:normalScreens="true" android:anyDensity="true" />
 
 	<uses-feature android:name="android.hardware.location.network" android:required="false" />

--- a/osmdroid-geopackage/build.gradle
+++ b/osmdroid-geopackage/build.gradle
@@ -7,7 +7,8 @@ group = project.property("pom.groupId")
 version = project.property("pom.version")
 
 android {
-    compileSdkVersion findProperty('android.compileSdkVersion').toInteger()
+    namespace "org.osmdroid.gpkg"
+    compileSdk findProperty('android.compileSdkVersion').toInteger()
 
     defaultConfig {
         minSdkVersion 23

--- a/osmdroid-geopackage/build.gradle
+++ b/osmdroid-geopackage/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     api 'mil.nga:tiff:3.0.0'
 }
 
-task androidSourcesJar(type: Jar) {
+tasks.register('androidSourcesJar', Jar) {
     from android.sourceSets.main.java.srcDirs
 }
 

--- a/osmdroid-geopackage/src/main/AndroidManifest.xml
+++ b/osmdroid-geopackage/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest
-    package="org.osmdroid.gpkg">
+<manifest >
   
 
 </manifest>

--- a/osmdroid-geopackage/src/main/java/org/osmdroid/gpkg/overlay/OsmMapShapeConverter.java
+++ b/osmdroid-geopackage/src/main/java/org/osmdroid/gpkg/overlay/OsmMapShapeConverter.java
@@ -692,7 +692,7 @@ public class OsmMapShapeConverter {
             m.setAlpha(options.getAlpha());
             m.setTitle(options.getTitle());
             m.setSubDescription(options.getSubdescription());
-            m.setInfoWindow(new BasicInfoWindow(R.layout.bonuspack_bubble, map));
+            m.setInfoWindow(new BasicInfoWindow(org.osmdroid.library.R.layout.bonuspack_bubble, map));
         }
         map.getOverlayManager().add(m);
         return m;
@@ -708,7 +708,7 @@ public class OsmMapShapeConverter {
     public static Polyline addPolylineToMap(MapView map,
                                             Polyline polyline) {
         if (polyline.getInfoWindow() == null)
-            polyline.setInfoWindow(new BasicInfoWindow(R.layout.bonuspack_bubble, map));
+            polyline.setInfoWindow(new BasicInfoWindow(org.osmdroid.library.R.layout.bonuspack_bubble, map));
         map.getOverlayManager().add(polyline);
         return polyline;
     }
@@ -732,7 +732,7 @@ public class OsmMapShapeConverter {
             polygon1.getOutlinePaint().setColor(options.getStrokeColor());
             polygon1.getOutlinePaint().setStrokeWidth(options.getStrokeWidth());
             polygon1.setSubDescription(options.getSubtitle());
-            polygon1.setInfoWindow(new BasicInfoWindow(R.layout.bonuspack_bubble, map));
+            polygon1.setInfoWindow(new BasicInfoWindow(org.osmdroid.library.R.layout.bonuspack_bubble, map));
 
         }
 
@@ -759,7 +759,7 @@ public class OsmMapShapeConverter {
             polygon.getOutlinePaint().setColor(options.getStrokeColor());
             polygon.getOutlinePaint().setStrokeWidth(options.getStrokeWidth());
             polygon.setSubDescription(options.getSubtitle());
-            polygon.setInfoWindow(new BasicInfoWindow(R.layout.bonuspack_bubble, map));
+            polygon.setInfoWindow(new BasicInfoWindow(org.osmdroid.library.R.layout.bonuspack_bubble, map));
 
         }
 
@@ -798,7 +798,7 @@ public class OsmMapShapeConverter {
 
         for (Polyline line : polylines) {
             if (line.getInfoWindow() == null)
-                line.setInfoWindow(new BasicInfoWindow(R.layout.bonuspack_bubble, map));
+                line.setInfoWindow(new BasicInfoWindow(org.osmdroid.library.R.layout.bonuspack_bubble, map));
             map.getOverlayManager().add(line);
             multiPolyline.add(line);
         }
@@ -813,7 +813,7 @@ public class OsmMapShapeConverter {
             org.osmdroid.views.overlay.Polygon polygon = addPolygonToMap(map, polygonOption.getActualPoints(), polygonOption.getHoles(), opts);
 
             if (polygon.getInfoWindow() == null)
-                polygon.setInfoWindow(new BasicInfoWindow(R.layout.bonuspack_bubble, map));
+                polygon.setInfoWindow(new BasicInfoWindow(org.osmdroid.library.R.layout.bonuspack_bubble, map));
             multiPolygon.add(polygon);
         }
         return multiPolygon;

--- a/osmdroid-mapsforge/build.gradle
+++ b/osmdroid-mapsforge/build.gradle
@@ -6,7 +6,8 @@ group = project.property("pom.groupId")
 version =  project.property("pom.version")
 
 android {
-    compileSdkVersion findProperty('android.compileSdkVersion').toInteger()
+    namespace "org.osmdroid.mapsforge"
+    compileSdk findProperty('android.compileSdkVersion').toInteger()
 
     defaultConfig {
         // mapsforge 0.8.0 has minSdk 10

--- a/osmdroid-mapsforge/build.gradle
+++ b/osmdroid-mapsforge/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 
 
 
-task androidSourcesJar(type: Jar) {
+tasks.register('androidSourcesJar', Jar) {
     from android.sourceSets.main.java.srcDirs
 }
 

--- a/osmdroid-mapsforge/src/main/AndroidManifest.xml
+++ b/osmdroid-mapsforge/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
-<manifest
-    package="org.osmdroid.mapsforge">
+<manifest >
 
 </manifest>

--- a/osmdroid-server-jdk/build.gradle
+++ b/osmdroid-server-jdk/build.gradle
@@ -121,6 +121,6 @@ afterEvaluate {
 
         }
     }
-
+    publishPdZipPublicationPublicationToMavenLocal.dependsOn(distZip)
 
 }

--- a/osmdroid-shape/build.gradle
+++ b/osmdroid-shape/build.gradle
@@ -73,7 +73,7 @@ afterEvaluate {
 
 
 
-task androidSourcesJar(type: Jar) {
+tasks.register('androidSourcesJar', Jar) {
     from android.sourceSets.main.java.srcDirs
 }
 

--- a/osmdroid-shape/build.gradle
+++ b/osmdroid-shape/build.gradle
@@ -7,7 +7,8 @@ group = project.property("pom.groupId")
 version =  project.property("pom.version")
 
 android {
-    compileSdkVersion findProperty('android.compileSdkVersion').toInteger()
+    namespace "org.osmdroid.shape"
+    compileSdk findProperty('android.compileSdkVersion').toInteger()
     defaultConfig {
         minSdkVersion Integer.parseInt(project.property('android-minSdkForSupportLib.version'))
     }

--- a/osmdroid-shape/src/main/AndroidManifest.xml
+++ b/osmdroid-shape/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.osmdroid.shape"  >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" >
   
 
 </manifest>

--- a/osmdroid-simple-map/build.gradle
+++ b/osmdroid-simple-map/build.gradle
@@ -7,7 +7,8 @@ group = project.property("pom.groupId")
 version =  project.property("pom.version")
 
 android {
-    compileSdkVersion findProperty('android.compileSdkVersion').toInteger()
+    namespace "org.osmdroid.simplemap"
+    compileSdk findProperty('android.compileSdkVersion').toInteger()
      defaultConfig {
 
          applicationId project.group + "." +
@@ -16,7 +17,7 @@ android {
 
          minSdkVersion Integer.parseInt(project.property('android-minSdkForSupportLib.version'))
          multiDexEnabled = true
-         compileSdkVersion(project.hasProperty('android.compileSdkVersion')
+         compileSdk(project.hasProperty('android.compileSdkVersion')
                  ? Integer.parseInt(project.property('android.compileSdkVersion')) : 34)
 
 

--- a/osmdroid-simple-map/build.gradle
+++ b/osmdroid-simple-map/build.gradle
@@ -42,7 +42,7 @@ android {
 }
 
 dependencies {
-    implementation "androidx.appcompat:appcompat:1.6.1"
+//    implementation "androidx.appcompat:appcompat:1.7.0"
     implementation project(':osmdroid-android')
 }
 

--- a/osmdroid-simple-map/src/main/AndroidManifest.xml
+++ b/osmdroid-simple-map/src/main/AndroidManifest.xml
@@ -10,10 +10,9 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-        android:maxSdkVersion="32" />
+        android:maxSdkVersion="28" />
 
     <application
-        android:allowBackup="false"
         android:icon="@drawable/icon"
         android:label="@string/app_name"
 		

--- a/osmdroid-simple-map/src/main/AndroidManifest.xml
+++ b/osmdroid-simple-map/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="org.osmdroid.simplemap">
+    xmlns:tools="http://schemas.android.com/tools" >
 
     <!-- PROTECTION_NORMAL permissions, automatically granted -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
@@ -10,7 +9,8 @@
     <!-- DANGEROUS PERMISSIONS, must request -->
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
 
     <application
         android:allowBackup="false"

--- a/osmdroid-simple-map/src/main/java/org/osmdroid/sample/MapActivity.java
+++ b/osmdroid-simple-map/src/main/java/org/osmdroid/sample/MapActivity.java
@@ -7,7 +7,7 @@ import org.osmdroid.config.Configuration;
 import org.osmdroid.simplemap.R;
 import org.osmdroid.views.MapView;
 
-import androidx.appcompat.app.AppCompatActivity;
+//import androidx.appcompat.app.AppCompatActivity;
 
 /**
  * Bare bones osmdroid example

--- a/osmdroid-wms/build.gradle
+++ b/osmdroid-wms/build.gradle
@@ -70,7 +70,7 @@ afterEvaluate {
 
 }
 
-task androidSourcesJar(type: Jar) {
+tasks.register('androidSourcesJar', Jar) {
     from android.sourceSets.main.java.srcDirs
 }
 

--- a/osmdroid-wms/build.gradle
+++ b/osmdroid-wms/build.gradle
@@ -6,7 +6,8 @@ group = project.property("pom.groupId")
 version =  project.property("pom.version")
 
 android {
-    compileSdkVersion findProperty('android.compileSdkVersion').toInteger()
+    namespace "org.osmdroid.wms"
+    compileSdk findProperty('android.compileSdkVersion').toInteger()
     lintOptions {
         abortOnError false
     }

--- a/osmdroid-wms/src/main/AndroidManifest.xml
+++ b/osmdroid-wms/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.osmdroid.wms"/>
+<manifest />
 


### PR DESCRIPTION
So I finally figured out:
gradle  clean build publishToMavenLocal
and 
gradlew  clean build publishToMavenLocal

Had successful builds. (Still cannot figure out how to successfully gradlew build with Gradle 8.0 in terminal.)* fixed

Was able to output files to localMaven and then import into another Android Studio app.

Within Android Studio can Run OpenStreetMapViewer with
android.targetSdkVersion=   33 or 34

can also change 
android-plugin.version= from 7.4.2 to 8.5.2
gradle-7.6.4-bin.zip to 8.7
and then sync and Run OpenStreetMapViewer with
android.targetSdkVersion=   33 or 34

Set target to 34 in this pull request.

Updated: (because of build fail)
set android:maxSdkVersion="28" for WRITE permission

* Updated: Figured out Gradle 8.7 enough to compile. Add "dependsOn" in build.gradle files after each build fail.